### PR TITLE
Temporal: 8 value types + Temporal.Now (ISO calendar, offset zones)

### DIFF
--- a/src/runtime/builtins/array.zig
+++ b/src/runtime/builtins/array.zig
@@ -3614,13 +3614,13 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
     // registered a `state`-bound continuation.
     const fa_sc = try faRootState(realm, state);
     defer fa_sc.close();
-    state.set(realm.allocator, k_fa_cap_resolve, heap_mod.taggedFunction(cap.resolve)) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_cap_reject, heap_mod.taggedFunction(cap.reject)) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_array, heap_mod.taggedObject(out)) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_index, Value.fromInt32(0)) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_mapfn, mapfn_v) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_this_arg, this_arg) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_items, items) catch return error.OutOfMemory;
+    try faStateSet(realm, state, k_fa_cap_resolve, heap_mod.taggedFunction(cap.resolve));
+    try faStateSet(realm, state, k_fa_cap_reject, heap_mod.taggedFunction(cap.reject));
+    try faStateSet(realm, state, k_fa_array, heap_mod.taggedObject(out));
+    try faStateSet(realm, state, k_fa_index, Value.fromInt32(0));
+    try faStateSet(realm, state, k_fa_mapfn, mapfn_v);
+    try faStateSet(realm, state, k_fa_this_arg, this_arg);
+    try faStateSet(realm, state, k_fa_items, items);
 
     // step 3 — GetMethod(asyncItems, @@asyncIterator). Per §7.3.10
     // GetMethod, if the property is null/undefined return undefined
@@ -3656,7 +3656,7 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
             const ctor_v = constructForFromAsync(realm, c, &.{}) catch {
                 return rejectPendingException(realm, cap);
             };
-            state.set(realm.allocator, k_fa_array, ctor_v) catch return error.OutOfMemory;
+            try faStateSet(realm, state, k_fa_array, ctor_v);
         }
         const iter_outcome = lantern.callJSFunction(realm.allocator, realm, async_iter_fn, items, &.{}) catch {
             return rejectPendingException(realm, cap);
@@ -3674,10 +3674,10 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
         const next_fn = heap_mod.valueAsFunction(next_v) orelse {
             return rejectWithTypeError(realm, cap, "Array.fromAsync: async iterator missing callable 'next'");
         };
-        state.set(realm.allocator, k_fa_iter, iter_v) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_next_fn, heap_mod.taggedFunction(next_fn)) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_mode, Value.fromInt32(1)) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_is_async, Value.true_) catch return error.OutOfMemory;
+        try faStateSet(realm, state, k_fa_iter, iter_v);
+        try faStateSet(realm, state, k_fa_next_fn, heap_mod.taggedFunction(next_fn));
+        try faStateSet(realm, state, k_fa_mode, Value.fromInt32(1));
+        try faStateSet(realm, state, k_fa_is_async, Value.true_);
         fromAsyncIterStep(realm, state) catch {
             return rejectPendingException(realm, cap);
         };
@@ -3689,7 +3689,7 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
             const ctor_v = constructForFromAsync(realm, c, &.{}) catch {
                 return rejectPendingException(realm, cap);
             };
-            state.set(realm.allocator, k_fa_array, ctor_v) catch return error.OutOfMemory;
+            try faStateSet(realm, state, k_fa_array, ctor_v);
         }
         // step 3.h — sync `@@iterator` fallback. Per spec, wrap in
         // %AsyncFromSyncIteratorPrototype%. Cynic shortcut: drive the
@@ -3713,10 +3713,10 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
         const next_fn = heap_mod.valueAsFunction(next_v) orelse {
             return rejectWithTypeError(realm, cap, "Array.fromAsync: iterator missing callable 'next'");
         };
-        state.set(realm.allocator, k_fa_iter, iter_v) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_next_fn, heap_mod.taggedFunction(next_fn)) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_mode, Value.fromInt32(1)) catch return error.OutOfMemory;
-        state.set(realm.allocator, k_fa_is_async, Value.false_) catch return error.OutOfMemory;
+        try faStateSet(realm, state, k_fa_iter, iter_v);
+        try faStateSet(realm, state, k_fa_next_fn, heap_mod.taggedFunction(next_fn));
+        try faStateSet(realm, state, k_fa_mode, Value.fromInt32(1));
+        try faStateSet(realm, state, k_fa_is_async, Value.false_);
         fromAsyncIterStep(realm, state) catch {
             return rejectPendingException(realm, cap);
         };
@@ -3739,7 +3739,7 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
             return rejectPendingException(realm, cap);
         };
     };
-    state.set(realm.allocator, k_fa_items, heap_mod.taggedObject(items_obj)) catch return error.OutOfMemory;
+    try faStateSet(realm, state, k_fa_items, heap_mod.taggedObject(items_obj));
 
     const raw_len = toLengthOf(realm, items_obj) catch {
         return rejectPendingException(realm, cap);
@@ -3747,8 +3747,8 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
     const len = intrinsics.clampArrayLengthR(realm, raw_len) catch {
         return rejectPendingException(realm, cap);
     };
-    state.set(realm.allocator, k_fa_length, numberFromI64(len)) catch return error.OutOfMemory;
-    state.set(realm.allocator, k_fa_mode, Value.fromInt32(0)) catch return error.OutOfMemory;
+    try faStateSet(realm, state, k_fa_length, numberFromI64(len));
+    try faStateSet(realm, state, k_fa_mode, Value.fromInt32(0));
 
     // §23.1.2.1.1 step 3.k.iv — `IsConstructor(C)` → `Construct(C, « 𝔽(len) »)`.
     if (this_ctor) |c| {
@@ -3756,7 +3756,7 @@ fn arrayFromAsync(realm: *Realm, this_value: Value, args: []const Value) NativeE
         const ctor_v = constructForFromAsync(realm, c, &ctor_args) catch {
             return rejectPendingException(realm, cap);
         };
-        state.set(realm.allocator, k_fa_array, ctor_v) catch return error.OutOfMemory;
+        try faStateSet(realm, state, k_fa_array, ctor_v);
     }
 
     fromAsyncArrayLikeStep(realm, state) catch {
@@ -3819,6 +3819,14 @@ fn awaitAndThen(
     on_resolve: *JSFunction,
     on_reject: *JSFunction,
 ) NativeError!void {
+    // Root `source` (possibly a freshly-wrapped promise) and the
+    // result promise across the allocations that follow — the
+    // `result_promise` allocation and `promiseReactionsPtr` /
+    // reaction-list growth would otherwise sweep an un-anchored
+    // `source` under aggressive GC.
+    const sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer sc.close();
+
     var source: *JSObject = undefined;
     if (heap_mod.valueAsPlainObject(value)) |obj| {
         if (obj.isPromise()) {
@@ -3829,8 +3837,10 @@ fn awaitAndThen(
     } else {
         source = try wrapValueInPromise(realm, value);
     }
+    sc.push(heap_mod.taggedObject(source)) catch return error.OutOfMemory;
 
     const result_promise = promise_mod.allocatePromiseFor(realm, null, .pending, Value.undefined_) catch return error.OutOfMemory;
+    sc.push(result_promise) catch return error.OutOfMemory;
     const on_resolve_v = heap_mod.taggedFunction(on_resolve);
     const on_reject_v = heap_mod.taggedFunction(on_reject);
     switch (source.promise_state) {
@@ -3850,6 +3860,13 @@ fn awaitAndThen(
 fn wrapValueInPromise(realm: *Realm, value: Value) NativeError!*JSObject {
     const wrap_v = promise_mod.allocatePromiseFor(realm, null, .pending, Value.undefined_) catch return error.OutOfMemory;
     const wrap = heap_mod.valueAsPlainObject(wrap_v).?;
+    // Root `wrap` across `promiseResolveImplExported` — it re-enters
+    // JS (runs the resolve machinery) and can GC, which would
+    // otherwise sweep the freshly-allocated, not-yet-referenced
+    // `wrap` and return a dangling promise to `awaitAndThen`.
+    const sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer sc.close();
+    sc.push(wrap_v) catch return error.OutOfMemory;
     const args = [_]Value{value};
     _ = promise_mod.promiseResolveImplExported(realm, heap_mod.taggedObject(wrap), &args) catch return error.OutOfMemory;
     return wrap;
@@ -3857,16 +3874,63 @@ fn wrapValueInPromise(realm: *Realm, value: Value) NativeError!*JSObject {
 
 // ── Bound-callback helpers ──────────────────────────────────────────────────
 
-fn makeBoundCb(realm: *Realm, impl: *const fn (*Realm, Value, []const Value) NativeError!Value, state: *JSObject) NativeError!*JSFunction {
+fn makeBoundCb(
+    realm: *Realm,
+    impl: *const fn (*Realm, Value, []const Value) NativeError!Value,
+    state: *JSObject,
+    sc: *heap_mod.HandleScope,
+) NativeError!*JSFunction {
     const impl_fn = realm.heap.allocateFunctionNative(impl, 1, "") catch return error.OutOfMemory;
     impl_fn.proto = realm.intrinsics.function_prototype;
     impl_fn.has_construct = false;
+    // Root `impl_fn` across the `bound` allocation below — otherwise
+    // a GC there (deterministic at `gc-threshold=1`) sweeps the
+    // un-anchored `impl_fn`, leaving `setBoundTarget` to store a
+    // dangling pointer that surfaces as "value is not callable" when
+    // the trampoline later dereferences `bound_target`.
+    sc.push(heap_mod.taggedFunction(impl_fn)) catch return error.OutOfMemory;
     const bound = realm.heap.allocateFunctionNative(promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
     bound.proto = realm.intrinsics.function_prototype;
     bound.has_construct = false;
     realm.heap.setBoundTarget(bound, impl_fn);
     realm.heap.setBoundThis(bound, heap_mod.taggedObject(state));
+    // Keep `bound` rooted until the caller registers it in a promise
+    // reaction — a sibling `makeBoundCb` call (the reject twin)
+    // allocates again before `awaitAndThen` runs.
+    sc.push(heap_mod.taggedFunction(bound)) catch return error.OutOfMemory;
     return bound;
+}
+
+/// Allocate the resolve / reject bound continuations for one
+/// `Array.fromAsync` await and schedule them. Roots the awaited
+/// `value` and every intermediate function on `sc` so the cascade
+/// of allocations under aggressive GC can't sweep a callable before
+/// it lands in a (rooted) promise reaction.
+fn awaitWithCbs(
+    realm: *Realm,
+    sc: *heap_mod.HandleScope,
+    state: *JSObject,
+    value: Value,
+    on_res_impl: *const fn (*Realm, Value, []const Value) NativeError!Value,
+    on_rej_impl: *const fn (*Realm, Value, []const Value) NativeError!Value,
+) NativeError!void {
+    sc.push(value) catch return error.OutOfMemory;
+    const on_res = try makeBoundCb(realm, on_res_impl, state, sc);
+    const on_rej = try makeBoundCb(realm, on_rej_impl, state, sc);
+    try awaitAndThen(realm, value, on_res, on_rej);
+}
+
+/// Store into the engine-internal `Array.fromAsync` driver `state`
+/// object with the generational write barrier. `state` lives across
+/// every `await` suspension and is therefore promoted to mature; a
+/// later young value stored into a `__cynic_fa_*` slot via the raw
+/// `JSObject.set` (which doesn't barrier) is an un-remembered
+/// mature→young edge that the next minor GC sweeps — a
+/// use-after-free on the next driver step. The barrier no-ops for
+/// the primitive slots (index / mode / length flags).
+fn faStateSet(realm: *Realm, state: *JSObject, key: []const u8, value: Value) NativeError!void {
+    realm.heap.writeBarrier(.{ .object = state }, value);
+    state.set(realm.allocator, key, value) catch return error.OutOfMemory;
 }
 
 // ── Iterator-path driver ────────────────────────────────────────────────────
@@ -3907,9 +3971,7 @@ fn fromAsyncIterStep(realm: *Realm, state: *JSObject) NativeError!void {
             return;
         },
     };
-    const on_res = try makeBoundCb(realm, fromAsyncIterOnNextResult, state);
-    const on_rej = try makeBoundCb(realm, fromAsyncIterOnNextReject, state);
-    try awaitAndThen(realm, next_v, on_res, on_rej);
+    try awaitWithCbs(realm, fa_sc, state, next_v, fromAsyncIterOnNextResult, fromAsyncIterOnNextReject);
 }
 
 fn fromAsyncIterOnNextResult(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
@@ -3956,9 +4018,7 @@ fn fromAsyncIterOnNextResult(realm: *Realm, this_value: Value, args: []const Val
     // (e.g. a thenable yielded by the generator calls `reject`), the
     // sync iterator MUST be closed (IfAbruptCloseAsyncIterator).
     // `sync-iterable-with-rejecting-thenable-closes.js`.
-    const on_res = try makeBoundCb(realm, fromAsyncIterOnValueAwaited, state);
-    const on_rej = try makeBoundCb(realm, fromAsyncIterOnValueReject, state);
-    try awaitAndThen(realm, value_v, on_res, on_rej);
+    try awaitWithCbs(realm, fa_sc, state, value_v, fromAsyncIterOnValueAwaited, fromAsyncIterOnValueReject);
     return Value.undefined_;
 }
 
@@ -3991,9 +4051,7 @@ fn fromAsyncIterOnValueAwaited(realm: *Realm, this_value: Value, args: []const V
                 return closeIterAndReject(realm, state);
             },
         };
-        const on_res = try makeBoundCb(realm, fromAsyncIterOnMappedAwaited, state);
-        const on_rej = try makeBoundCb(realm, fromAsyncIterOnMappedReject, state);
-        try awaitAndThen(realm, mapped, on_res, on_rej);
+        try awaitWithCbs(realm, fa_sc, state, mapped, fromAsyncIterOnMappedAwaited, fromAsyncIterOnMappedReject);
         return Value.undefined_;
     }
 
@@ -4094,13 +4152,20 @@ fn appendAndStepIter(realm: *Realm, state: *JSObject, value: Value) NativeError!
     var ibuf: [24]u8 = undefined;
     const islice = std.fmt.bufPrint(&ibuf, "{d}", .{k}) catch unreachable;
     const owned = realm.heap.allocateString(islice) catch return error.OutOfMemory;
+    // Root the key string and the element value across
+    // `createDataPropertyOrThrow` — for a Proxy `A` it fires the
+    // `defineProperty` trap (user JS, can GC), and the borrowed
+    // `key` slice into `owned.bytes` would dangle if `owned` were
+    // swept mid-trap.
+    fa_sc.push(Value.fromString(owned)) catch return error.OutOfMemory;
+    fa_sc.push(value) catch return error.OutOfMemory;
     // §23.1.2.1.1 step 3.j.ii.8 — `CreateDataPropertyOrThrow(A, Pk,
     // mappedValue)`. Abrupt completion routes through
     // `closeIterAndReject` (step 9 — `AsyncIteratorClose`).
     createDataPropertyOrThrow(realm, out, owned, value) catch {
         return closeIterAndReject(realm, state);
     };
-    state.set(realm.allocator, k_fa_index, Value.fromInt32(k + 1)) catch return error.OutOfMemory;
+    try faStateSet(realm, state, k_fa_index, Value.fromInt32(k + 1));
     fromAsyncIterStep(realm, state) catch {
         return rejectFromState(realm, state);
     };
@@ -4159,9 +4224,7 @@ fn fromAsyncArrayLikeStep(realm: *Realm, state: *JSObject) NativeError!void {
         return;
     };
 
-    const on_res = try makeBoundCb(realm, fromAsyncArrayLikeOnAwaited, state);
-    const on_rej = try makeBoundCb(realm, fromAsyncArrayLikeOnReject, state);
-    try awaitAndThen(realm, raw, on_res, on_rej);
+    try awaitWithCbs(realm, fa_sc, state, raw, fromAsyncArrayLikeOnAwaited, fromAsyncArrayLikeOnReject);
 }
 
 fn fromAsyncArrayLikeOnAwaited(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
@@ -4182,9 +4245,7 @@ fn fromAsyncArrayLikeOnAwaited(realm: *Realm, this_value: Value, args: []const V
             .value, .yielded => |v| v,
             .thrown => |ex| return rejectFromStateWithReason(realm, state, ex),
         };
-        const on_res = try makeBoundCb(realm, fromAsyncArrayLikeOnMapped, state);
-        const on_rej = try makeBoundCb(realm, fromAsyncArrayLikeOnReject, state);
-        try awaitAndThen(realm, mapped, on_res, on_rej);
+        try awaitWithCbs(realm, fa_sc, state, mapped, fromAsyncArrayLikeOnMapped, fromAsyncArrayLikeOnReject);
         return Value.undefined_;
     }
 
@@ -4211,13 +4272,17 @@ fn appendAndStepArrayLike(realm: *Realm, state: *JSObject, value: Value) NativeE
     var ibuf: [24]u8 = undefined;
     const islice = std.fmt.bufPrint(&ibuf, "{d}", .{k}) catch unreachable;
     const owned = realm.heap.allocateString(islice) catch return error.OutOfMemory;
+    // Root key + value across the (proxy-capable) define — see
+    // `appendAndStepIter`.
+    fa_sc.push(Value.fromString(owned)) catch return error.OutOfMemory;
+    fa_sc.push(value) catch return error.OutOfMemory;
     // §23.1.2.1.1 step 3.l.iii — `CreateDataPropertyOrThrow(A, Pk,
     // mappedValue)`. There's no iterator to close on the array-like
     // path; an abrupt completion just rejects the outer promise.
     createDataPropertyOrThrow(realm, out, owned, value) catch {
         return rejectFromState(realm, state);
     };
-    state.set(realm.allocator, k_fa_index, Value.fromInt32(k + 1)) catch return error.OutOfMemory;
+    try faStateSet(realm, state, k_fa_index, Value.fromInt32(k + 1));
     fromAsyncArrayLikeStep(realm, state) catch {
         return rejectFromState(realm, state);
     };

--- a/src/runtime/builtins/date.zig
+++ b/src/runtime/builtins/date.zig
@@ -13,6 +13,7 @@ const JSFunction = @import("../function.zig").JSFunction;
 const NativeError = @import("../function.zig").NativeError;
 const heap_mod = @import("../heap.zig");
 const intrinsics = @import("../intrinsics.zig");
+const temporal_builtin = @import("temporal.zig");
 const installConstructor = intrinsics.installConstructor;
 const installNativeMethod = intrinsics.installNativeMethod;
 const installNativeMethodOnProto = intrinsics.installNativeMethodOnProto;
@@ -115,6 +116,9 @@ pub fn install(realm: *Realm) !void {
     try installNativeMethodOnProto(realm, proto, "toLocaleString", dateToString, 0);
     try installNativeMethodOnProto(realm, proto, "toLocaleDateString", dateToDateString, 0);
     try installNativeMethodOnProto(realm, proto, "toLocaleTimeString", dateToTimeString, 0);
+    // Temporal proposal — `Date.prototype.toTemporalInstant` bridges a
+    // legacy Date to a Temporal.Instant (epoch ms → epoch ns).
+    try installNativeMethodOnProto(realm, proto, "toTemporalInstant", dateToTemporalInstant, 0);
 
     // §21.4.4.45 Date.prototype[@@toPrimitive] — OrdinaryToPrimitive
     // on the receiver with `tryFirst` determined by the hint. Spec
@@ -1196,4 +1200,19 @@ fn dateGetTzOffset(realm: *Realm, this_value: Value, args: []const Value) Native
     // otherwise returns +0 (no local offset to report).
     if (std.math.isNan(ms)) return Value.fromDouble(std.math.nan(f64));
     return Value.fromInt32(0);
+}
+
+/// Date.prototype.toTemporalInstant ( ) — the Temporal proposal's
+/// bridge from a legacy Date: `ns = NumberToBigInt([[DateValue]]) ×
+/// 10^6`. An invalid (NaN) Date throws RangeError. A finite Date value
+/// is always integral and within ±8.64×10^15 ms, so the resulting
+/// epoch ns is always inside the representable Instant range.
+fn dateToTemporalInstant(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    const ms = try requireDateMs(realm, this_value);
+    if (std.math.isNan(ms)) {
+        return throwRangeError(realm, "Cannot convert an invalid Date to a Temporal.Instant");
+    }
+    const ns: i128 = @as(i128, @intFromFloat(ms)) * 1_000_000;
+    return temporal_builtin.createTemporalInstant(realm, ns);
 }

--- a/src/runtime/builtins/promise.zig
+++ b/src/runtime/builtins/promise.zig
@@ -202,6 +202,15 @@ pub fn newPromiseCapability(realm: *Realm, ctor: *JSFunction) NativeError!Promis
     // `this_value` without needing closures.
     const state = realm.heap.allocateObject() catch return error.OutOfMemory;
     realm.heap.setObjectPrototype(state, realm.intrinsics.object_prototype);
+    // Root `state` (and the executor below) across the executor
+    // allocations and the user-constructor `constructValue` call —
+    // the latter runs arbitrary JS and can GC repeatedly. `state`'s
+    // `capability_record` is where the executor stashes resolve/reject,
+    // so a swept `state` mid-construct loses the capability and the
+    // executor's `bound_this` dangles.
+    const cap_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer cap_sc.close();
+    cap_sc.push(heap_mod.taggedObject(state)) catch return error.OutOfMemory;
     const rec = realm.allocator.create(@import("../object.zig").PromiseCapabilityRecord) catch return error.OutOfMemory;
     rec.* = .{};
     state.capability_record = rec;
@@ -212,9 +221,11 @@ pub fn newPromiseCapability(realm: *Realm, ctor: *JSFunction) NativeError!Promis
     const executor_impl = realm.heap.allocateFunctionNative(capabilityExecutorImpl, 2, "") catch return error.OutOfMemory;
     executor_impl.proto = realm.intrinsics.function_prototype;
     executor_impl.has_construct = false;
+    cap_sc.push(heap_mod.taggedFunction(executor_impl)) catch return error.OutOfMemory;
     const executor = realm.heap.allocateFunctionNative(boundResolveTrampoline, 2, "") catch return error.OutOfMemory;
     executor.proto = realm.intrinsics.function_prototype;
     executor.has_construct = false;
+    cap_sc.push(heap_mod.taggedFunction(executor)) catch return error.OutOfMemory;
     realm.heap.setBoundTarget(executor, executor_impl);
     realm.heap.setBoundThis(executor, heap_mod.taggedObject(state));
 
@@ -711,20 +722,32 @@ fn promiseFinally(realm: *Realm, this_value: Value, args: []const Value) NativeE
     // onFinally is callable; otherwise pass through.
     var then_arg: Value = on_finally;
     var catch_arg: Value = on_finally;
+    // Root the reaction context + both wrappers across the
+    // allocations below AND the `.then` call further down (which
+    // allocates a capability before enqueuing the reactions). Until
+    // a wrapper lands in a microtask's reaction_handler it is
+    // reachable only through unrooted native locals; a mid-`.then`
+    // sweep would otherwise enqueue a dangling handler. Opened at
+    // function scope so it outlives the `.then` invocation.
+    const fin_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer fin_sc.close();
     if (on_finally_fn != null) {
         const ctx = realm.heap.allocateObject() catch return error.OutOfMemory;
         realm.heap.setObjectPrototype(ctx, realm.intrinsics.object_prototype);
+        fin_sc.push(heap_mod.taggedObject(ctx)) catch return error.OutOfMemory;
         realm.heap.setFinallyCallback(ctx, on_finally_fn);
         realm.heap.setFinallyConstructor(ctx, C);
 
         const then_fn = realm.heap.allocateFunctionNative(finallyThenReaction, 1, "") catch return error.OutOfMemory;
         then_fn.proto = realm.intrinsics.function_prototype;
         then_fn.is_arrow = true;
+        fin_sc.push(heap_mod.taggedFunction(then_fn)) catch return error.OutOfMemory;
         realm.heap.setCapturedThis(then_fn, heap_mod.taggedObject(ctx));
 
         const catch_fn = realm.heap.allocateFunctionNative(finallyCatchReaction, 1, "") catch return error.OutOfMemory;
         catch_fn.proto = realm.intrinsics.function_prototype;
         catch_fn.is_arrow = true;
+        fin_sc.push(heap_mod.taggedFunction(catch_fn)) catch return error.OutOfMemory;
         realm.heap.setCapturedThis(catch_fn, heap_mod.taggedObject(ctx));
 
         then_arg = heap_mod.taggedFunction(then_fn);
@@ -1156,6 +1179,15 @@ fn collectIterable(realm: *Realm, source_v: Value) NativeError!std.ArrayList(Val
 
     if (try iteratorOpen(realm, source_v)) |rec_in| {
         var rec = rec_in;
+        // Root the iterator object + `next` method, and every value
+        // collected so far, across each `iteratorStep` re-entry —
+        // `list` is a native ArrayList the GC does not scan, so a
+        // young value already appended would be swept by the next
+        // step's allocations under aggressive GC.
+        const it_sc = realm.heap.openScope() catch return error.OutOfMemory;
+        defer it_sc.close();
+        it_sc.push(rec.iter_v) catch return error.OutOfMemory;
+        it_sc.push(heap_mod.taggedFunction(rec.next_fn)) catch return error.OutOfMemory;
         const max_iter: usize = 1 << 24;
         var step: usize = 0;
         while (step < max_iter) : (step += 1) {
@@ -1165,6 +1197,7 @@ fn collectIterable(realm: *Realm, source_v: Value) NativeError!std.ArrayList(Val
                 return err;
             } orelse break;
             try list.append(realm.allocator, v);
+            it_sc.push(v) catch return error.OutOfMemory;
         }
         return list;
     }
@@ -1242,6 +1275,16 @@ fn iterateAggregator(
     // array-like fallback (spec §7.4.2 only allows GetIterator).
     const rec_in = (try iteratorOpen(realm, source_v)) orelse unreachable;
     var rec = rec_in;
+    // Root the iterator object + its `next` method for the whole
+    // walk. `iteratorStep`, the per-item `resolve` call, and
+    // `process` all re-enter JS and can GC; the user-created
+    // iterator is reachable only through this native record, so
+    // without rooting it a collection sweeps it and `iteratorClose`
+    // (or the next `iteratorStep`) dereferences freed memory.
+    const it_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer it_sc.close();
+    it_sc.push(rec.iter_v) catch return error.OutOfMemory;
+    it_sc.push(heap_mod.taggedFunction(rec.next_fn)) catch return error.OutOfMemory;
     const max_iter: usize = 1 << 24;
     var idx: usize = 0;
     while (idx < max_iter) : (idx += 1) {
@@ -1250,6 +1293,16 @@ fn iterateAggregator(
             // here (rec.done is true).
             return err;
         } orelse return;
+
+        // Root the yielded value and (below) the resolved Promise
+        // across the `resolve` call and `process` — both re-enter
+        // JS and allocate (`process` builds the per-element resolve/
+        // reject closures), and these are bare natives the GC can't
+        // otherwise see. Per-iteration scope so the roots don't
+        // accumulate across a long iterable.
+        const step_sc = realm.heap.openScope() catch return error.OutOfMemory;
+        defer step_sc.close();
+        step_sc.push(next_v) catch return error.OutOfMemory;
 
         const r_outcome = interp.callJSFunction(realm.allocator, realm, resolve_fn, heap_mod.taggedFunction(ctor), &.{next_v}) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
@@ -1266,6 +1319,7 @@ fn iterateAggregator(
                 return error.NativeThrew;
             },
         };
+        step_sc.push(resolved) catch return error.OutOfMemory;
 
         const action = process(ctx, realm, ctor, idx, resolved) catch |err| {
             iteratorClose(realm, &rec);
@@ -1403,9 +1457,17 @@ fn allocAggState(realm: *Realm, kind: AggKind, cap: PromiseCapability, values: *
 /// bound function whose `bound_this` is a fresh wrapper carrying
 /// `(state, index, alreadyCalled)` so the shared element impl
 /// can read the wrapper out of `this_value`.
-fn allocElementClosures(realm: *Realm, state: *JSObject, idx: u32) NativeError!struct { resolve: *JSFunction, reject: *JSFunction } {
+fn allocElementClosures(realm: *Realm, sc: *heap_mod.HandleScope, state: *JSObject, idx: u32) NativeError!struct { resolve: *JSFunction, reject: *JSFunction } {
     const wrapper = realm.heap.allocateObject() catch return error.OutOfMemory;
     realm.heap.setObjectPrototype(wrapper, realm.intrinsics.object_prototype);
+    // Root the wrapper + each closure as it is allocated. Every
+    // `allocateFunctionNative` below is a GC point, and until a
+    // closure lands in a microtask's reaction_handler (via the
+    // caller's `.then`) it is reachable only through unrooted native
+    // locals — without `sc` a mid-allocation sweep frees an earlier
+    // one and the later `.then` enqueues a dangling handler. The
+    // caller keeps `sc` open across `invokeThenWithClosures`.
+    sc.push(heap_mod.taggedObject(wrapper)) catch return error.OutOfMemory;
     wrapper.set(realm.allocator, k_elem_state, heap_mod.taggedObject(state)) catch return error.OutOfMemory;
     wrapper.set(realm.allocator, k_elem_index, Value.fromInt32(@intCast(idx))) catch return error.OutOfMemory;
     wrapper.set(realm.allocator, k_elem_called, Value.false_) catch return error.OutOfMemory;
@@ -1415,18 +1477,22 @@ fn allocElementClosures(realm: *Realm, state: *JSObject, idx: u32) NativeError!s
     const resolve_impl = realm.heap.allocateFunctionNative(aggResolveElement, 1, "") catch return error.OutOfMemory;
     resolve_impl.proto = realm.intrinsics.function_prototype;
     resolve_impl.has_construct = false;
+    sc.push(heap_mod.taggedFunction(resolve_impl)) catch return error.OutOfMemory;
     const resolve_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     resolve_fn.proto = realm.intrinsics.function_prototype;
     resolve_fn.has_construct = false;
+    sc.push(heap_mod.taggedFunction(resolve_fn)) catch return error.OutOfMemory;
     realm.heap.setBoundTarget(resolve_fn, resolve_impl);
     realm.heap.setBoundThis(resolve_fn, heap_mod.taggedObject(wrapper));
 
     const reject_impl = realm.heap.allocateFunctionNative(aggRejectElement, 1, "") catch return error.OutOfMemory;
     reject_impl.proto = realm.intrinsics.function_prototype;
     reject_impl.has_construct = false;
+    sc.push(heap_mod.taggedFunction(reject_impl)) catch return error.OutOfMemory;
     const reject_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     reject_fn.proto = realm.intrinsics.function_prototype;
     reject_fn.has_construct = false;
+    sc.push(heap_mod.taggedFunction(reject_fn)) catch return error.OutOfMemory;
     realm.heap.setBoundTarget(reject_fn, reject_impl);
     realm.heap.setBoundThis(reject_fn, heap_mod.taggedObject(wrapper));
 
@@ -1573,9 +1639,23 @@ fn invokeCapReject(realm: *Realm, state: *JSObject, reason: Value) NativeError!V
 }
 
 fn setIndexedOnArray(realm: *Realm, arr: *JSObject, idx: u32, v: Value) NativeError!void {
+    // `arr` is an aggregator results array (`Promise.all` values,
+    // `allSettled` entries, `any` errors) that survives across the
+    // whole walk and is promoted to mature. Two GC hazards under
+    // aggressive collection:
+    //   (1) the index-string allocation below is a GC point that
+    //       would sweep a young `v` before it lands — root it;
+    //   (2) storing a young `v` into the mature `arr` via the raw
+    //       `JSObject.set` (no barrier) is an un-remembered
+    //       mature→young edge the next minor GC sweeps (the gc1
+    //       remembered-set verifier trips on exactly this).
+    const sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer sc.close();
+    sc.push(v) catch return error.OutOfMemory;
     var ibuf: [24]u8 = undefined;
     const islice = std.fmt.bufPrint(&ibuf, "{d}", .{idx}) catch unreachable;
     const owned = realm.heap.allocateString(islice) catch return error.OutOfMemory;
+    realm.heap.writeBarrier(.{ .object = arr }, v);
     arr.set(realm.allocator, owned.flatBytes(), v) catch return error.OutOfMemory;
 }
 
@@ -1608,7 +1688,12 @@ fn aggregatorAllProcess(ctx_ptr: *anyopaque, realm: *Realm, ctor: *JSFunction, i
     setLength(realm, values, @intCast(@as(u32, @intCast(idx + 1)))) catch return error.OutOfMemory;
     const cur = ctx.state.get(k_remaining).asInt32();
     ctx.state.set(realm.allocator, k_remaining, Value.fromInt32(cur + 1)) catch return error.OutOfMemory;
-    const closures = try allocElementClosures(realm, ctx.state, @intCast(idx));
+    // Keep the element closures rooted across `.then` (which allocates
+    // a capability before enqueuing the reaction); markRoots adopts
+    // them once the reaction lands in the microtask queue.
+    const closures_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer closures_sc.close();
+    const closures = try allocElementClosures(realm, closures_sc, ctx.state, @intCast(idx));
     return invokeThenWithClosures(realm, resolved, closures.resolve, ctx.cap.reject);
 }
 
@@ -1625,7 +1710,9 @@ fn aggregatorAllSettledProcess(ctx_ptr: *anyopaque, realm: *Realm, ctor: *JSFunc
     setLength(realm, values, @intCast(@as(u32, @intCast(idx + 1)))) catch return error.OutOfMemory;
     const cur = ctx.state.get(k_remaining).asInt32();
     ctx.state.set(realm.allocator, k_remaining, Value.fromInt32(cur + 1)) catch return error.OutOfMemory;
-    const closures = try allocElementClosures(realm, ctx.state, @intCast(idx));
+    const closures_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer closures_sc.close();
+    const closures = try allocElementClosures(realm, closures_sc, ctx.state, @intCast(idx));
     return invokeThenWithClosures(realm, resolved, closures.resolve, closures.reject);
 }
 
@@ -1637,7 +1724,9 @@ fn aggregatorAnyProcess(ctx_ptr: *anyopaque, realm: *Realm, ctor: *JSFunction, i
     setLength(realm, errors, @intCast(@as(u32, @intCast(idx + 1)))) catch return error.OutOfMemory;
     const cur = ctx.state.get(k_remaining).asInt32();
     ctx.state.set(realm.allocator, k_remaining, Value.fromInt32(cur + 1)) catch return error.OutOfMemory;
-    const closures = try allocElementClosures(realm, ctx.state, @intCast(idx));
+    const closures_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer closures_sc.close();
+    const closures = try allocElementClosures(realm, closures_sc, ctx.state, @intCast(idx));
     // §27.2.4.3.1 PerformPromiseAny step 8.j —
     //   Perform ? Invoke(nextPromise, "then",
     //     « resultCapability.[[Resolve]], onRejected »).
@@ -1865,6 +1954,16 @@ fn promiseRace(realm: *Realm, this_value: Value, args: []const Value) NativeErro
     // each `.then` call, so we need them populated even for the
     // built-in Promise constructor.
     const cap = try newPromiseCapability(realm, ctor);
+    // Root the capability closures + result promise across the
+    // walk. Unlike all / allSettled / any, race keeps no `state`
+    // object — `cap` lives only in the native `RaceCtx`, which the
+    // GC can't scan, so `iterateAggregator`'s re-entries would sweep
+    // `cap.resolve` / `cap.reject` / `cap.promise` mid-iteration.
+    const agg_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer agg_scope.close();
+    agg_scope.push(heap_mod.taggedFunction(cap.resolve)) catch return error.OutOfMemory;
+    agg_scope.push(heap_mod.taggedFunction(cap.reject)) catch return error.OutOfMemory;
+    agg_scope.push(cap.promise) catch return error.OutOfMemory;
     var ctx = RaceCtx{ .cap = cap };
     iterateAggregator(realm, ctor, argOr(args, 0, Value.undefined_), &ctx, raceProcess) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -879,31 +879,106 @@ fn plainTimeCompare(realm: *Realm, this_value: Value, args: []const Value) Nativ
     return Value.fromInt32(temporal.compareTime(a, b));
 }
 
-// Deferred PlainTime arithmetic / difference.
+/// §4.5.x AddDurationToTime — add (`sign` +1) or subtract (−1) a
+/// duration's time part to a PlainTime, wrapping mod 24 h. A PlainTime
+/// has no date, so the duration's calendar units (years/months/weeks/
+/// days) are ignored, not rejected.
+fn plainTimeAddSubtract(realm: *Realm, this_value: Value, duration_like: Value, sign: i128) NativeError!Value {
+    const base = try requirePlainTime(realm, this_value);
+    const d = try toTemporalDuration(realm, duration_like);
+    if (!temporal.isValidDuration(d)) return throwRangeError(realm, "Duration values are out of range");
+    const total = temporal.timeRecordToNanoseconds(base) + temporal.timeDurationNanoseconds(d) * sign;
+    const wrapped = @mod(total, @as(i128, 86_400_000_000_000));
+    return createTemporalTime(realm, temporal.nanosecondsToTimeRecord(wrapped));
+}
+
 fn plainTimeAdd(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainTime(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainTime.prototype.add is not yet implemented");
+    return plainTimeAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), 1);
 }
+
 fn plainTimeSubtract(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainTime(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainTime.prototype.subtract is not yet implemented");
+    return plainTimeAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), -1);
 }
+
+/// §4.5.x Temporal.PlainTime.prototype.round ( roundTo ). String
+/// shorthand for `{ smallestUnit }`; smallestUnit required (hour..ns).
+/// A rounding that reaches 24 h wraps back to 00:00.
 fn plainTimeRound(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainTime(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainTime.prototype.round is not yet implemented");
+    const t = try requirePlainTime(realm, this_value);
+    const round_to = argOr(args, 0, Value.undefined_);
+    if (round_to.isUndefined()) {
+        return throwTypeError(realm, "Temporal.PlainTime.prototype.round requires a smallestUnit");
+    }
+    var unit: temporal.LargestUnit = undefined;
+    var increment: i128 = 1;
+    var mode: temporal.RoundingMode = .half_expand;
+    if (round_to.isString()) {
+        const s: *JSString = @ptrCast(@alignCast(round_to.asString()));
+        unit = temporal.parseTemporalUnit(s.flatBytes()) orelse
+            return throwRangeError(realm, "invalid smallestUnit");
+    } else {
+        const opts = try getOptionsObject(realm, round_to);
+        increment = try getRoundingIncrementOption(realm, opts);
+        mode = try getRoundingModeOption(realm, opts, .half_expand);
+        unit = (try getTemporalUnitOption(realm, opts, "smallestUnit")) orelse
+            return throwRangeError(realm, "smallestUnit is required");
+    }
+    try requireUnitInRange(realm, unit, .hour, .nanosecond);
+    const per_day = @divExact(@as(i128, 86_400_000_000_000), temporal.unitNanoseconds(unit));
+    if (!temporal.validateRoundingIncrement(increment, per_day, true)) {
+        return throwRangeError(realm, "roundingIncrement does not divide evenly into a day");
+    }
+    const rounded = temporal.roundToIncrement(temporal.timeRecordToNanoseconds(t), increment * temporal.unitNanoseconds(unit), mode);
+    const wrapped = @mod(rounded, @as(i128, 86_400_000_000_000));
+    return createTemporalTime(realm, temporal.nanosecondsToTimeRecord(wrapped));
 }
+
 fn plainTimeUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainTime(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainTime.prototype.until is not yet implemented");
+    return differenceTemporalTime(realm, this_value, args, false);
 }
+
 fn plainTimeSince(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainTime(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainTime.prototype.since is not yet implemented");
+    return differenceTemporalTime(realm, this_value, args, true);
+}
+
+/// §4.5.x DifferenceTemporalPlainTime — like the Instant difference, but
+/// the operands are times-of-day (delta within ±24 h) and the default
+/// largestUnit is "hour".
+fn differenceTemporalTime(realm: *Realm, this_value: Value, args: []const Value, is_since: bool) NativeError!Value {
+    const this_t = try requirePlainTime(realm, this_value);
+    const other_t = try toTemporalTime(realm, argOr(args, 0, Value.undefined_), Value.undefined_);
+    const opts = try getOptionsObject(realm, argOr(args, 1, Value.undefined_));
+
+    const largest_opt = try getTemporalUnitOption(realm, opts, "largestUnit");
+    const increment = try getRoundingIncrementOption(realm, opts);
+    const mode = try getRoundingModeOption(realm, opts, .trunc);
+    const smallest_opt = try getTemporalUnitOption(realm, opts, "smallestUnit");
+
+    if (largest_opt) |lu| try requireUnitInRange(realm, lu, .hour, .nanosecond);
+    const smallest = smallest_opt orelse temporal.LargestUnit.nanosecond;
+    try requireUnitInRange(realm, smallest, .hour, .nanosecond);
+    const largest = largest_opt orelse temporal.LargestUnit.hour;
+    if (@intFromEnum(largest) > @intFromEnum(smallest)) {
+        return throwRangeError(realm, "largestUnit must not be smaller than smallestUnit");
+    }
+    if (!temporal.validateRoundingIncrement(increment, differenceDividend(smallest), false)) {
+        return throwRangeError(realm, "invalid roundingIncrement for the smallestUnit");
+    }
+
+    const diff = temporal.timeRecordToNanoseconds(other_t) - temporal.timeRecordToNanoseconds(this_t);
+    const eff_mode = if (is_since) negateRoundingMode(mode) else mode;
+    const rounded = temporal.roundToIncrement(diff, increment * temporal.unitNanoseconds(smallest), eff_mode);
+    var dr = temporal.balanceTimeDuration(rounded, largest);
+    if (is_since) {
+        dr.days = negZero(dr.days);
+        dr.hours = negZero(dr.hours);
+        dr.minutes = negZero(dr.minutes);
+        dr.seconds = negZero(dr.seconds);
+        dr.milliseconds = negZero(dr.milliseconds);
+        dr.microseconds = negZero(dr.microseconds);
+        dr.nanoseconds = negZero(dr.nanoseconds);
+    }
+    return createTemporalDuration(realm, dr);
 }
 
 // ── §8 Temporal.Instant ────────────────────────────────────────────────────
@@ -1172,23 +1247,194 @@ fn instantValueOf(realm: *Realm, this_value: Value, args: []const Value) NativeE
     return throwTypeError(realm, "Called valueOf on a Temporal.Instant; use compare() instead");
 }
 
-// Deferred Instant deep-end — present for shape, throw until the
-// rounding / time-zone machinery lands.
+// ── §13 Rounding / difference option parsing (shared) ─────────────────────
+
+/// §13.x GetOptionsObject — the options object, or null when options is
+/// undefined. A non-object, non-undefined value throws TypeError. A
+/// callable options bag is tolerated as empty (property reads want a
+/// plain object); function-valued options are a rare edge.
+fn getOptionsObject(realm: *Realm, options: Value) NativeError!?*JSObject {
+    if (options.isUndefined()) return null;
+    if (heap_mod.valueAsPlainObject(options)) |o| return o;
+    if (heap_mod.valueAsFunction(options) != null) return null;
+    return throwTypeError(realm, "options must be an object or undefined");
+}
+
+/// §13.x GetRoundingModeOption.
+fn getRoundingModeOption(realm: *Realm, opts: ?*JSObject, default_mode: temporal.RoundingMode) NativeError!temporal.RoundingMode {
+    const obj = opts orelse return default_mode;
+    const v = try getPropertyChain(realm, obj, "roundingMode");
+    if (v.isUndefined()) return default_mode;
+    const s = try stringifyArg(realm, v);
+    return temporal.parseRoundingMode(s.flatBytes()) orelse
+        throwRangeError(realm, "invalid roundingMode");
+}
+
+/// §13.x GetRoundingIncrementOption — ToNumber, reject non-finite,
+/// truncate, then require an integer in [1, 1e9].
+fn getRoundingIncrementOption(realm: *Realm, opts: ?*JSObject) NativeError!i128 {
+    const obj = opts orelse return 1;
+    const v = try getPropertyChain(realm, obj, "roundingIncrement");
+    if (v.isUndefined()) return 1;
+    const d = numberToF64(try toNumber(realm, v));
+    if (!std.math.isFinite(d)) return throwRangeError(realm, "roundingIncrement must be finite");
+    const t = std.math.trunc(d);
+    if (t < 1 or t > 1_000_000_000) return throwRangeError(realm, "roundingIncrement is out of range");
+    return @intFromFloat(t);
+}
+
+/// §13.x GetTemporalUnitValuedOption — read a unit option (ToString),
+/// returning null for undefined / "auto". Rejects only an *unrecognised*
+/// unit name here; the operation-specific allowed-range check is a later
+/// algorithmic validation (see `requireUnitInRange`), so every option is
+/// read before any range error fires.
+fn getTemporalUnitOption(realm: *Realm, opts: ?*JSObject, key: []const u8) NativeError!?temporal.LargestUnit {
+    const obj = opts orelse return null;
+    const v = try getPropertyChain(realm, obj, key);
+    if (v.isUndefined()) return null;
+    const s = try stringifyArg(realm, v);
+    const bytes = s.flatBytes();
+    if (std.mem.eql(u8, bytes, "auto")) return null;
+    return temporal.parseTemporalUnit(bytes) orelse
+        throwRangeError(realm, "invalid unit value");
+}
+
+/// Reject a resolved unit outside the operation's allowed magnitude
+/// range [largest_allowed, smallest_allowed]. Run after all options are
+/// read, per GetDifferenceSettings' read-then-validate ordering.
+fn requireUnitInRange(realm: *Realm, unit: temporal.LargestUnit, largest_allowed: temporal.LargestUnit, smallest_allowed: temporal.LargestUnit) NativeError!void {
+    if (@intFromEnum(unit) < @intFromEnum(largest_allowed) or @intFromEnum(unit) > @intFromEnum(smallest_allowed)) {
+        return throwRangeError(realm, "unit is outside the allowed range");
+    }
+}
+
+/// §13.x NegateRoundingMode — lets `since` round in the reverse
+/// direction of `until`. Only the directed ceil/floor pair flips; the
+/// sign-symmetric modes are unchanged.
+fn negateRoundingMode(mode: temporal.RoundingMode) temporal.RoundingMode {
+    return switch (mode) {
+        .ceil => .floor,
+        .floor => .ceil,
+        .half_ceil => .half_floor,
+        .half_floor => .half_ceil,
+        else => mode,
+    };
+}
+
+/// §8.4.x Temporal.Instant.prototype.round ( roundTo ). A string
+/// `roundTo` is shorthand for `{ smallestUnit }`; smallestUnit is
+/// required (hour..nanosecond). roundingIncrement (default 1) must
+/// divide a 24-hour day evenly; roundingMode defaults to halfExpand.
 fn instantRound(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireInstant(realm, this_value);
-    return throwTypeError(realm, "Temporal.Instant.prototype.round is not yet implemented");
+    const ns = try requireInstant(realm, this_value);
+    const round_to = argOr(args, 0, Value.undefined_);
+    if (round_to.isUndefined()) {
+        return throwTypeError(realm, "Temporal.Instant.prototype.round requires a smallestUnit");
+    }
+
+    var unit: temporal.LargestUnit = undefined;
+    var increment: i128 = 1;
+    var mode: temporal.RoundingMode = .half_expand;
+    if (round_to.isString()) {
+        const s: *JSString = @ptrCast(@alignCast(round_to.asString()));
+        unit = temporal.parseTemporalUnit(s.flatBytes()) orelse
+            return throwRangeError(realm, "invalid smallestUnit");
+        if (@intFromEnum(unit) < @intFromEnum(temporal.LargestUnit.hour)) {
+            return throwRangeError(realm, "smallestUnit is outside the allowed range");
+        }
+    } else {
+        const opts = try getOptionsObject(realm, round_to);
+        increment = try getRoundingIncrementOption(realm, opts);
+        mode = try getRoundingModeOption(realm, opts, .half_expand);
+        unit = (try getTemporalUnitOption(realm, opts, "smallestUnit")) orelse
+            return throwRangeError(realm, "smallestUnit is required");
+        try requireUnitInRange(realm, unit, .hour, .nanosecond);
+    }
+
+    // increment × unit-span must divide a solar day evenly (inclusive).
+    const per_day = @divExact(@as(i128, 86_400_000_000_000), temporal.unitNanoseconds(unit));
+    if (!temporal.validateRoundingIncrement(increment, per_day, true)) {
+        return throwRangeError(realm, "roundingIncrement does not divide evenly into a day");
+    }
+
+    const rounded = temporal.roundToIncrementAsIfPositive(ns, increment * temporal.unitNanoseconds(unit), mode);
+    if (!temporal.isValidEpochNanoseconds(rounded)) {
+        return throwRangeError(realm, "rounded instant is out of range");
+    }
+    return createTemporalInstant(realm, rounded);
 }
+
 fn instantUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireInstant(realm, this_value);
-    return throwTypeError(realm, "Temporal.Instant.prototype.until is not yet implemented");
+    return differenceTemporalInstant(realm, this_value, args, false);
 }
+
 fn instantSince(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireInstant(realm, this_value);
-    return throwTypeError(realm, "Temporal.Instant.prototype.since is not yet implemented");
+    return differenceTemporalInstant(realm, this_value, args, true);
 }
+
+/// Dividend for a difference roundingIncrement: the count of `unit` in
+/// the next-larger unit (non-inclusive bound). Day and above are
+/// disallowed for Instant differences.
+fn differenceDividend(unit: temporal.LargestUnit) i128 {
+    return switch (unit) {
+        .hour => 24,
+        .minute, .second => 60,
+        .millisecond, .microsecond, .nanosecond => 1000,
+        else => unreachable,
+    };
+}
+
+/// §8.4.x DifferenceTemporalInstant — `until` (sign +) / `since` (sign
+/// −). Reads the difference settings (largestUnit, increment, mode,
+/// smallestUnit in that order), rounds the epoch-ns delta, and balances
+/// it into a time-only Duration. `since` negates the rounding mode and
+/// the result, so `a.since(b)` equals `a.until(b).negated()`.
+fn differenceTemporalInstant(realm: *Realm, this_value: Value, args: []const Value, is_since: bool) NativeError!Value {
+    const this_ns = try requireInstant(realm, this_value);
+    const other_ns = try toTemporalInstant(realm, argOr(args, 0, Value.undefined_));
+    const opts = try getOptionsObject(realm, argOr(args, 1, Value.undefined_));
+
+    // GetDifferenceSettings read order: largestUnit, increment, mode,
+    // smallestUnit. Allowed units: hour..nanosecond.
+    const largest_opt = try getTemporalUnitOption(realm, opts, "largestUnit");
+    const increment = try getRoundingIncrementOption(realm, opts);
+    const mode = try getRoundingModeOption(realm, opts, .trunc);
+    const smallest_opt = try getTemporalUnitOption(realm, opts, "smallestUnit");
+
+    // All options read; now validate. Units must be in range (hour..ns).
+    if (largest_opt) |lu| try requireUnitInRange(realm, lu, .hour, .nanosecond);
+    const smallest = smallest_opt orelse temporal.LargestUnit.nanosecond;
+    try requireUnitInRange(realm, smallest, .hour, .nanosecond);
+
+    // Default largestUnit is the larger of smallestUnit and "second".
+    const largest = largest_opt orelse (if (@intFromEnum(smallest) < @intFromEnum(temporal.LargestUnit.second))
+        smallest
+    else
+        temporal.LargestUnit.second);
+    if (@intFromEnum(largest) > @intFromEnum(smallest)) {
+        return throwRangeError(realm, "largestUnit must not be smaller than smallestUnit");
+    }
+    if (!temporal.validateRoundingIncrement(increment, differenceDividend(smallest), false)) {
+        return throwRangeError(realm, "invalid roundingIncrement for the smallestUnit");
+    }
+
+    const diff = other_ns - this_ns;
+    const eff_mode = if (is_since) negateRoundingMode(mode) else mode;
+    const rounded = temporal.roundToIncrement(diff, increment * temporal.unitNanoseconds(smallest), eff_mode);
+    var d = temporal.balanceTimeDuration(rounded, largest);
+    if (is_since) {
+        d.days = negZero(d.days);
+        d.hours = negZero(d.hours);
+        d.minutes = negZero(d.minutes);
+        d.seconds = negZero(d.seconds);
+        d.milliseconds = negZero(d.milliseconds);
+        d.microseconds = negZero(d.microseconds);
+        d.nanoseconds = negZero(d.nanoseconds);
+    }
+    return createTemporalDuration(realm, d);
+}
+
+/// Deferred — needs the time-zone machinery + Temporal.ZonedDateTime.
 fn instantToZonedDateTimeISO(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = args;
     _ = try requireInstant(realm, this_value);

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -1942,14 +1942,80 @@ fn plainDateSubtract(realm: *Realm, this_value: Value, args: []const Value) Nati
     return plainDateAddSubtract(realm, this_value, args, true);
 }
 fn plainDateUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainDate(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainDate.prototype.until is not yet implemented");
+    return differenceTemporalDate(realm, this_value, args, false);
 }
 fn plainDateSince(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainDate(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainDate.prototype.since is not yet implemented");
+    return differenceTemporalDate(realm, this_value, args, true);
+}
+
+/// §3.3.x DifferenceTemporalPlainDate — `until` (forward, this → other) /
+/// `since` (reverse). Reads GetDifferenceSettings for the date unit group
+/// (largestUnit, roundingIncrement, roundingMode, smallestUnit — in that
+/// read order, every option read before any range validation), computes
+/// the calendar difference via DifferenceISODate, and returns a date-only
+/// Duration. Per §13 GetDifferenceSettings the result is always computed
+/// in the this → other direction; `since` negates the rounding mode and
+/// then the result fields, so `a.since(b)` equals `a.until(b).negated()`.
+///
+/// Calendar-unit rounding — a smallestUnit of year/month/week, or a day
+/// increment that must bubble into a coarser largestUnit — needs
+/// RoundRelativeDuration / NudgeToCalendarUnit, which is not wired yet.
+/// Those option shapes throw a RangeError until that machinery lands; the
+/// default (smallestUnit "day", increment 1) and pure-day increments are
+/// handled here.
+fn differenceTemporalDate(realm: *Realm, this_value: Value, args: []const Value, is_since: bool) NativeError!Value {
+    const this_date = try requirePlainDate(realm, this_value);
+    const other_date = try toTemporalDate(realm, argOr(args, 0, Value.undefined_), Value.undefined_);
+    const opts = try getOptionsObject(realm, argOr(args, 1, Value.undefined_));
+
+    // GetDifferenceSettings read order: largestUnit, increment, mode,
+    // smallestUnit — read every option before any range validation.
+    const largest_opt = try getTemporalUnitOption(realm, opts, "largestUnit");
+    const increment = try getRoundingIncrementOption(realm, opts);
+    const mode = try getRoundingModeOption(realm, opts, .trunc);
+    const smallest_opt = try getTemporalUnitOption(realm, opts, "smallestUnit");
+
+    if (largest_opt) |lu| try requireUnitInRange(realm, lu, .year, .day);
+    const smallest = smallest_opt orelse temporal.LargestUnit.day;
+    try requireUnitInRange(realm, smallest, .year, .day);
+    // defaultLargestUnit = LargerOfTwoTemporalUnits("day", smallestUnit).
+    // Within the date group "day" is the finest unit, so the coarser of
+    // the two is always the smallestUnit itself.
+    const largest = largest_opt orelse smallest;
+    if (@intFromEnum(largest) > @intFromEnum(smallest)) {
+        return throwRangeError(realm, "largestUnit must not be smaller than smallestUnit");
+    }
+    // Date units have no MaximumTemporalDurationRoundingIncrement, so the
+    // increment is unconstrained beyond the [1, 1e9] range GetRounding-
+    // IncrementOption already enforced.
+
+    var diff = temporal.differenceISODate(this_date, other_date, largest);
+
+    // Rounding. The default (smallestUnit "day", increment 1) is a no-op
+    // on the whole-day difference. A day increment > 1 re-balances safely
+    // only when there is no coarser calendar unit to bubble into
+    // (largestUnit "day"); calendar smallestUnits (year/month/week) need
+    // RoundRelativeDuration — deferred.
+    if (smallest != .day) {
+        return throwRangeError(realm, "rounding to calendar units is not yet implemented");
+    }
+    if (increment != 1) {
+        if (largest != .day) {
+            return throwRangeError(realm, "day rounding with a calendar largestUnit is not yet implemented");
+        }
+        const eff_mode = if (is_since) negateRoundingMode(mode) else mode;
+        const days_i: i128 = @intFromFloat(diff.days);
+        const rounded = temporal.roundToIncrement(days_i, increment, eff_mode);
+        diff.days = @floatFromInt(rounded);
+    }
+
+    if (is_since) {
+        diff.years = negZero(diff.years);
+        diff.months = negZero(diff.months);
+        diff.weeks = negZero(diff.weeks);
+        diff.days = negZero(diff.days);
+    }
+    return createTemporalDuration(realm, diff);
 }
 fn plainDateWithCalendar(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = args;

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -32,6 +32,7 @@ const NativeFn = @import("../function.zig").NativeFn;
 const heap_mod = @import("../heap.zig");
 const intrinsics = @import("../intrinsics.zig");
 const temporal = @import("../temporal.zig");
+const bigint_builtin = @import("bigint.zig");
 
 const installConstructor = intrinsics.installConstructor;
 const installNativeMethod = intrinsics.installNativeMethod;
@@ -83,6 +84,7 @@ pub fn install(realm: *Realm) !void {
 
     try installDuration(realm, ns);
     try installPlainTime(realm, ns);
+    try installInstant(realm, ns);
 
     // `Temporal` is a non-enumerable, writable, configurable global
     // (§17 namespace-object convention, matching the property
@@ -902,4 +904,293 @@ fn plainTimeSince(realm: *Realm, this_value: Value, args: []const Value) NativeE
     _ = args;
     _ = try requirePlainTime(realm, this_value);
     return throwTypeError(realm, "Temporal.PlainTime.prototype.since is not yet implemented");
+}
+
+// ── §8 Temporal.Instant ────────────────────────────────────────────────────
+
+fn installInstant(realm: *Realm, ns: *JSObject) !void {
+    // §8.1.1 — `new`-only constructor, arity 1 (the epoch-nanoseconds
+    // BigInt).
+    const r = try installConstructor(realm, .{
+        .name = "Instant",
+        .ctor = instantConstructor,
+        .arity = 1,
+        .is_class = true,
+        .set_home_object = true,
+        .to_string_tag = "Temporal.Instant",
+        .install_global = false,
+    });
+    const fn_obj = r.ctor;
+    const proto = r.proto;
+
+    try installNativeGetter(realm, proto, "epochMilliseconds", instantEpochMilliseconds);
+    try installNativeGetter(realm, proto, "epochNanoseconds", instantEpochNanoseconds);
+
+    try installNativeMethodOnProto(realm, proto, "add", instantAdd, 1);
+    try installNativeMethodOnProto(realm, proto, "subtract", instantSubtract, 1);
+    try installNativeMethodOnProto(realm, proto, "equals", instantEquals, 1);
+    try installNativeMethodOnProto(realm, proto, "toString", instantToString, 0);
+    try installNativeMethodOnProto(realm, proto, "toJSON", instantToJSON, 0);
+    try installNativeMethodOnProto(realm, proto, "toLocaleString", instantToLocaleString, 0);
+    try installNativeMethodOnProto(realm, proto, "valueOf", instantValueOf, 0);
+    // Deferred deep-end methods — present with the right shape, but
+    // they throw until the rounding / time-zone machinery lands.
+    try installNativeMethodOnProto(realm, proto, "round", instantRound, 1);
+    try installNativeMethodOnProto(realm, proto, "until", instantUntil, 1);
+    try installNativeMethodOnProto(realm, proto, "since", instantSince, 1);
+    try installNativeMethodOnProto(realm, proto, "toZonedDateTimeISO", instantToZonedDateTimeISO, 1);
+
+    try installNativeMethod(realm, fn_obj, "from", instantFrom, 1);
+    try installNativeMethod(realm, fn_obj, "fromEpochMilliseconds", instantFromEpochMilliseconds, 1);
+    try installNativeMethod(realm, fn_obj, "fromEpochNanoseconds", instantFromEpochNanoseconds, 1);
+    try installNativeMethod(realm, fn_obj, "compare", instantCompare, 2);
+
+    realm.intrinsics.temporal_instant_constructor = fn_obj;
+    realm.intrinsics.temporal_instant_prototype = proto;
+
+    try setNonEnumerable(ns, realm.allocator, "Instant", heap_mod.taggedFunction(fn_obj));
+}
+
+/// §8.1.1 Temporal.Instant ( epochNanoseconds ). `new`-only. ToBigInt-
+/// coerces the argument (so a numeric string parses as a BigInt and a
+/// Number throws TypeError), then validates the epoch-ns range.
+fn instantConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const inst = heap_mod.valueAsPlainObject(this_value) orelse
+        return throwTypeError(realm, "Temporal.Instant constructor requires 'new'");
+    // §8.1.1 step 2 — ToBigInt(epochNanoseconds) (§7.1.13).
+    const bi_val = try bigint_builtin.toBigIntValue(realm, argOr(args, 0, Value.undefined_));
+    const epoch_ns = try epochNsFromBigInt(realm, bi_val);
+    try storeInstant(realm, inst, epoch_ns);
+    return heap_mod.taggedObject(inst);
+}
+
+/// Extract a validated epoch-ns `i128` from a BigInt `Value`, throwing
+/// RangeError when it is outside the representable instant range —
+/// including BigInts too large to fit `i128` (`2n ** 128n`).
+fn epochNsFromBigInt(realm: *Realm, bi_val: Value) NativeError!i128 {
+    const bi = heap_mod.valueAsBigInt(bi_val) orelse
+        return throwTypeError(realm, "expected a BigInt");
+    if (!bi.fitsI128()) return throwRangeError(realm, "epoch nanoseconds are out of range");
+    const ns = bi.toI128();
+    if (!temporal.isValidEpochNanoseconds(ns)) {
+        return throwRangeError(realm, "epoch nanoseconds are out of range");
+    }
+    return ns;
+}
+
+fn storeInstant(realm: *Realm, inst: *JSObject, epoch_ns: i128) NativeError!void {
+    const rec = realm.allocator.create(TemporalRecord) catch return error.OutOfMemory;
+    rec.* = .{ .instant = .{ .epoch_ns = epoch_ns } };
+    inst.setTemporalRecord(realm.allocator, rec) catch return error.OutOfMemory;
+}
+
+/// §8.1.x CreateTemporalInstant — allocate a fresh Instant with the
+/// realm prototype. Exposed (`pub`) so `Date.prototype.toTemporalInstant`
+/// can mint the bridged Instant.
+pub fn createTemporalInstant(realm: *Realm, epoch_ns: i128) NativeError!Value {
+    const inst = realm.heap.allocateObject() catch return error.OutOfMemory;
+    realm.heap.setObjectPrototype(inst, realm.intrinsics.temporal_instant_prototype.?);
+    try storeInstant(realm, inst, epoch_ns);
+    return heap_mod.taggedObject(inst);
+}
+
+/// §8.x RequireInternalSlot(instant, [[InitializedTemporalInstant]]).
+fn requireInstant(realm: *Realm, this_value: Value) NativeError!i128 {
+    const obj = heap_mod.valueAsPlainObject(this_value) orelse
+        return throwTypeError(realm, "not a Temporal.Instant");
+    const rec = obj.getTemporalRecord() orelse
+        return throwTypeError(realm, "not a Temporal.Instant");
+    return switch (rec.*) {
+        .instant => |i| i.epoch_ns,
+        else => throwTypeError(realm, "not a Temporal.Instant"),
+    };
+}
+
+/// §8.5.x ToTemporalInstant — a Temporal.Instant (copy), or any other
+/// value coerced via ToPrimitive(string) and parsed as an ISO instant
+/// string. A non-string primitive (Number, …) throws TypeError; a
+/// malformed string throws RangeError. (Temporal.ZonedDateTime would
+/// also resolve here once it ships.)
+fn toTemporalInstant(realm: *Realm, item: Value) NativeError!i128 {
+    var v = item;
+    // Any Object — plain OR callable (a function is still an Object per
+    // the spec) — coerces via ToPrimitive(string); a branded
+    // Temporal.Instant short-circuits to its epoch ns. A non-string,
+    // non-object primitive (Number, Symbol, …) falls through to the
+    // TypeError below.
+    if (heap_mod.valueAsPlainObject(v) != null or heap_mod.valueAsFunction(v) != null) {
+        if (heap_mod.valueAsPlainObject(v)) |obj| {
+            if (obj.getTemporalRecord()) |rec| {
+                switch (rec.*) {
+                    .instant => |i| return i.epoch_ns,
+                    else => {},
+                }
+            }
+        }
+        v = try intrinsics.toPrimitive(realm, v, .string);
+    }
+    if (!v.isString()) {
+        return throwTypeError(realm, "Temporal.Instant.from expects a Temporal.Instant or ISO 8601 string");
+    }
+    const s: *JSString = @ptrCast(@alignCast(v.asString()));
+    return temporal.parseInstantString(s.flatBytes()) catch
+        return throwRangeError(realm, "invalid ISO 8601 instant string");
+}
+
+/// §8.4.4 get Temporal.Instant.prototype.epochMilliseconds — floor of
+/// the epoch ns divided by 10^6, as a Number (always exact: |ms| ≤
+/// 8.64×10^15 < 2^53).
+fn instantEpochMilliseconds(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const ns = try requireInstant(realm, t);
+    const ms = @divFloor(ns, 1_000_000);
+    return Value.fromDouble(@floatFromInt(ms));
+}
+
+/// §8.4.5 get Temporal.Instant.prototype.epochNanoseconds — the slot
+/// value as a BigInt.
+fn instantEpochNanoseconds(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const ns = try requireInstant(realm, t);
+    const bi = realm.heap.allocateBigInt(ns) catch return error.OutOfMemory;
+    return heap_mod.taggedBigInt(bi);
+}
+
+/// §8.2.2 Temporal.Instant.from ( item ).
+fn instantFrom(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const ns = try toTemporalInstant(realm, argOr(args, 0, Value.undefined_));
+    return createTemporalInstant(realm, ns);
+}
+
+/// §8.2.3 Temporal.Instant.fromEpochMilliseconds ( epochMilliseconds ).
+fn instantFromEpochMilliseconds(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const num = try toNumber(realm, argOr(args, 0, Value.undefined_));
+    const d = numberToF64(num);
+    // §21.2.1.1.1 NumberToBigInt — RangeError on a non-finite or
+    // non-integral Number.
+    if (!std.math.isFinite(d) or @trunc(d) != d) {
+        return throwRangeError(realm, "epoch milliseconds must be an integer");
+    }
+    // |ms| ≤ 8.64×10^15 ⇔ |ns| ≤ 8.64×10^21; the bound also keeps the
+    // i128 conversion in range.
+    if (d < -8_640_000_000_000_000.0 or d > 8_640_000_000_000_000.0) {
+        return throwRangeError(realm, "epoch milliseconds are out of range");
+    }
+    const ns: i128 = @as(i128, @intFromFloat(d)) * 1_000_000;
+    return createTemporalInstant(realm, ns);
+}
+
+/// §8.2.4 Temporal.Instant.fromEpochNanoseconds ( epochNanoseconds ).
+fn instantFromEpochNanoseconds(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const bi_val = try bigint_builtin.toBigIntValue(realm, argOr(args, 0, Value.undefined_));
+    const ns = try epochNsFromBigInt(realm, bi_val);
+    return createTemporalInstant(realm, ns);
+}
+
+/// §8.2.5 Temporal.Instant.compare ( one, two ).
+fn instantCompare(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const a = try toTemporalInstant(realm, argOr(args, 0, Value.undefined_));
+    const b = try toTemporalInstant(realm, argOr(args, 1, Value.undefined_));
+    return Value.fromInt32(temporal.compareInstant(a, b));
+}
+
+/// §8.4.9 Temporal.Instant.prototype.equals ( other ).
+fn instantEquals(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const a = try requireInstant(realm, this_value);
+    const b = try toTemporalInstant(realm, argOr(args, 0, Value.undefined_));
+    return Value.fromBool(a == b);
+}
+
+fn instantAdd(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return instantAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), 1);
+}
+
+fn instantSubtract(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return instantAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), -1);
+}
+
+/// §8.4.6 / §8.4.7 AddDurationToInstant — fold a time-only Duration
+/// into the epoch nanoseconds. `sign` is +1 for `add`, -1 for
+/// `subtract`. §8 disallows calendar units (years / months / weeks /
+/// days): a non-zero one throws RangeError.
+fn instantAddSubtract(realm: *Realm, this_value: Value, duration_like: Value, sign: i128) NativeError!Value {
+    const epoch_ns = try requireInstant(realm, this_value);
+    const d = try toTemporalDuration(realm, duration_like);
+    // ToTemporalDuration's property-bag path does not itself run
+    // IsValidDuration, so a mixed-sign / out-of-range duration-like
+    // reaches here unvalidated — reject it (RangeError).
+    if (!temporal.isValidDuration(d)) {
+        return throwRangeError(realm, "Duration values are out of range");
+    }
+    if (d.years != 0 or d.months != 0 or d.weeks != 0 or d.days != 0) {
+        return throwRangeError(realm, "Temporal.Instant arithmetic does not allow calendar units (years/months/weeks/days)");
+    }
+    const delta = temporal.timeDurationNanoseconds(d) * sign;
+    const result = temporal.addInstant(epoch_ns, delta) orelse
+        return throwRangeError(realm, "Temporal.Instant arithmetic result is out of range");
+    return createTemporalInstant(realm, result);
+}
+
+/// §8.4.10 Temporal.Instant.prototype.toString — default / `auto`
+/// precision (UTC, trailing `Z`). Options-driven rounding / time-zone
+/// rendering is deferred; an options argument is rejected.
+fn instantToString(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const ns = try requireInstant(realm, this_value);
+    const opts = argOr(args, 0, Value.undefined_);
+    if (!opts.isUndefined()) {
+        return throwTypeError(realm, "Temporal.Instant.prototype.toString options are not yet supported");
+    }
+    var buf: [48]u8 = undefined;
+    const s = temporal.instantToString(ns, &buf);
+    const js = realm.heap.allocateString(s) catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+
+/// §8.4.11 Temporal.Instant.prototype.toJSON — always `auto`, UTC.
+fn instantToJSON(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    const ns = try requireInstant(realm, this_value);
+    var buf: [48]u8 = undefined;
+    const s = temporal.instantToString(ns, &buf);
+    const js = realm.heap.allocateString(s) catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+
+fn instantToLocaleString(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return instantToJSON(realm, this_value, args);
+}
+
+/// §8.4.12 Temporal.Instant.prototype.valueOf — always throws
+/// (Temporal values are not relationally comparable via the operators).
+fn instantValueOf(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    _ = args;
+    return throwTypeError(realm, "Called valueOf on a Temporal.Instant; use compare() instead");
+}
+
+// Deferred Instant deep-end — present for shape, throw until the
+// rounding / time-zone machinery lands.
+fn instantRound(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requireInstant(realm, this_value);
+    return throwTypeError(realm, "Temporal.Instant.prototype.round is not yet implemented");
+}
+fn instantUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requireInstant(realm, this_value);
+    return throwTypeError(realm, "Temporal.Instant.prototype.until is not yet implemented");
+}
+fn instantSince(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requireInstant(realm, this_value);
+    return throwTypeError(realm, "Temporal.Instant.prototype.since is not yet implemented");
+}
+fn instantToZonedDateTimeISO(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requireInstant(realm, this_value);
+    return throwTypeError(realm, "Temporal.Instant.prototype.toZonedDateTimeISO is not yet implemented");
 }

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -452,37 +452,108 @@ fn durationFrom(realm: *Realm, this_value: Value, args: []const Value) NativeErr
     return createTemporalDuration(realm, d);
 }
 
-/// §7.2.3 Temporal.Duration.compare — without a relativeTo, only
-/// durations whose largest unit is days-or-smaller can be compared
-/// (calendar units need a reference point). Deferred: the full
-/// TimeDuration normalisation. Throws for now.
-fn durationCompare(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = this_value;
-    _ = args;
-    return throwTypeError(realm, "Temporal.Duration.compare is not yet implemented");
+/// Whether an options bag carries a present `relativeTo` — the
+/// calendar / zoned-anchored path, which Cynic defers.
+fn relativeToPresent(realm: *Realm, opts: ?*JSObject) NativeError!bool {
+    const obj = opts orelse return false;
+    const v = try getPropertyChain(realm, obj, "relativeTo");
+    return !v.isUndefined();
 }
 
-// Deferred arithmetic — present for shape, throw until the
-// TimeDuration machinery lands.
+/// The larger-magnitude of two largest units (smaller enum index wins).
+fn largerLargestUnit(a: temporal.LargestUnit, b: temporal.LargestUnit) temporal.LargestUnit {
+    return if (@intFromEnum(a) < @intFromEnum(b)) a else b;
+}
+
+/// §7.3.x Temporal.Duration.compare ( one, two [, options] ). Without a
+/// relativeTo, calendar units (years/months/weeks) can't be ordered and
+/// throw; day-and-smaller durations compare by total nanoseconds (each
+/// day a fixed 24 h). The relativeTo path is deferred.
+fn durationCompare(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const one = try toTemporalDuration(realm, argOr(args, 0, Value.undefined_));
+    if (!temporal.isValidDuration(one)) return throwRangeError(realm, "Duration values are out of range");
+    const two = try toTemporalDuration(realm, argOr(args, 1, Value.undefined_));
+    if (!temporal.isValidDuration(two)) return throwRangeError(realm, "Duration values are out of range");
+    const opts = try getOptionsObject(realm, argOr(args, 2, Value.undefined_));
+    if (try relativeToPresent(realm, opts)) {
+        return throwTypeError(realm, "Temporal.Duration.compare with relativeTo is not yet implemented");
+    }
+    if (temporal.hasCalendarUnits(one) or temporal.hasCalendarUnits(two)) {
+        return throwRangeError(realm, "a relativeTo is required to compare durations with calendar units");
+    }
+    const ns_one = temporal.dayTimeDurationNanoseconds(one);
+    const ns_two = temporal.dayTimeDurationNanoseconds(two);
+    const cmp: i32 = if (ns_one < ns_two) -1 else if (ns_one > ns_two) 1 else 0;
+    return Value.fromInt32(cmp);
+}
+
+/// §7.3.x AddDurations — `add` (sign +1) / `subtract` (−1). These take
+/// no relativeTo, so calendar units (years/months/weeks) are
+/// unorderable and throw; day-and-smaller durations combine by total
+/// nanoseconds and re-balance to the larger of the two largest units.
+fn durationAddSubtract(realm: *Realm, this_value: Value, other_v: Value, sign: i128) NativeError!Value {
+    const a = try requireDuration(realm, this_value);
+    const b = try toTemporalDuration(realm, other_v);
+    if (!temporal.isValidDuration(b)) return throwRangeError(realm, "Duration values are out of range");
+    if (temporal.hasCalendarUnits(a) or temporal.hasCalendarUnits(b)) {
+        return throwRangeError(realm, "a relativeTo is required to add durations with calendar units");
+    }
+    const total = temporal.dayTimeDurationNanoseconds(a) + temporal.dayTimeDurationNanoseconds(b) * sign;
+    const largest = largerLargestUnit(temporal.defaultTemporalLargestUnit(a), temporal.defaultTemporalLargestUnit(b));
+    return createTemporalDuration(realm, temporal.balanceTimeDuration(total, largest));
+}
+
 fn durationAdd(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireDuration(realm, this_value);
-    return throwTypeError(realm, "Temporal.Duration.prototype.add is not yet implemented");
+    return durationAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), 1);
 }
+
 fn durationSubtract(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireDuration(realm, this_value);
-    return throwTypeError(realm, "Temporal.Duration.prototype.subtract is not yet implemented");
+    return durationAddSubtract(realm, this_value, argOr(args, 0, Value.undefined_), -1);
 }
+
+/// Deferred — rounding/balancing calendar units against a relativeTo
+/// reference still needs the calendar path.
 fn durationRound(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = args;
     _ = try requireDuration(realm, this_value);
     return throwTypeError(realm, "Temporal.Duration.prototype.round is not yet implemented");
 }
+
+/// §7.3.x Temporal.Duration.prototype.total ( totalOf ). A string
+/// selects the unit; an options bag may also carry relativeTo
+/// (deferred). For a day-or-smaller unit and a calendar-unit-free
+/// duration, returns the ratio as a Number.
 fn durationTotal(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requireDuration(realm, this_value);
-    return throwTypeError(realm, "Temporal.Duration.prototype.total is not yet implemented");
+    const d = try requireDuration(realm, this_value);
+    const total_of = argOr(args, 0, Value.undefined_);
+    if (total_of.isUndefined()) {
+        return throwTypeError(realm, "Temporal.Duration.prototype.total requires a unit");
+    }
+    var unit_opt: ?temporal.LargestUnit = null;
+    if (total_of.isString()) {
+        const s: *JSString = @ptrCast(@alignCast(total_of.asString()));
+        unit_opt = temporal.parseTemporalUnit(s.flatBytes());
+    } else {
+        const opts = try getOptionsObject(realm, total_of);
+        if (try relativeToPresent(realm, opts)) {
+            return throwTypeError(realm, "Temporal.Duration.prototype.total with relativeTo is not yet implemented");
+        }
+        unit_opt = try getTemporalUnitOption(realm, opts, "unit");
+    }
+    const unit = unit_opt orelse return throwRangeError(realm, "a unit is required");
+    if (@intFromEnum(unit) < @intFromEnum(temporal.LargestUnit.day)) {
+        return throwTypeError(realm, "totalling a calendar unit requires relativeTo (not yet implemented)");
+    }
+    if (temporal.hasCalendarUnits(d)) {
+        return throwRangeError(realm, "a relativeTo is required to total a duration with calendar units");
+    }
+    const total_ns = temporal.dayTimeDurationNanoseconds(d);
+    const unit_ns = temporal.unitNanoseconds(unit);
+    const q = @divTrunc(total_ns, unit_ns);
+    const r = @rem(total_ns, unit_ns);
+    const result: f64 = @as(f64, @floatFromInt(q)) + @as(f64, @floatFromInt(r)) / @as(f64, @floatFromInt(unit_ns));
+    return Value.fromDouble(result);
 }
 
 // ── §4 Temporal.PlainTime ────────────────────────────────────────────────

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -1991,22 +1991,27 @@ fn differenceTemporalDate(realm: *Realm, this_value: Value, args: []const Value,
 
     var diff = temporal.differenceISODate(this_date, other_date, largest);
 
-    // Rounding. The default (smallestUnit "day", increment 1) is a no-op
-    // on the whole-day difference. A day increment > 1 re-balances safely
-    // only when there is no coarser calendar unit to bubble into
-    // (largestUnit "day"); calendar smallestUnits (year/month/week) need
-    // RoundRelativeDuration — deferred.
-    if (smallest != .day) {
-        return throwRangeError(realm, "rounding to calendar units is not yet implemented");
-    }
-    if (increment != 1) {
-        if (largest != .day) {
-            return throwRangeError(realm, "day rounding with a calendar largestUnit is not yet implemented");
+    // §7.5.31 RoundRelativeDuration. For `since` the mode is negated before
+    // rounding and the result negated after (§ NegateRoundingMode +
+    // CreateNegatedDateDuration), so rounding `this → other` then flipping
+    // matches rounding `other → this` directly.
+    const eff_mode = if (is_since) negateRoundingMode(mode) else mode;
+    if (smallest == .day) {
+        // A "day" smallestUnit has fixed length, so it rounds by pure
+        // day-count arithmetic (NudgeToDayOrTime) — no date is constructed, so
+        // a large increment (e.g. 1e9) stays representable. increment 1 is a
+        // no-op on the already whole-day difference.
+        if (increment != 1) {
+            const days_i: i128 = @intFromFloat(diff.days);
+            diff.days = @floatFromInt(temporal.roundToIncrement(days_i, increment, eff_mode));
         }
-        const eff_mode = if (is_since) negateRoundingMode(mode) else mode;
-        const days_i: i128 = @intFromFloat(diff.days);
-        const rounded = temporal.roundToIncrement(days_i, increment, eff_mode);
-        diff.days = @floatFromInt(rounded);
+    } else {
+        // Calendar smallestUnits (year/month/week) round through NudgeToCalen-
+        // darUnit, which re-expresses the span capped at largestUnit (folding
+        // in BubbleRelativeDuration's unit promotion). A candidate end date
+        // out of range yields RangeError, matching AddDate overflow.
+        diff = temporal.roundRelativeDate(this_date, other_date, diff, smallest, increment, eff_mode, largest) orelse
+            return throwRangeError(realm, "rounded date is outside the representable range");
     }
 
     if (is_since) {

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -1912,15 +1912,34 @@ fn plainDateValueOf(realm: *Realm, this_value: Value, args: []const Value) Nativ
 
 // Deferred PlainDate methods — date arithmetic and conversions to types
 // Cynic doesn't ship yet.
+/// §3.3.x AddDurationToDate — shared by add (negate=false) and subtract
+/// (negate=true). The duration's time components truncate toward zero
+/// into whole days (a PlainDate has no time), then AddISODate folds in
+/// years/months/weeks/days under the overflow option.
+fn plainDateAddSubtract(realm: *Realm, this_value: Value, args: []const Value, negate: bool) NativeError!Value {
+    const base = try requirePlainDate(realm, this_value);
+    var dur = try toTemporalDuration(realm, argOr(args, 0, Value.undefined_));
+    if (!temporal.isValidDuration(dur)) return throwRangeError(realm, "Duration values are out of range");
+    const overflow = try getTemporalOverflowOption(realm, argOr(args, 1, Value.undefined_));
+    if (negate) dur = temporal.negateDuration(dur);
+    // §7.5.x ToDateDurationRecordWithoutTime — time units collapse to
+    // whole days (truncated toward zero); 86_400_000_000_000 ns = 1 day.
+    const time_days: i64 = @intCast(@divTrunc(temporal.timeDurationNanoseconds(dur), 86_400_000_000_000));
+    const rec = temporal.addISODate(
+        base,
+        @intFromFloat(dur.years),
+        @intFromFloat(dur.months),
+        @intFromFloat(dur.weeks),
+        @as(i64, @intFromFloat(dur.days)) + time_days,
+        overflow == .reject,
+    ) orelse return throwRangeError(realm, "PlainDate is out of range");
+    return createTemporalDate(realm, rec);
+}
 fn plainDateAdd(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainDate(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainDate.prototype.add is not yet implemented");
+    return plainDateAddSubtract(realm, this_value, args, false);
 }
 fn plainDateSubtract(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    _ = args;
-    _ = try requirePlainDate(realm, this_value);
-    return throwTypeError(realm, "Temporal.PlainDate.prototype.subtract is not yet implemented");
+    return plainDateAddSubtract(realm, this_value, args, true);
 }
 fn plainDateUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = args;

--- a/src/runtime/builtins/temporal.zig
+++ b/src/runtime/builtins/temporal.zig
@@ -49,6 +49,7 @@ const stringifyArg = intrinsics.stringifyArg;
 
 const DurationRecord = temporal.DurationRecord;
 const PlainTimeRecord = temporal.PlainTimeRecord;
+const PlainDateRecord = temporal.PlainDateRecord;
 const TemporalRecord = temporal.TemporalRecord;
 
 /// Extract the f64 mathematical value from a Number `Value` (the
@@ -85,6 +86,7 @@ pub fn install(realm: *Realm) !void {
     try installDuration(realm, ns);
     try installPlainTime(realm, ns);
     try installInstant(realm, ns);
+    try installPlainDate(realm, ns);
 
     // `Temporal` is a non-enumerable, writable, configurable global
     // (§17 namespace-object convention, matching the property
@@ -1510,4 +1512,448 @@ fn instantToZonedDateTimeISO(realm: *Realm, this_value: Value, args: []const Val
     _ = args;
     _ = try requireInstant(realm, this_value);
     return throwTypeError(realm, "Temporal.Instant.prototype.toZonedDateTimeISO is not yet implemented");
+}
+
+// ── §3 Temporal.PlainDate (ISO calendar) ───────────────────────────────────
+
+fn installPlainDate(realm: *Realm, ns: *JSObject) !void {
+    // §3.1.1 — `new`-only constructor (year, month, day, [calendar]).
+    const r = try installConstructor(realm, .{
+        .name = "PlainDate",
+        .ctor = plainDateConstructor,
+        .arity = 3,
+        .is_class = true,
+        .set_home_object = true,
+        .to_string_tag = "Temporal.PlainDate",
+        .install_global = false,
+    });
+    const fn_obj = r.ctor;
+    const proto = r.proto;
+
+    try installNativeGetter(realm, proto, "calendarId", plainDateCalendarId);
+    try installNativeGetter(realm, proto, "year", plainDateYear);
+    try installNativeGetter(realm, proto, "month", plainDateMonth);
+    try installNativeGetter(realm, proto, "monthCode", plainDateMonthCode);
+    try installNativeGetter(realm, proto, "day", plainDateDay);
+    try installNativeGetter(realm, proto, "dayOfWeek", plainDateDayOfWeek);
+    try installNativeGetter(realm, proto, "dayOfYear", plainDateDayOfYear);
+    try installNativeGetter(realm, proto, "weekOfYear", plainDateWeekOfYear);
+    try installNativeGetter(realm, proto, "yearOfWeek", plainDateYearOfWeek);
+    try installNativeGetter(realm, proto, "daysInWeek", plainDateDaysInWeek);
+    try installNativeGetter(realm, proto, "daysInMonth", plainDateDaysInMonth);
+    try installNativeGetter(realm, proto, "daysInYear", plainDateDaysInYear);
+    try installNativeGetter(realm, proto, "monthsInYear", plainDateMonthsInYear);
+    try installNativeGetter(realm, proto, "inLeapYear", plainDateInLeapYear);
+    try installNativeGetter(realm, proto, "era", plainDateEra);
+    try installNativeGetter(realm, proto, "eraYear", plainDateEraYear);
+
+    try installNativeMethodOnProto(realm, proto, "with", plainDateWith, 1);
+    try installNativeMethodOnProto(realm, proto, "equals", plainDateEquals, 1);
+    try installNativeMethodOnProto(realm, proto, "toString", plainDateToString, 0);
+    try installNativeMethodOnProto(realm, proto, "toJSON", plainDateToJSON, 0);
+    try installNativeMethodOnProto(realm, proto, "toLocaleString", plainDateToLocaleString, 0);
+    try installNativeMethodOnProto(realm, proto, "valueOf", plainDateValueOf, 0);
+    // Deferred — date arithmetic / conversions to types Cynic doesn't ship yet.
+    try installNativeMethodOnProto(realm, proto, "add", plainDateAdd, 1);
+    try installNativeMethodOnProto(realm, proto, "subtract", plainDateSubtract, 1);
+    try installNativeMethodOnProto(realm, proto, "until", plainDateUntil, 1);
+    try installNativeMethodOnProto(realm, proto, "since", plainDateSince, 1);
+    try installNativeMethodOnProto(realm, proto, "withCalendar", plainDateWithCalendar, 1);
+    try installNativeMethodOnProto(realm, proto, "toPlainYearMonth", plainDateToPlainYearMonth, 0);
+    try installNativeMethodOnProto(realm, proto, "toPlainMonthDay", plainDateToPlainMonthDay, 0);
+    try installNativeMethodOnProto(realm, proto, "toPlainDateTime", plainDateToPlainDateTime, 1);
+    try installNativeMethodOnProto(realm, proto, "toZonedDateTime", plainDateToZonedDateTime, 1);
+
+    try installNativeMethod(realm, fn_obj, "from", plainDateFrom, 1);
+    try installNativeMethod(realm, fn_obj, "compare", plainDateCompare, 2);
+
+    realm.intrinsics.temporal_plain_date_constructor = fn_obj;
+    realm.intrinsics.temporal_plain_date_prototype = proto;
+    try setNonEnumerable(ns, realm.allocator, "PlainDate", heap_mod.taggedFunction(fn_obj));
+}
+
+/// Coerce a truncated date field to i64, rejecting values far outside
+/// the representable range (which also guards the later i32 cast).
+fn dateFieldToI64(realm: *Realm, v: f64) NativeError!i64 {
+    if (v < -1_000_000_000.0 or v > 1_000_000_000.0) return throwRangeError(realm, "date field is out of range");
+    return @intFromFloat(v);
+}
+
+/// §3.1.1 — the `calendar` argument must be undefined or a string that
+/// canonicalises to "iso8601" (Cynic ships only the ISO calendar). A
+/// non-string is a TypeError; an unsupported/unknown calendar string is
+/// a RangeError.
+fn requireISOCalendar(realm: *Realm, calendar: Value) NativeError!void {
+    if (calendar.isUndefined()) return;
+    if (!calendar.isString()) return throwTypeError(realm, "calendar must be a string");
+    const s: *JSString = @ptrCast(@alignCast(calendar.asString()));
+    if (!std.ascii.eqlIgnoreCase(s.flatBytes(), "iso8601")) {
+        return throwRangeError(realm, "only the iso8601 calendar is supported");
+    }
+}
+
+/// The `calendar` field of a Temporal-date-like property bag must be
+/// undefined or a String; a non-string (number, bigint, boolean, Symbol,
+/// null, or a non-calendar-bearing object) is a TypeError. Full
+/// canonicalisation of a calendar *string* — which may be a bare ID or an
+/// ISO string whose `[u-ca=…]` annotation names the calendar — is deferred
+/// with the rest of calendar support, so any accepted string resolves to
+/// the ISO calendar Cynic ships. (Distinct from the constructor's
+/// `requireISOCalendar`, which canonicalises a calendar ID strictly.)
+fn requireCalendarFieldType(realm: *Realm, calendar: Value) NativeError!void {
+    if (calendar.isUndefined()) return;
+    if (!calendar.isString()) return throwTypeError(realm, "calendar must be a string");
+}
+
+fn storePlainDate(realm: *Realm, inst: *JSObject, rec: PlainDateRecord) NativeError!void {
+    const r = realm.allocator.create(TemporalRecord) catch return error.OutOfMemory;
+    r.* = .{ .plain_date = rec };
+    inst.setTemporalRecord(realm.allocator, r) catch return error.OutOfMemory;
+}
+
+fn createTemporalDate(realm: *Realm, rec: PlainDateRecord) NativeError!Value {
+    const inst = realm.heap.allocateObject() catch return error.OutOfMemory;
+    realm.heap.setObjectPrototype(inst, realm.intrinsics.temporal_plain_date_prototype.?);
+    try storePlainDate(realm, inst, rec);
+    return heap_mod.taggedObject(inst);
+}
+
+fn requirePlainDate(realm: *Realm, this_value: Value) NativeError!PlainDateRecord {
+    const obj = heap_mod.valueAsPlainObject(this_value) orelse
+        return throwTypeError(realm, "not a Temporal.PlainDate");
+    const rec = obj.getTemporalRecord() orelse
+        return throwTypeError(realm, "not a Temporal.PlainDate");
+    return switch (rec.*) {
+        .plain_date => |pd| pd,
+        else => throwTypeError(realm, "not a Temporal.PlainDate"),
+    };
+}
+
+/// §3.1.1 Temporal.PlainDate ( isoYear, isoMonth, isoDay [, calendar] ).
+fn plainDateConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const inst = heap_mod.valueAsPlainObject(this_value) orelse
+        return throwTypeError(realm, "Temporal.PlainDate constructor requires 'new'");
+    const y = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, argOr(args, 0, Value.undefined_)));
+    const m = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, argOr(args, 1, Value.undefined_)));
+    const d = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, argOr(args, 2, Value.undefined_)));
+    try requireISOCalendar(realm, argOr(args, 3, Value.undefined_));
+    const rec = temporal.regulateISODate(y, m, d, true) orelse
+        return throwRangeError(realm, "PlainDate is out of range");
+    try storePlainDate(realm, inst, rec);
+    return heap_mod.taggedObject(inst);
+}
+
+fn plainDateCalendarId(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    _ = try requirePlainDate(realm, t);
+    const js = realm.heap.allocateString("iso8601") catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+fn plainDateYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    return Value.fromInt32((try requirePlainDate(realm, t)).iso_year);
+}
+fn plainDateMonth(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    return Value.fromInt32(@intCast((try requirePlainDate(realm, t)).iso_month));
+}
+fn plainDateDay(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    return Value.fromInt32(@intCast((try requirePlainDate(realm, t)).iso_day));
+}
+fn plainDateMonthCode(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    const mc = [_]u8{ 'M', '0' + @as(u8, @intCast(rec.iso_month / 10)), '0' + @as(u8, @intCast(rec.iso_month % 10)) };
+    const js = realm.heap.allocateString(&mc) catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+fn plainDateDayOfWeek(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(temporal.isoDayOfWeek(rec.iso_year, rec.iso_month, rec.iso_day));
+}
+fn plainDateDayOfYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(temporal.isoDayOfYear(rec.iso_year, rec.iso_month, rec.iso_day));
+}
+fn plainDateWeekOfYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(temporal.isoWeekOfYear(rec.iso_year, rec.iso_month, rec.iso_day).week);
+}
+fn plainDateYearOfWeek(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(temporal.isoWeekOfYear(rec.iso_year, rec.iso_month, rec.iso_day).year);
+}
+fn plainDateDaysInWeek(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    _ = try requirePlainDate(realm, t);
+    return Value.fromInt32(7);
+}
+fn plainDateDaysInMonth(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(@intCast(temporal.daysInIsoMonth(rec.iso_year, rec.iso_month)));
+}
+fn plainDateDaysInYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromInt32(temporal.isoDaysInYear(rec.iso_year));
+}
+fn plainDateMonthsInYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    _ = try requirePlainDate(realm, t);
+    return Value.fromInt32(12);
+}
+fn plainDateInLeapYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    const rec = try requirePlainDate(realm, t);
+    return Value.fromBool(temporal.isLeapYear(rec.iso_year));
+}
+fn plainDateEra(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    _ = try requirePlainDate(realm, t);
+    return Value.undefined_; // ISO calendar has no era
+}
+fn plainDateEraYear(realm: *Realm, t: Value, a: []const Value) NativeError!Value {
+    _ = a;
+    _ = try requirePlainDate(realm, t);
+    return Value.undefined_;
+}
+
+/// §3.5.x parse an ISO monthCode ("M01".."M12"; no leap month in ISO).
+/// The `monthCode` field must be a primitive String — a number, bigint,
+/// boolean, Symbol, null, or object is a TypeError (it is never coerced),
+/// distinct from the RangeError for a malformed string.
+fn parseMonthCode(realm: *Realm, v: Value) NativeError!i64 {
+    if (!v.isString()) return throwTypeError(realm, "monthCode must be a string");
+    const s: *JSString = @ptrCast(@alignCast(v.asString()));
+    const b = s.flatBytes();
+    if (b.len != 3 or b[0] != 'M' or b[1] < '0' or b[1] > '9' or b[2] < '0' or b[2] > '9') {
+        return throwRangeError(realm, "invalid monthCode");
+    }
+    const m: i64 = @as(i64, b[1] - '0') * 10 + @as(i64, b[2] - '0');
+    if (m < 1 or m > 12) return throwRangeError(realm, "invalid monthCode");
+    return m;
+}
+
+/// §3.5.x ISODateFromFields — read year, month/monthCode, day off a
+/// property bag and regulate per `options`.
+fn toISODateFields(realm: *Realm, obj: *JSObject, options: Value) NativeError!PlainDateRecord {
+    // The calendar field (if present) must be undefined or a String;
+    // the string's canonicalisation is deferred with calendar support.
+    try requireCalendarFieldType(realm, try getPropertyChain(realm, obj, "calendar"));
+    const day_v = try getPropertyChain(realm, obj, "day");
+    const month_v = try getPropertyChain(realm, obj, "month");
+    const month_code_v = try getPropertyChain(realm, obj, "monthCode");
+    const year_v = try getPropertyChain(realm, obj, "year");
+    if (year_v.isUndefined()) return throwTypeError(realm, "PlainDate-like is missing 'year'");
+    if (day_v.isUndefined()) return throwTypeError(realm, "PlainDate-like is missing 'day'");
+    const year = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, year_v));
+    const day = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, day_v));
+    var month: i64 = undefined;
+    if (!month_code_v.isUndefined()) {
+        month = try parseMonthCode(realm, month_code_v);
+        if (!month_v.isUndefined()) {
+            const m2 = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, month_v));
+            if (m2 != month) return throwRangeError(realm, "month and monthCode disagree");
+        }
+    } else if (!month_v.isUndefined()) {
+        month = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, month_v));
+    } else {
+        return throwTypeError(realm, "PlainDate-like is missing 'month' / 'monthCode'");
+    }
+    const overflow = try getTemporalOverflowOption(realm, options);
+    return temporal.regulateISODate(year, month, day, overflow == .reject) orelse
+        throwRangeError(realm, "PlainDate is out of range");
+}
+
+/// §3.5.x ToTemporalDate — a PlainDate (copy), a property bag, or an
+/// ISO date string.
+fn toTemporalDate(realm: *Realm, item: Value, options: Value) NativeError!PlainDateRecord {
+    if (heap_mod.valueAsPlainObject(item)) |obj| {
+        if (obj.getTemporalRecord()) |rec| {
+            switch (rec.*) {
+                .plain_date => |pd| {
+                    _ = try getTemporalOverflowOption(realm, options);
+                    return pd;
+                },
+                else => {},
+            }
+        }
+        return toISODateFields(realm, obj, options);
+    }
+    if (!item.isString()) {
+        return throwTypeError(realm, "Temporal.PlainDate.from expects an object or ISO 8601 string");
+    }
+    const s: *JSString = @ptrCast(@alignCast(item.asString()));
+    const rec = temporal.parseTemporalDateString(s.flatBytes()) catch
+        return throwRangeError(realm, "invalid ISO 8601 date string");
+    _ = try getTemporalOverflowOption(realm, options);
+    return rec;
+}
+
+fn compareISODate(a: PlainDateRecord, b: PlainDateRecord) i32 {
+    if (a.iso_year != b.iso_year) return if (a.iso_year < b.iso_year) -1 else 1;
+    if (a.iso_month != b.iso_month) return if (a.iso_month < b.iso_month) -1 else 1;
+    if (a.iso_day != b.iso_day) return if (a.iso_day < b.iso_day) -1 else 1;
+    return 0;
+}
+
+/// §3.2.2 Temporal.PlainDate.from ( item [, options] ).
+fn plainDateFrom(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const rec = try toTemporalDate(realm, argOr(args, 0, Value.undefined_), argOr(args, 1, Value.undefined_));
+    return createTemporalDate(realm, rec);
+}
+
+/// §3.2.3 Temporal.PlainDate.compare ( one, two ).
+fn plainDateCompare(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    const a = try toTemporalDate(realm, argOr(args, 0, Value.undefined_), Value.undefined_);
+    const b = try toTemporalDate(realm, argOr(args, 1, Value.undefined_), Value.undefined_);
+    return Value.fromInt32(compareISODate(a, b));
+}
+
+/// §3.3.x Temporal.PlainDate.prototype.equals ( other ).
+fn plainDateEquals(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const a = try requirePlainDate(realm, this_value);
+    const b = try toTemporalDate(realm, argOr(args, 0, Value.undefined_), Value.undefined_);
+    return Value.fromBool(compareISODate(a, b) == 0);
+}
+
+/// §3.3.x Temporal.PlainDate.prototype.with ( temporalDateLike [, options] ).
+fn plainDateWith(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const base = try requirePlainDate(realm, this_value);
+    const like = argOr(args, 0, Value.undefined_);
+    const obj = heap_mod.valueAsPlainObject(like) orelse
+        return throwTypeError(realm, "PlainDate-like must be an object");
+    try rejectTemporalLikeObject(realm, obj);
+
+    var year: i64 = base.iso_year;
+    var month: i64 = base.iso_month;
+    var day: i64 = base.iso_day;
+    var any = false;
+
+    const day_v = try getPropertyChain(realm, obj, "day");
+    if (!day_v.isUndefined()) {
+        day = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, day_v));
+        any = true;
+    }
+    const month_v = try getPropertyChain(realm, obj, "month");
+    const month_code_v = try getPropertyChain(realm, obj, "monthCode");
+    if (!month_code_v.isUndefined()) {
+        month = try parseMonthCode(realm, month_code_v);
+        any = true;
+        if (!month_v.isUndefined()) {
+            const m2 = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, month_v));
+            if (m2 != month) return throwRangeError(realm, "month and monthCode disagree");
+        }
+    } else if (!month_v.isUndefined()) {
+        month = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, month_v));
+        any = true;
+    }
+    const year_v = try getPropertyChain(realm, obj, "year");
+    if (!year_v.isUndefined()) {
+        year = try dateFieldToI64(realm, try toIntegerWithTruncation(realm, year_v));
+        any = true;
+    }
+    if (!any) return throwTypeError(realm, "PlainDate-like must have at least one date property");
+
+    const overflow = try getTemporalOverflowOption(realm, argOr(args, 1, Value.undefined_));
+    const rec = temporal.regulateISODate(year, month, day, overflow == .reject) orelse
+        return throwRangeError(realm, "PlainDate is out of range");
+    return createTemporalDate(realm, rec);
+}
+
+/// §13.x GetTemporalShowCalendarNameOption — auto / always / never /
+/// critical (default auto).
+fn getCalendarNameOption(realm: *Realm, options: Value) NativeError!temporal.CalendarDisplay {
+    const obj = (try getOptionsObject(realm, options)) orelse return .auto;
+    const v = try getPropertyChain(realm, obj, "calendarName");
+    if (v.isUndefined()) return .auto;
+    const s = try stringifyArg(realm, v);
+    const b = s.flatBytes();
+    if (std.mem.eql(u8, b, "auto")) return .auto;
+    if (std.mem.eql(u8, b, "always")) return .always;
+    if (std.mem.eql(u8, b, "never")) return .never;
+    if (std.mem.eql(u8, b, "critical")) return .critical;
+    return throwRangeError(realm, "calendarName must be auto / always / never / critical");
+}
+
+/// §3.3.x Temporal.PlainDate.prototype.toString ( [options] ).
+fn plainDateToString(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    const rec = try requirePlainDate(realm, this_value);
+    const cal = try getCalendarNameOption(realm, argOr(args, 0, Value.undefined_));
+    var buf: [40]u8 = undefined;
+    const s = temporal.isoDateToString(rec, &buf, cal);
+    const js = realm.heap.allocateString(s) catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+fn plainDateToJSON(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    const rec = try requirePlainDate(realm, this_value);
+    var buf: [40]u8 = undefined;
+    const s = temporal.isoDateToString(rec, &buf, .auto);
+    const js = realm.heap.allocateString(s) catch return error.OutOfMemory;
+    return Value.fromString(js);
+}
+fn plainDateToLocaleString(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return plainDateToJSON(realm, this_value, args);
+}
+fn plainDateValueOf(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = this_value;
+    _ = args;
+    return throwTypeError(realm, "Called valueOf on a Temporal.PlainDate; use compare() instead");
+}
+
+// Deferred PlainDate methods — date arithmetic and conversions to types
+// Cynic doesn't ship yet.
+fn plainDateAdd(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.add is not yet implemented");
+}
+fn plainDateSubtract(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.subtract is not yet implemented");
+}
+fn plainDateUntil(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.until is not yet implemented");
+}
+fn plainDateSince(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.since is not yet implemented");
+}
+fn plainDateWithCalendar(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.withCalendar is not yet implemented");
+}
+fn plainDateToPlainYearMonth(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.toPlainYearMonth is not yet implemented");
+}
+fn plainDateToPlainMonthDay(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.toPlainMonthDay is not yet implemented");
+}
+fn plainDateToPlainDateTime(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.toPlainDateTime is not yet implemented");
+}
+fn plainDateToZonedDateTime(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    _ = args;
+    _ = try requirePlainDate(realm, this_value);
+    return throwTypeError(realm, "Temporal.PlainDate.prototype.toZonedDateTime is not yet implemented");
 }

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -1712,6 +1712,16 @@ pub const Heap = struct {
         self.markValue(gen.this_value);
         if (gen.env) |e| self.markEnvironment(e);
         if (gen.home_object) |ho| self.markValue(taggedObject(ho));
+        if (gen.home_function) |hf| self.markValue(taggedFunction(hf));
+        // The Promise a suspended async function must still settle:
+        // once the caller has attached its reactions and unwound, it
+        // is reachable only through this generator. Likewise the
+        // `.return(v)` / `.throw(v)` completion values pending at the
+        // next resume. Omitting these sweeps live heap referenced
+        // solely by a suspended frame — a use-after-free on resume.
+        if (gen.result_promise) |rp| self.markValue(rp);
+        if (gen.pending_return) |v| self.markValue(v);
+        if (gen.pending_throw) |v| self.markValue(v);
         // §27.6.3.4 — every buffered AsyncGeneratorRequest holds
         // both a completion value (the `.next(v)` / `.return(v)` /
         // `.throw(v)` arg) and the capability Promise we'll later
@@ -2477,6 +2487,13 @@ pub const Heap = struct {
         self.markValue(g.this_value);
         if (g.env) |e| self.markEnvironment(e);
         if (g.home_object) |ho| self.markValue(taggedObject(ho));
+        if (g.home_function) |hf| self.markValue(taggedFunction(hf));
+        // See `markGenerator` — these suspended-frame roots must be
+        // marked on the minor path too, or a young generator's
+        // result Promise / pending completion is swept on resume.
+        if (g.result_promise) |rp| self.markValue(rp);
+        if (g.pending_return) |v| self.markValue(v);
+        if (g.pending_throw) |v| self.markValue(v);
         for (g.queue.items) |req| {
             switch (req.completion) {
                 .normal => |v| self.markValue(v),

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -101,6 +101,8 @@ pub const Intrinsics = struct {
     temporal_duration_prototype: ?*JSObject = null,
     temporal_plain_time_constructor: ?*JSFunction = null,
     temporal_plain_time_prototype: ?*JSObject = null,
+    temporal_instant_constructor: ?*JSFunction = null,
+    temporal_instant_prototype: ?*JSObject = null,
 
     /// `%GeneratorPrototype%` (§27.5.1). Lazily installed on the
     /// first `function*` call by `lantern.ensureGeneratorPrototype`;

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -103,6 +103,8 @@ pub const Intrinsics = struct {
     temporal_plain_time_prototype: ?*JSObject = null,
     temporal_instant_constructor: ?*JSFunction = null,
     temporal_instant_prototype: ?*JSObject = null,
+    temporal_plain_date_constructor: ?*JSFunction = null,
+    temporal_plain_date_prototype: ?*JSObject = null,
 
     /// `%GeneratorPrototype%` (§27.5.1). Lazily installed on the
     /// first `function*` call by `lantern.ensureGeneratorPrototype`;

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -3326,6 +3326,18 @@ pub fn runFrames(
             const excl_v = registers[r_excl];
             const out_obj = realm.heap.allocateObject() catch return error.OutOfMemory;
             realm.heap.setObjectPrototype(out_obj, realm.intrinsics.object_prototype);
+            // §7.3.27 — `out_obj` is held as a raw pointer across
+            // every source read below (ToObject coercion, the Proxy
+            // ownKeys / get traps, accessor getters via
+            // getPropertyChain), each a JS re-entry that can GC. It
+            // doesn't become reachable from a rooted graph until it
+            // lands in `acc` at the end, so a sweep mid-walk frees it
+            // and the `storeProperty(out_obj, …)` below dereferences
+            // poisoned memory. Root it (and the coerced source
+            // wrapper) for the whole opcode.
+            const out_scope = realm.heap.openScope() catch return error.OutOfMemory;
+            defer out_scope.close();
+            out_scope.push(heap_mod.taggedObject(out_obj)) catch return error.OutOfMemory;
             // §7.3.27 CopyDataProperties step 2 — `ToObject(source)`.
             // Primitive sources (Strings, Numbers, Booleans, Symbols,
             // BigInts) wrap into the matching boxed object — a String
@@ -3354,6 +3366,11 @@ pub fn runFrames(
                 break :blk_coerce heap_mod.taggedObject(w);
             };
             if (committed) continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+            // For a primitive source (`{...r} = "ab"`) this is a
+            // fresh boxed wrapper held across the same getter
+            // re-entries as `out_obj`; for an object source it's a
+            // register-backed value (rooting is a harmless no-op).
+            out_scope.push(src_coerced) catch return error.OutOfMemory;
             if (heap_mod.valueAsPlainObject(src_coerced)) |src_obj| {
                 // §14.3.3.4 RestBindingInitialization →
                 // §7.3.27 CopyDataProperties: build the

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -4815,6 +4815,59 @@ test "GC: integer-index keys on an array-like survive gc_threshold=1" {
     , 30);
 }
 
+test "GC: suspended async fn result Promise survives gc_threshold=1" {
+    // A fire-and-forget async function suspends on `await`; its
+    // [[Promise]] (the value returned to the caller) is reachable
+    // ONLY through the suspended JSGenerator's `result_promise`
+    // slot once `.then` has registered its reaction and the caller
+    // frame unwound. `markGenerator` did not mark `result_promise`
+    // (nor `home_function` / `pending_return` / `pending_throw`),
+    // so under gc_threshold=1 the awaited continuation's allocations
+    // swept the result Promise — `.then`'s reaction was lost and
+    // `acc` never updated (or the resume settled freed memory).
+    try expectScriptIntUnderGcPressure(
+        \\var acc = -1;
+        \\async function f() { var x = await 1; var y = await (x + 2); return y + 4; }
+        \\f().then(function(v) { acc = v; });
+        \\globalThis.__drainMicrotasks();
+        \\acc;
+    , 7);
+}
+
+test "GC: Array.fromAsync over a sync iterable survives gc_threshold=1" {
+    // The fromAsync driver keeps its cursor in an engine-internal
+    // `state` object reached through each continuation's `bound_this`.
+    // Three roots had to hold under gc_threshold=1: the bound
+    // resolve/reject callables (`makeBoundCb` allocated the inner fn
+    // then the bound wrapper — a GC between freed the inner fn →
+    // "value is not callable"); the generational write barrier on
+    // `state` (promoted to mature across awaits, then a young
+    // iterator stored into `__cynic_fa_iter__` was an un-remembered
+    // edge); and `wrapValueInPromise`'s freshly-allocated Promise
+    // across the resolve re-entry.
+    try expectScriptIntUnderGcPressure(
+        \\var acc = -1;
+        \\Array.fromAsync([10, 20, 30]).then(function(a) { acc = a[0] + a[1] + a[2]; });
+        \\globalThis.__drainMicrotasks();
+        \\acc;
+    , 60);
+}
+
+test "GC: Array.fromAsync with a mapfn survives gc_threshold=1" {
+    // Exercises the mapped-value branch: each element is mapped then
+    // re-awaited via `awaitWithCbs` → `awaitAndThen` →
+    // `wrapValueInPromise`. Before rooting the wrapper Promise across
+    // the resolve re-entry, the awaited `source` was a dangling
+    // pointer and `switch (source.promise_state)` paniced on a
+    // corrupt enum value under gc_threshold=1.
+    try expectScriptIntUnderGcPressure(
+        \\var acc = -1;
+        \\Array.fromAsync([1, 2, 3], function(x) { return x * 10; }).then(function(a) { acc = a[0] + a[1] + a[2]; });
+        \\globalThis.__drainMicrotasks();
+        \\acc;
+    , 60);
+}
+
 test "GC: long Promise microtask chain survives alternating GC pressure" {
     // The 3-deep chain above doesn't surface two interacting
     // hazards: (1) the colour-flip cross-cycle stale-mark hazard
@@ -5136,6 +5189,61 @@ test "GC: destructuring iterator record survives gc_threshold=1" {
         \\let [a, b, c] = g;
         \\a + b + c;
     , 6);
+}
+
+test "GC: object-rest target survives gc_threshold=1" {
+    // §7.3.27 CopyDataProperties (`const {a, ...rest} = src`). The
+    // `object_rest_from` opcode allocates `rest` up front, then walks
+    // the source's own keys reading each through `[[Get]]` — and an
+    // accessor getter (`get c`) re-enters JS, so with threshold=1 a
+    // full sweep fires mid-walk. `rest` is reachable only through a
+    // native local until it lands in the accumulator at the end, so
+    // without rooting it the sweep freed it and the next
+    // `storeProperty(rest, …)` dereferenced poisoned memory (the
+    // for-await-of segfault). Reads back the copied props to prove
+    // the target stayed live across the getter.
+    try expectScriptIntUnderGcPressure(
+        \\const src = { a: 1, b: 2, get c() { return 3; }, d: 4 };
+        \\const { a, ...rest } = src;
+        \\rest.b + rest.c + rest.d;
+    , 9);
+}
+
+test "GC: object-rest over a primitive source survives gc_threshold=1" {
+    // Same opcode, ToObject(source) branch: a String primitive boxes
+    // into a fresh wrapper held across the same getter re-entries as
+    // the target. `{...rest} = "wxyz"` copies the indexed chars; the
+    // coerced wrapper must be rooted too, or it's swept mid-walk.
+    try expectScriptStringUnderGcPressure(
+        \\const { 0: first, ...rest } = "wxyz";
+        \\rest[1] + rest[2] + rest[3];
+    , "xyz");
+}
+
+test "GC: young fn assigned to a promise's .then survives gc_threshold=1" {
+    // §27.2.4 Promise aggregators forward each item via
+    // `Invoke(item, "then", « resolve, reject »)`, calling the
+    // per-item user `.then`. This fixture (mirrors test262
+    // built-ins/Promise/any/invoke-then-on-promises-every-iteration)
+    // overwrites each promise's `.then` with a fresh (young) closure
+    // inside `forEach`. The aggregator's native write path stamped
+    // that young function into the mature promise's shape slot
+    // without the generational write barrier, so the next minor
+    // sweep collected the still-reachable closure (`verifyRememberedSet`
+    // slot[0]->young). `calls` only reaches 3 if every overridden
+    // `.then` survived to be invoked.
+    try expectScriptIntUnderGcPressure(
+        \\let calls = 0;
+        \\const ps = [Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)];
+        \\ps.forEach(p => {
+        \\  const bound = p.then.bind(p);
+        \\  p.then = function(onF, onR) { calls++; return bound(onF, onR); };
+        \\});
+        \\let done = 0;
+        \\Promise.any(ps).then(() => { done = calls; });
+        \\globalThis.__drainMicrotasks();
+        \\done;
+    , 3);
 }
 
 test "debug globals: installBuiltins is debug-clean — production realms ship without test hooks" {

--- a/src/runtime/module.zig
+++ b/src/runtime/module.zig
@@ -172,7 +172,14 @@ pub fn getModuleNamespace(realm: *Realm, mr: *ModuleRecord) !*JSObject {
     // Idempotent — the `hasOwn` guard keeps repeated calls cheap.
     if (!ns.hasOwn("@@toStringTag")) {
         const tag = try realm.heap.allocateString("Module");
-        try ns.setWithFlags(realm.allocator, "@@toStringTag", Value.fromString(tag), .{
+        const tag_v = Value.fromString(tag);
+        // `ns` (`mr.exports`) is promoted to mature across the
+        // module's evaluation; storing the freshly-allocated young
+        // tag string via the raw setter is an un-remembered
+        // mature→young edge that the next minor GC sweeps (the gc1
+        // remembered-set verifier trips on exactly this). Barrier it.
+        realm.heap.writeBarrier(.{ .object = ns }, tag_v);
+        try ns.setWithFlags(realm.allocator, "@@toStringTag", tag_v, .{
             .writable = false,
             .enumerable = false,
             .configurable = false,

--- a/src/runtime/object.zig
+++ b/src/runtime/object.zig
@@ -2033,6 +2033,12 @@ pub const JSObject = struct {
                     e.attrs.configurable == flags.configurable)
                 {
                     self.slots.items[e.slot] = v;
+                    // Generational write barrier — a mature object
+                    // gaining a young referent in a shape slot must
+                    // join the remembered set, or the minor sweep
+                    // collects the still-reachable young value
+                    // (`verifyRememberedSet` slot-edge assert).
+                    heap.writeBarrier(.{ .object = self }, v);
                     return true;
                 }
                 try self.demoteFromShape(allocator);
@@ -2059,6 +2065,9 @@ pub const JSObject = struct {
             return err;
         };
         self.slots.items[child.slot] = v;
+        // Generational write barrier for the freshly transitioned
+        // slot — same hazard as the same-descriptor update above.
+        heap.writeBarrier(.{ .object = self }, v);
         self.shape = child;
         return true;
     }

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -28,6 +28,7 @@ const std = @import("std");
 pub const TemporalKind = enum {
     duration,
     plain_time,
+    instant,
 };
 
 /// §7.5 Temporal.Duration internal slots. Each field is the ℝ
@@ -59,12 +60,22 @@ pub const PlainTimeRecord = struct {
     nanosecond: u32 = 0,
 };
 
+/// §8.1 Temporal.Instant internal slot ([[EpochNanoseconds]]). The
+/// representable range is ±(86400 × 10^17) ns = ±8.64×10^21, which
+/// fits an `i128` with room to spare, so the record carries no heap
+/// pointer and adds no GC mark edge; it converts to/from a `JSBigInt`
+/// only at the JS boundary, like the other plain records.
+pub const InstantRecord = struct {
+    epoch_ns: i128 = 0,
+};
+
 /// The side allocation a Temporal instance's `JSObject` points to
 /// through `JSObjectExtension.temporal_record`. A tagged union so
 /// the single slot serves every plain Temporal type.
 pub const TemporalRecord = union(TemporalKind) {
     duration: DurationRecord,
     plain_time: PlainTimeRecord,
+    instant: InstantRecord,
 
     pub fn deinit(self: *TemporalRecord, allocator: std.mem.Allocator) void {
         // No owned heap memory inside any variant today; the record
@@ -911,6 +922,460 @@ pub fn plainTimeToString(t: PlainTimeRecord, buf: []u8) []const u8 {
     return w.buf[0..w.len];
 }
 
+// ── §8 Temporal.Instant abstract operations (pure) ────────────────────────
+
+/// §8.x nsMinInstant / nsMaxInstant — the inclusive epoch-nanosecond
+/// bounds of a representable Instant: ±(86400 × 10^17) ns (±10^8 days
+/// from the epoch). Equal to the nanosecond form of the legacy Date
+/// ±8.64×10^15 ms range, so `Date.prototype.toTemporalInstant` never
+/// overflows.
+pub const ns_min_instant: i128 = -8_640_000_000_000_000_000_000;
+pub const ns_max_instant: i128 = 8_640_000_000_000_000_000_000;
+
+/// §8.x IsValidEpochNanoseconds — within the inclusive instant bounds.
+pub fn isValidEpochNanoseconds(ns: i128) bool {
+    return ns >= ns_min_instant and ns <= ns_max_instant;
+}
+
+/// §8.x AddInstant — add a signed nanosecond delta to an epoch-ns
+/// value, returning null when the result leaves the representable
+/// range (the caller throws RangeError). The i128 sum cannot overflow:
+/// a valid Instant is ≤ 8.64×10^21 and a valid Duration's time total
+/// is ≤ ~9×10^24 ns, both far inside i128.
+pub fn addInstant(epoch_ns: i128, delta_ns: i128) ?i128 {
+    const sum = epoch_ns + delta_ns;
+    if (!isValidEpochNanoseconds(sum)) return null;
+    return sum;
+}
+
+/// Total nanoseconds contributed by a duration's time components
+/// (hours and smaller). Callers performing Instant arithmetic must
+/// first verify the date components (years/months/weeks/days) are
+/// zero — §8 disallows calendar units. Exact for the valid duration
+/// range (each field is an integer ≤ 2^53).
+pub fn timeDurationNanoseconds(d: DurationRecord) i128 {
+    return f64ToI128(d.hours) * 3_600_000_000_000 +
+        f64ToI128(d.minutes) * 60_000_000_000 +
+        f64ToI128(d.seconds) * 1_000_000_000 +
+        f64ToI128(d.milliseconds) * 1_000_000 +
+        f64ToI128(d.microseconds) * 1_000 +
+        f64ToI128(d.nanoseconds);
+}
+
+fn f64ToI128(v: f64) i128 {
+    return @intFromFloat(v);
+}
+
+/// §8.x CompareEpochNanoseconds — -1 / 0 / +1.
+pub fn compareInstant(a: i128, b: i128) i32 {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+}
+
+// ── Proleptic-Gregorian civil-date math (Howard Hinnant) ──────────────────
+// Implemented here in the runtime layer so Temporal stays independent
+// of `builtins/date.zig` (runtime must not depend on the builtins
+// layer). Valid across the whole Temporal year range.
+
+const Ymd = struct { year: i64, month: u32, day: u32 };
+
+/// Days from 1970-01-01 to a proleptic-Gregorian date. `month` is
+/// 1..12, `day` 1..31.
+pub fn daysFromCivil(year: i64, month: u32, day: u32) i64 {
+    const m: i64 = @intCast(month);
+    const d: i64 = @intCast(day);
+    const y: i64 = year - (if (month <= 2) @as(i64, 1) else 0);
+    const era: i64 = @divTrunc(if (y >= 0) y else y - 399, 400);
+    const yoe: i64 = y - era * 400; // [0, 399]
+    const doy: i64 = @divTrunc(153 * (if (m > 2) m - 3 else m + 9) + 2, 5) + d - 1; // [0, 365]
+    const doe: i64 = yoe * 365 + @divTrunc(yoe, 4) - @divTrunc(yoe, 100) + doy; // [0, 146096]
+    return era * 146097 + doe - 719468;
+}
+
+/// Inverse of `daysFromCivil`.
+pub fn civilFromDays(z_in: i64) Ymd {
+    const z: i64 = z_in + 719468;
+    const era: i64 = @divTrunc(if (z >= 0) z else z - 146096, 146097);
+    const doe: i64 = z - era * 146097; // [0, 146096]
+    const yoe: i64 = @divTrunc(doe - @divTrunc(doe, 1460) + @divTrunc(doe, 36524) - @divTrunc(doe, 146096), 365); // [0, 399]
+    const y: i64 = yoe + era * 400;
+    const doy: i64 = doe - (365 * yoe + @divTrunc(yoe, 4) - @divTrunc(yoe, 100)); // [0, 365]
+    const mp: i64 = @divTrunc(5 * doy + 2, 153); // [0, 11]
+    const d: i64 = doy - @divTrunc(153 * mp + 2, 5) + 1; // [1, 31]
+    const m: i64 = if (mp < 10) mp + 3 else mp - 9; // [1, 12]
+    return .{ .year = y + (if (m <= 2) @as(i64, 1) else 0), .month = @intCast(m), .day = @intCast(d) };
+}
+
+fn isLeapYear(y: i64) bool {
+    return (@mod(y, 4) == 0 and @mod(y, 100) != 0) or @mod(y, 400) == 0;
+}
+
+fn daysInIsoMonth(y: i64, m: u32) u32 {
+    return switch (m) {
+        1, 3, 5, 7, 8, 10, 12 => 31,
+        4, 6, 9, 11 => 30,
+        2 => if (isLeapYear(y)) @as(u32, 29) else 28,
+        else => 0,
+    };
+}
+
+// ── §8.x TemporalInstantToString (UTC, precision = "auto") ────────────────
+
+/// Format an epoch-ns value to its UTC ISO-8601 string — the form
+/// `Temporal.Instant.prototype.toString` / `toJSON` produce with no
+/// time-zone and `precision="auto"`: `YYYY-MM-DDTHH:MM:SS` plus a
+/// trimmed sub-second fraction and a trailing `Z`. Years outside
+/// 0000..9999 use the expanded `±YYYYYY` form.
+pub fn instantToString(epoch_ns: i128, buf: []u8) []const u8 {
+    const sec = @divFloor(epoch_ns, 1_000_000_000);
+    const sub_ns: u32 = @intCast(epoch_ns - sec * 1_000_000_000); // [0, 999999999]
+    const days = @divFloor(sec, 86400);
+    const sod = sec - days * 86400; // [0, 86399]
+    const ymd = civilFromDays(@intCast(days));
+    const hour: u32 = @intCast(@divTrunc(sod, 3600));
+    const minute: u32 = @intCast(@divTrunc(@mod(sod, 3600), 60));
+    const second: u32 = @intCast(@mod(sod, 60));
+
+    var w = Writer{ .buf = buf, .len = 0 };
+    writeIsoYear(&w, ymd.year);
+    w.byte('-');
+    w.pad2(ymd.month);
+    w.byte('-');
+    w.pad2(ymd.day);
+    w.byte('T');
+    w.pad2(hour);
+    w.byte(':');
+    w.pad2(minute);
+    w.byte(':');
+    w.pad2(second);
+    if (sub_ns != 0) {
+        w.byte('.');
+        w.fraction9(sub_ns);
+    }
+    w.byte('Z');
+    return w.buf[0..w.len];
+}
+
+fn writeIsoYear(w: *Writer, year: i64) void {
+    if (year >= 0 and year <= 9999) {
+        var tmp: [4]u8 = undefined;
+        var y: u32 = @intCast(year);
+        var i: usize = 4;
+        while (i > 0) {
+            i -= 1;
+            tmp[i] = '0' + @as(u8, @intCast(y % 10));
+            y /= 10;
+        }
+        w.bytes(&tmp);
+        return;
+    }
+    w.byte(if (year < 0) '-' else '+');
+    var y: u64 = @intCast(if (year < 0) -year else year);
+    var tmp: [6]u8 = undefined;
+    var i: usize = 6;
+    while (i > 0) {
+        i -= 1;
+        tmp[i] = '0' + @as(u8, @intCast(y % 10));
+        y /= 10;
+    }
+    w.bytes(&tmp);
+}
+
+// ── §8.x ParseTemporalInstantString ───────────────────────────────────────
+
+/// Parse an ISO-8601 / RFC 9557 date-time that carries BOTH a time and
+/// a UTC offset (or `Z`), then fold the offset in to yield the epoch
+/// nanoseconds. Returns `error.Invalid` (caller throws RangeError) on
+/// any malformed / unsupported form, or when the resulting instant is
+/// out of range.
+///
+/// Required shape: a calendar date (`YYYY-MM-DD`, basic `YYYYMMDD`, or
+/// expanded `±YYYYYY-MM-DD`), a `T`/`t`/space separator, a time
+/// (`HH[:MM[:SS[.fraction]]]` or the compact colon-free forms), and a
+/// trailing `Z`/`z` or numeric offset. Optional `[...]` annotations
+/// (a time-zone identifier, then `key=value` pairs) follow and are
+/// validated then discarded. A date with no time, or a date-time with
+/// no offset, is rejected — an Instant needs an exact point in time.
+pub fn parseInstantString(input: []const u8) error{Invalid}!i128 {
+    var c = Cursor{ .s = input };
+
+    const date = try parseIsoDate(&c);
+
+    // Date-time separator (required — an Instant must have a time).
+    if (!c.eatAny("Tt ")) return error.Invalid;
+
+    const time = try parseIsoTime(&c);
+
+    // Offset (required) — `Z`/`z` or a signed numeric offset.
+    var offset_ns: i128 = 0;
+    if (c.eatAny("Zz")) {
+        offset_ns = 0;
+    } else if (c.peek()) |ch| {
+        if (ch == '+' or ch == '-') {
+            offset_ns = try parseUtcOffsetNs(&c);
+        } else return error.Invalid;
+    } else return error.Invalid;
+
+    // Optional annotations, then the string must end.
+    try consumeAnnotations(&c);
+    if (!c.done()) return error.Invalid;
+
+    // Fold the offset in: epoch = wall-clock-as-UTC − offset.
+    const epoch_days = daysFromCivil(date.year, date.month, date.day);
+    const wall_sec: i128 = @as(i128, epoch_days) * 86400 +
+        @as(i128, time.hour) * 3600 + @as(i128, time.minute) * 60 + @as(i128, time.second);
+    const wall_ns: i128 = wall_sec * 1_000_000_000 + @as(i128, time.sub_ns);
+    const epoch_ns = wall_ns - offset_ns;
+    if (!isValidEpochNanoseconds(epoch_ns)) return error.Invalid;
+    return epoch_ns;
+}
+
+const Cursor = struct {
+    s: []const u8,
+    i: usize = 0,
+
+    fn done(self: *const Cursor) bool {
+        return self.i >= self.s.len;
+    }
+    fn peek(self: *const Cursor) ?u8 {
+        return if (self.i < self.s.len) self.s[self.i] else null;
+    }
+    fn eat(self: *Cursor, ch: u8) bool {
+        if (self.i < self.s.len and self.s[self.i] == ch) {
+            self.i += 1;
+            return true;
+        }
+        return false;
+    }
+    fn eatAny(self: *Cursor, set: []const u8) bool {
+        const ch = self.peek() orelse return false;
+        for (set) |x| {
+            if (ch == x) {
+                self.i += 1;
+                return true;
+            }
+        }
+        return false;
+    }
+    fn isDigit(self: *const Cursor) bool {
+        const ch = self.peek() orelse return false;
+        return ch >= '0' and ch <= '9';
+    }
+    /// Read EXACTLY n decimal digits as a u64; null (no advance) if
+    /// fewer than n digits are available at the cursor.
+    fn fixedDigits(self: *Cursor, n: usize) ?u64 {
+        if (self.i + n > self.s.len) return null;
+        var v: u64 = 0;
+        var k: usize = 0;
+        while (k < n) : (k += 1) {
+            const ch = self.s[self.i + k];
+            if (ch < '0' or ch > '9') return null;
+            v = v * 10 + (ch - '0');
+        }
+        self.i += n;
+        return v;
+    }
+};
+
+const ParsedDate = struct { year: i64, month: u32, day: u32 };
+const ParsedTime = struct { hour: u32, minute: u32, second: u32, sub_ns: u32 };
+
+fn parseIsoDate(c: *Cursor) error{Invalid}!ParsedDate {
+    var year: i64 = undefined;
+    var expanded = false;
+    const lead = c.peek() orelse return error.Invalid;
+    if (lead == '+' or lead == '-') {
+        // Expanded year: ASCII sign + exactly six digits. A `-000000`
+        // (negative zero) expanded year is forbidden.
+        const neg = lead == '-';
+        c.i += 1;
+        const y = c.fixedDigits(6) orelse return error.Invalid;
+        if (neg and y == 0) return error.Invalid;
+        year = if (neg) -@as(i64, @intCast(y)) else @as(i64, @intCast(y));
+        expanded = true;
+    } else {
+        const y = c.fixedDigits(4) orelse return error.Invalid;
+        year = @intCast(y);
+    }
+
+    // Extended (`-` separators) vs basic (none). An expanded `±YYYYYY`
+    // year may be followed by either form (`+001976-11-18` and the
+    // dash-free `+0019761118` are both valid).
+    const extended = c.eat('-');
+    const month_u = c.fixedDigits(2) orelse return error.Invalid;
+    if (extended and !c.eat('-')) return error.Invalid;
+    const day_u = c.fixedDigits(2) orelse return error.Invalid;
+
+    const month: u32 = @intCast(month_u);
+    const day: u32 = @intCast(day_u);
+    if (month < 1 or month > 12) return error.Invalid;
+    if (day < 1 or day > daysInIsoMonth(year, month)) return error.Invalid;
+    return .{ .year = year, .month = month, .day = day };
+}
+
+fn parseIsoTime(c: *Cursor) error{Invalid}!ParsedTime {
+    const hour_u = c.fixedDigits(2) orelse return error.Invalid;
+    var minute: u32 = 0;
+    var second: u32 = 0;
+    var sub_ns: u32 = 0;
+
+    if (c.eat(':')) {
+        minute = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+        if (c.eat(':')) {
+            second = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+            sub_ns = try parseFractionNs(c);
+        }
+    } else if (c.isDigit()) {
+        minute = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+        if (c.isDigit()) {
+            second = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+            sub_ns = try parseFractionNs(c);
+        }
+    }
+
+    const hour: u32 = @intCast(hour_u);
+    if (hour > 23 or minute > 59 or second > 60) return error.Invalid;
+    if (second == 60) second = 59; // leap second → clamp (Temporal has none)
+    return .{ .hour = hour, .minute = minute, .second = second, .sub_ns = sub_ns };
+}
+
+/// Parse a numeric UTC offset at the cursor (`+`/`-` already peeked):
+/// `±HH`, `±HH:MM`, `±HH:MM:SS`, `±HH:MM:SS(.|,)fraction`, or the
+/// compact colon-free forms. Returns the offset in signed nanoseconds.
+fn parseUtcOffsetNs(c: *Cursor) error{Invalid}!i128 {
+    const sign = c.peek() orelse return error.Invalid;
+    if (sign != '+' and sign != '-') return error.Invalid;
+    c.i += 1;
+    const neg = sign == '-';
+
+    const hour: u32 = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+    var minute: u32 = 0;
+    var second: u32 = 0;
+    var sub_ns: u32 = 0;
+
+    if (c.eat(':')) {
+        minute = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+        if (c.eat(':')) {
+            second = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+            sub_ns = try parseFractionNs(c);
+        }
+    } else if (c.isDigit()) {
+        minute = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+        if (c.isDigit()) {
+            second = @intCast(c.fixedDigits(2) orelse return error.Invalid);
+            sub_ns = try parseFractionNs(c);
+        }
+    }
+
+    if (hour > 23 or minute > 59 or second > 59) return error.Invalid;
+    const total: i128 = (@as(i128, hour) * 3600 + @as(i128, minute) * 60 + @as(i128, second)) *
+        1_000_000_000 + @as(i128, sub_ns);
+    return if (neg) -total else total;
+}
+
+/// Read an optional `.`/`,` fraction (1..9 digits) at the cursor,
+/// returning whole nanoseconds (0 when no fraction follows).
+fn parseFractionNs(c: *Cursor) error{Invalid}!u32 {
+    const ch = c.peek() orelse return 0;
+    if (ch != '.' and ch != ',') return 0;
+    c.i += 1;
+    const start = c.i;
+    while (c.isDigit()) c.i += 1;
+    const len = c.i - start;
+    if (len == 0 or len > 9) return error.Invalid;
+    return fractionToNanos(c.s[start..c.i]);
+}
+
+/// Validate and discard the trailing `[...]` annotation blocks per the
+/// RFC 9557 grammar: an optional leading time-zone annotation (an
+/// identifier, no `=`), then zero or more `key=value` annotations. At
+/// most one time-zone and at most one `u-ca` calendar annotation; a
+/// `[!key=…]` critical flag on an unknown key is rejected. Leaves the
+/// cursor at the first non-`[` byte (the caller requires end-of-input).
+fn consumeAnnotations(c: *Cursor) error{Invalid}!void {
+    var saw_tz = false;
+    var calendars: usize = 0;
+    var critical_calendar = false;
+    var first = true;
+    while (c.peek()) |ch| {
+        if (ch != '[') break;
+        c.i += 1; // consume '['
+        const critical = c.eat('!');
+        const start = c.i;
+        while (c.peek()) |x| {
+            if (x == ']') break;
+            c.i += 1;
+        }
+        if (c.peek() != ']') return error.Invalid; // unterminated
+        const body = c.s[start..c.i];
+        c.i += 1; // consume ']'
+        if (body.len == 0) return error.Invalid;
+
+        if (std.mem.indexOfScalar(u8, body, '=')) |eq| {
+            // key=value annotation. The key must match the lowercase
+            // AnnotationKey grammar; a non-empty value is required.
+            const key = body[0..eq];
+            const value = body[eq + 1 ..];
+            if (!isValidAnnotationKey(key) or value.len == 0) return error.Invalid;
+            if (std.mem.eql(u8, key, "u-ca")) {
+                calendars += 1;
+                if (critical) critical_calendar = true;
+                // Two or more calendar annotations are only syntactical
+                // if none carries the critical flag.
+                if (calendars > 1 and critical_calendar) return error.Invalid;
+            } else if (critical) {
+                return error.Invalid; // unknown critical annotation
+            }
+        } else {
+            // Time-zone annotation (an identifier or a numeric offset):
+            // at most one, and it must precede any key=value
+            // annotations. A numeric offset must not carry sub-minute
+            // precision.
+            if (saw_tz or !first) return error.Invalid;
+            if (!isValidTimeZoneAnnotation(body)) return error.Invalid;
+            saw_tz = true;
+        }
+        first = false;
+    }
+}
+
+/// AnnotationKey :: AKeyLeadingChar (AKeyChar)*, where AKeyLeadingChar
+/// is a lowercase letter or `_`, and AKeyChar adds digits and `-`.
+/// Capitalised keys (`U-CA`, `u-CA`) are not valid; `_foo-bar0` is.
+fn isValidAnnotationKey(key: []const u8) bool {
+    if (key.len == 0) return false;
+    if (!((key[0] >= 'a' and key[0] <= 'z') or key[0] == '_')) return false;
+    for (key[1..]) |ch| {
+        const ok = (ch >= 'a' and ch <= 'z') or ch == '_' or
+            (ch >= '0' and ch <= '9') or ch == '-';
+        if (!ok) return false;
+    }
+    return true;
+}
+
+/// A time-zone annotation is either an IANA-style identifier or a
+/// numeric UTC offset. A numeric offset (`±HH`, `±HH:MM`, `±HHMM`) must
+/// NOT carry sub-minute precision — `[-07:00:01]` is rejected. Other
+/// identifier shapes are accepted and discarded (Instant is
+/// time-zone-free).
+fn isValidTimeZoneAnnotation(body: []const u8) bool {
+    if (body.len == 0) return false;
+    if (body[0] != '+' and body[0] != '-') return true; // IANA-style name
+    var k: usize = 1;
+    if (k + 2 > body.len or !isAsciiDigit(body[k]) or !isAsciiDigit(body[k + 1])) return false;
+    k += 2;
+    if (k == body.len) return true; // ±HH
+    if (body[k] == ':') k += 1;
+    if (k + 2 > body.len or !isAsciiDigit(body[k]) or !isAsciiDigit(body[k + 1])) return false;
+    k += 2;
+    return k == body.len; // ±HH:MM / ±HHMM — seconds are not allowed
+}
+
+fn isAsciiDigit(ch: u8) bool {
+    return ch >= '0' and ch <= '9';
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -1158,4 +1623,116 @@ test "parseTemporalTimeString: Z designator (trailing) rejected as UTC" {
     try testing.expectError(error.UTCDesignator, parseTemporalTimeString("00:00:00Z"));
     try testing.expectError(error.Invalid, parseTemporalTimeString("00:00:00Zjunk"));
     try testing.expectError(error.Invalid, parseTemporalTimeString("00:00Zjunk"));
+}
+
+test "isValidEpochNanoseconds: inclusive bounds" {
+    try testing.expect(isValidEpochNanoseconds(0));
+    try testing.expect(isValidEpochNanoseconds(ns_max_instant));
+    try testing.expect(isValidEpochNanoseconds(ns_min_instant));
+    try testing.expect(!isValidEpochNanoseconds(ns_max_instant + 1));
+    try testing.expect(!isValidEpochNanoseconds(ns_min_instant - 1));
+}
+
+test "civil-date round trip" {
+    try testing.expectEqual(@as(i64, 0), daysFromCivil(1970, 1, 1));
+    try testing.expectEqual(@as(i64, -1), daysFromCivil(1969, 12, 31));
+    const r = civilFromDays(2513);
+    try testing.expectEqual(@as(i64, 1976), r.year);
+    try testing.expectEqual(@as(u32, 11), r.month);
+    try testing.expectEqual(@as(u32, 18), r.day);
+    var d: i64 = -2_000_000;
+    while (d < 2_000_000) : (d += 7919) {
+        const ymd = civilFromDays(d);
+        try testing.expectEqual(d, daysFromCivil(ymd.year, ymd.month, ymd.day));
+    }
+}
+
+test "instantToString: UTC forms with trimmed fraction" {
+    var buf: [64]u8 = undefined;
+    try testing.expectEqualStrings("1970-01-01T00:00:00Z", instantToString(0, &buf));
+    try testing.expectEqualStrings("1976-11-18T14:23:30.123456789Z", instantToString(217175010123456789, &buf));
+    try testing.expectEqualStrings("1963-02-13T09:36:29.123456789Z", instantToString(-217175010876543211, &buf));
+}
+
+test "compareInstant" {
+    try testing.expectEqual(@as(i32, 0), compareInstant(5, 5));
+    try testing.expectEqual(@as(i32, -1), compareInstant(-1, 1));
+    try testing.expectEqual(@as(i32, 1), compareInstant(2, -2));
+}
+
+test "timeDurationNanoseconds" {
+    try testing.expectEqual(@as(i128, 3_600_000_000_000), timeDurationNanoseconds(.{ .hours = 1 }));
+    try testing.expectEqual(@as(i128, -1_000_000_000), timeDurationNanoseconds(.{ .seconds = -1 }));
+    try testing.expectEqual(@as(i128, 1_001_001_001), timeDurationNanoseconds(.{ .seconds = 1, .milliseconds = 1, .microseconds = 1, .nanoseconds = 1 }));
+}
+
+test "parseInstantString: valid forms fold the offset" {
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00Z"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00+00:00"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1969-12-31T16-08[America/Vancouver]"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00:00+00:00[UTC][u-ca=iso8601]"));
+    try testing.expectEqual(@as(i128, 217175010123456789), try parseInstantString("1976-11-18T14:23:30.123456789Z"));
+    // Range edges (inclusive).
+    try testing.expectEqual(ns_min_instant, try parseInstantString("-271821-04-20T00:00Z"));
+    try testing.expectEqual(ns_max_instant, try parseInstantString("+275760-09-13T00:00Z"));
+    try testing.expectEqual(ns_min_instant, try parseInstantString("-271821-04-19T23:00-01:00"));
+}
+
+test "parseInstantString: invalid forms reject" {
+    const bad = [_][]const u8{
+        "",                          "invalid iso8601",
+        "2020-01-00T00:00Z",         "2020-01-32T00:00Z",
+        "2020-02-30T00:00Z",         "2021-02-29T00:00Z",
+        "2020-00-01T00:00Z",         "2020-13-01T00:00Z",
+        "2020-01-01TZ",              "2020-01-01T25:00:00Z",
+        "2020-01-01T01:60:00Z",      "2020-01-01T00:00Zjunk",
+        "2020-01-01T00:00:00+00:00junk", "2020-01-01T00:00:00+00:00[UTC]junk",
+        "02020-01-01T00:00Z",        "2020-001-01T00:00Z",
+        "2020-01-001T00:00Z",        "2020-01-01T001Z",
+        "2020-01-01T00:00-24:00",    "2020-01-01T00:00+24:00",
+        "2020-W01-1T00:00Z",         "2020-001T00:00Z",
+        "+0002020-01-01T00:00Z",     "2020-01",
+        "01-01",                     "P1Y",
+        "2020-01-01",                "2020-01-01T00",
+        "2020-01-01T00:00",          "2020-01-01T00:00:00",
+        "2020-01-01T00:00:00.000000000", "-999999-01-01T00:00Z",
+        "+999999-01-01T00:00Z",      "2025-01-01T00:00:00+00:0000",
+        "2022-09-15Z",               "2022-09-15+00:00",
+    };
+    for (bad) |s| {
+        try testing.expectError(error.Invalid, parseInstantString(s));
+    }
+}
+
+test "parseInstantString: non-ASCII minus sign rejected" {
+    try testing.expectError(error.Invalid, parseInstantString("1976-11-18T15:23:30.12\u{2212}02:00"));
+    try testing.expectError(error.Invalid, parseInstantString("\u{2212}009999-11-18T15:23:30.12Z"));
+}
+
+test "parseInstantString: annotations + expanded basic year accepted" {
+    // Two non-critical calendar annotations are allowed (first wins,
+    // rest ignored); numeric-offset and IANA-style time-zone
+    // annotations are accepted and discarded.
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z[u-ca=iso8601][u-ca=discord]"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z[+00]"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z[-00:00]"));
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z[NotATimeZone]"));
+    // Unknown annotation keys may lead with `_` and carry mixed-case values.
+    try testing.expectEqual(@as(i128, 0), try parseInstantString("1970-01-01T00:00Z[foo=bar][_foo-bar0=Ignore-This-999999999999]"));
+    // Expanded year followed by basic (dash-free) date + time.
+    try testing.expectEqual(@as(i128, 217178610100000000), try parseInstantString("+0019761118T15:23:30.1+00:00"));
+}
+
+test "parseInstantString: annotation rule violations reject" {
+    const bad = [_][]const u8{
+        "1970-01-01T00:00Z[U-CA=iso8601]", // uppercase key
+        "1970-01-01T00:00Z[u-CA=iso8601]", // partially capitalised key
+        "1970-01-01T00:00Z[FOO=bar]", // capitalised unknown key
+        "1970-01-01T00:00Z[u-ca=iso8601][!u-ca=iso8601]", // 2 calendars, one critical
+        "1970-01-01T00:00Z[!u-ca=iso8601][u-ca=iso8601]",
+        "1970-01-01T00:00Z[!unknown=x]", // critical unknown annotation
+        "2021-08-19T17:30-07:00:01[-07:00:01]", // sub-minute time-zone offset annotation
+    };
+    for (bad) |s| try testing.expectError(error.Invalid, parseInstantString(s));
 }

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -113,6 +113,24 @@ pub fn durationSign(d: DurationRecord) i32 {
     return 0;
 }
 
+/// §7.5.x CreateNegatedTemporalDuration — flip the sign of every field.
+/// Used by the `subtract` methods, which negate the operand duration
+/// and reuse the `add` path.
+pub fn negateDuration(d: DurationRecord) DurationRecord {
+    return .{
+        .years = -d.years,
+        .months = -d.months,
+        .weeks = -d.weeks,
+        .days = -d.days,
+        .hours = -d.hours,
+        .minutes = -d.minutes,
+        .seconds = -d.seconds,
+        .milliseconds = -d.milliseconds,
+        .microseconds = -d.microseconds,
+        .nanoseconds = -d.nanoseconds,
+    };
+}
+
 /// §7.5.x IsValidDuration — the validity predicate `CreateTemporal
 /// Duration` (and the `RejectDuration` polyfill helper) enforce.
 ///
@@ -1738,6 +1756,37 @@ pub fn regulateISODate(year: i64, month: i64, day: i64, reject: bool) ?PlainDate
     return .{ .iso_year = @intCast(year), .iso_month = @intCast(m), .iso_day = @intCast(d) };
 }
 
+/// §3.5.x BalanceISOYearMonth — fold an out-of-range month into the
+/// year so the month lands in 1..12 (carrying whole years; works for
+/// negative months too via floored division).
+pub fn balanceISOYearMonth(year: i64, month: i64) struct { year: i64, month: i64 } {
+    return .{
+        .year = year + @divFloor(month - 1, 12),
+        .month = @mod(month - 1, 12) + 1,
+    };
+}
+
+/// §3.5.x AddISODate — add a date duration (years, months, weeks, days)
+/// to an ISO date under `overflow`. Years/months shift the year-month
+/// first, with the original day constrained into (or rejected against)
+/// the target month; then weeks·7 + days are folded in through the
+/// civil-day calendar. Returns null when the result leaves the
+/// representable range (→ the caller raises RangeError). Components are
+/// the already-validated integer parts of a duration; the valid
+/// duration range keeps every intermediate inside i64.
+pub fn addISODate(rec: PlainDateRecord, years: i64, months: i64, weeks: i64, days: i64, reject: bool) ?PlainDateRecord {
+    const bym = balanceISOYearMonth(@as(i64, rec.iso_year) + years, @as(i64, rec.iso_month) + months);
+    const anchored = regulateISODate(bym.year, bym.month, rec.iso_day, reject) orelse return null;
+    const epoch = daysFromCivil(anchored.iso_year, anchored.iso_month, anchored.iso_day) + days + weeks * 7;
+    if (epoch < iso_date_min_days or epoch > iso_date_max_days) return null;
+    const ymd = civilFromDays(epoch);
+    return .{
+        .iso_year = @intCast(ymd.year),
+        .iso_month = @intCast(ymd.month),
+        .iso_day = @intCast(ymd.day),
+    };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -1954,6 +2003,62 @@ test "parseTemporalDateString + regulateISODate" {
     try testing.expect(regulateISODate(2000, 1, -1, false) == null);
     try testing.expect(regulateISODate(2000, 1, 0, false) == null);
     try testing.expect(regulateISODate(1_000_000_000, 1, 1, true) == null);
+}
+
+test "balanceISOYearMonth" {
+    try testing.expectEqual(@as(i64, 1977), balanceISOYearMonth(1976, 14).year);
+    try testing.expectEqual(@as(i64, 2), balanceISOYearMonth(1976, 14).month);
+    try testing.expectEqual(@as(i64, 1975), balanceISOYearMonth(1976, 0).year);
+    try testing.expectEqual(@as(i64, 12), balanceISOYearMonth(1976, 0).month);
+    try testing.expectEqual(@as(i64, 1976), balanceISOYearMonth(1976, 6).year);
+    try testing.expectEqual(@as(i64, 6), balanceISOYearMonth(1976, 6).month);
+}
+
+test "addISODate" {
+    const base: PlainDateRecord = .{ .iso_year = 1976, .iso_month = 11, .iso_day = 18 };
+    // +43 years: only the year moves (basic.js).
+    {
+        const r = addISODate(base, 43, 0, 0, 0, false).?;
+        try testing.expectEqual(@as(i32, 2019), r.iso_year);
+        try testing.expectEqual(@as(u8, 11), r.iso_month);
+        try testing.expectEqual(@as(u8, 18), r.iso_day);
+    }
+    // +3 months wraps the year (Nov → Feb next year).
+    {
+        const r = addISODate(base, 0, 3, 0, 0, false).?;
+        try testing.expectEqual(@as(i32, 1977), r.iso_year);
+        try testing.expectEqual(@as(u8, 2), r.iso_month);
+    }
+    // +20 days balances into the next month.
+    {
+        const r = addISODate(base, 0, 0, 0, 20, false).?;
+        try testing.expectEqual(@as(u8, 12), r.iso_month);
+        try testing.expectEqual(@as(u8, 8), r.iso_day);
+    }
+    // +1 week.
+    try testing.expectEqual(@as(u8, 25), addISODate(base, 0, 0, 1, 0, false).?.iso_day);
+    // Jan 31 + 1 month: constrain clamps the day to Feb 28; reject → null.
+    {
+        const jan31: PlainDateRecord = .{ .iso_year = 2019, .iso_month = 1, .iso_day = 31 };
+        try testing.expectEqual(@as(u8, 28), addISODate(jan31, 0, 1, 0, 0, false).?.iso_day);
+        try testing.expect(addISODate(jan31, 0, 1, 0, 0, true) == null);
+    }
+    // Negative months symmetric (Feb 28 − 1 month → Jan 28).
+    {
+        const feb: PlainDateRecord = .{ .iso_year = 2019, .iso_month = 2, .iso_day = 28 };
+        const r = addISODate(feb, 0, -1, 0, 0, false).?;
+        try testing.expectEqual(@as(u8, 1), r.iso_month);
+        try testing.expectEqual(@as(u8, 28), r.iso_day);
+    }
+    // Leap-day clamp: 2020-02-29 + 1 year → 2021-02-28.
+    {
+        const leap: PlainDateRecord = .{ .iso_year = 2020, .iso_month = 2, .iso_day = 29 };
+        const r = addISODate(leap, 1, 0, 0, 0, false).?;
+        try testing.expectEqual(@as(i32, 2021), r.iso_year);
+        try testing.expectEqual(@as(u8, 28), r.iso_day);
+    }
+    // Out of range → null.
+    try testing.expect(addISODate(base, 1_000_000, 0, 0, 0, false) == null);
 }
 
 test "durationSign: first non-zero field decides" {

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -1376,9 +1376,329 @@ fn isAsciiDigit(ch: u8) bool {
     return ch >= '0' and ch <= '9';
 }
 
+// ── §13 Rounding primitives ───────────────────────────────────────────────
+
+/// §13.x The nine ECMAScript rounding modes.
+pub const RoundingMode = enum {
+    ceil,
+    floor,
+    expand,
+    trunc,
+    half_ceil,
+    half_floor,
+    half_expand,
+    half_trunc,
+    half_even,
+};
+
+/// §13.x RoundNumberToIncrement — round `value` to the nearest multiple
+/// of `increment` (which must be > 0) per `mode`, in exact i128
+/// arithmetic. Multiples are measured from zero, so rounding an
+/// epoch-nanosecond value lands on boundaries aligned with the Unix
+/// epoch. Sign-aware: `trunc` rounds toward zero, `expand` away from it,
+/// and the half-* ties resolve by the named direction relative to zero.
+pub fn roundToIncrement(value: i128, increment: i128, mode: RoundingMode) i128 {
+    return roundToIncrementImpl(value, increment, mode, false);
+}
+
+/// §13.x RoundNumberToIncrementAsIfPositive — like `roundToIncrement`
+/// but evaluates the directed / half-tie modes as though `value` were
+/// non-negative, so `floor`/`trunc` always round toward −∞ and
+/// `ceil`/`expand` toward +∞. `Temporal.Instant.prototype.round` uses
+/// this: rounding is anchored to the timeline (the epoch), not mirrored
+/// about zero.
+pub fn roundToIncrementAsIfPositive(value: i128, increment: i128, mode: RoundingMode) i128 {
+    return roundToIncrementImpl(value, increment, mode, true);
+}
+
+/// `@divFloor` for the lower multiple makes `lower ≤ value` hold for
+/// negative values too, so the sign handling is uniform.
+fn roundToIncrementImpl(value: i128, increment: i128, mode: RoundingMode, as_if_positive: bool) i128 {
+    const quotient = @divFloor(value, increment);
+    const lower = quotient * increment; // greatest multiple ≤ value
+    if (lower == value) return value; // already an exact multiple
+    const upper = lower + increment;
+    const remainder = value - lower; // in (0, increment)
+    const twice = remainder * 2;
+    const positive = as_if_positive or value > 0;
+    const negative = !as_if_positive and value < 0;
+    const pick_upper = switch (mode) {
+        .ceil => true,
+        .floor => false,
+        .trunc => negative, // toward zero
+        .expand => positive, // away from zero
+        .half_ceil => twice >= increment,
+        .half_floor => twice > increment,
+        .half_expand => if (positive) twice >= increment else twice > increment,
+        .half_trunc => if (positive) twice > increment else twice >= increment,
+        .half_even => if (twice != increment) twice > increment else @mod(quotient, 2) != 0,
+    };
+    return if (pick_upper) upper else lower;
+}
+
+/// Nanoseconds in one fixed-length time unit (day and below). Calendar
+/// units have no fixed length and never reach the time-only balancing
+/// path.
+pub fn unitNanoseconds(unit: LargestUnit) i128 {
+    return switch (unit) {
+        .day => 86_400_000_000_000,
+        .hour => 3_600_000_000_000,
+        .minute => 60_000_000_000,
+        .second => 1_000_000_000,
+        .millisecond => 1_000_000,
+        .microsecond => 1_000,
+        .nanosecond => 1,
+        .year, .month, .week => unreachable,
+    };
+}
+
+fn timeUnitIncluded(unit: LargestUnit, largest: LargestUnit) bool {
+    // `unit` participates when its magnitude is no larger than
+    // `largest` — i.e. its enum index is at or past `largest`'s.
+    return @intFromEnum(unit) >= @intFromEnum(largest);
+}
+
+fn takeTimeUnit(rem: *i128, scale: i128) f64 {
+    const q = @divTrunc(rem.*, scale);
+    rem.* = @rem(rem.*, scale);
+    return @floatFromInt(q);
+}
+
+/// §7.5.x BalanceTimeDuration — distribute a signed nanosecond total
+/// into a Duration's time fields, with the highest field capped at
+/// `largest` (one of day..nanosecond). Every field takes the sign of
+/// `total_ns`. Fields are exact for `largest` ≥ second; for a smaller
+/// `largest` a very large field rounds to the nearest f64, which is the
+/// Number the spec stores.
+pub fn balanceTimeDuration(total_ns: i128, largest: LargestUnit) DurationRecord {
+    var rem = total_ns;
+    var d = DurationRecord{};
+    if (timeUnitIncluded(.day, largest)) d.days = takeTimeUnit(&rem, 86_400_000_000_000);
+    if (timeUnitIncluded(.hour, largest)) d.hours = takeTimeUnit(&rem, 3_600_000_000_000);
+    if (timeUnitIncluded(.minute, largest)) d.minutes = takeTimeUnit(&rem, 60_000_000_000);
+    if (timeUnitIncluded(.second, largest)) d.seconds = takeTimeUnit(&rem, 1_000_000_000);
+    if (timeUnitIncluded(.millisecond, largest)) d.milliseconds = takeTimeUnit(&rem, 1_000_000);
+    if (timeUnitIncluded(.microsecond, largest)) d.microseconds = takeTimeUnit(&rem, 1_000);
+    d.nanoseconds = @floatFromInt(rem);
+    return d;
+}
+
+/// §13.x ValidateTemporalRoundingIncrement — `increment` must divide
+/// `dividend` evenly; when `inclusive` is false it must also be strictly
+/// less than `dividend`. (`increment` ≥ 1 is enforced when the option is
+/// read.)
+pub fn validateRoundingIncrement(increment: i128, dividend: i128, inclusive: bool) bool {
+    if (@mod(dividend, increment) != 0) return false;
+    if (!inclusive and increment == dividend) return false;
+    return true;
+}
+
+/// Map a Temporal unit name (singular or plural) to its `LargestUnit`;
+/// null for an unrecognised name.
+pub fn parseTemporalUnit(s: []const u8) ?LargestUnit {
+    const entries = .{
+        .{ "year", LargestUnit.year },               .{ "years", LargestUnit.year },
+        .{ "month", LargestUnit.month },             .{ "months", LargestUnit.month },
+        .{ "week", LargestUnit.week },               .{ "weeks", LargestUnit.week },
+        .{ "day", LargestUnit.day },                 .{ "days", LargestUnit.day },
+        .{ "hour", LargestUnit.hour },               .{ "hours", LargestUnit.hour },
+        .{ "minute", LargestUnit.minute },           .{ "minutes", LargestUnit.minute },
+        .{ "second", LargestUnit.second },           .{ "seconds", LargestUnit.second },
+        .{ "millisecond", LargestUnit.millisecond }, .{ "milliseconds", LargestUnit.millisecond },
+        .{ "microsecond", LargestUnit.microsecond }, .{ "microseconds", LargestUnit.microsecond },
+        .{ "nanosecond", LargestUnit.nanosecond },   .{ "nanoseconds", LargestUnit.nanosecond },
+    };
+    inline for (entries) |e| {
+        if (std.mem.eql(u8, s, e[0])) return e[1];
+    }
+    return null;
+}
+
+/// Map a `roundingMode` option string to its `RoundingMode`; null for an
+/// unrecognised name.
+pub fn parseRoundingMode(s: []const u8) ?RoundingMode {
+    const entries = .{
+        .{ "ceil", RoundingMode.ceil },              .{ "floor", RoundingMode.floor },
+        .{ "expand", RoundingMode.expand },          .{ "trunc", RoundingMode.trunc },
+        .{ "halfCeil", RoundingMode.half_ceil },     .{ "halfFloor", RoundingMode.half_floor },
+        .{ "halfExpand", RoundingMode.half_expand }, .{ "halfTrunc", RoundingMode.half_trunc },
+        .{ "halfEven", RoundingMode.half_even },
+    };
+    inline for (entries) |e| {
+        if (std.mem.eql(u8, s, e[0])) return e[1];
+    }
+    return null;
+}
+
+/// §4.5.x Total nanoseconds of a PlainTime within its day (0..86400×10^9).
+pub fn timeRecordToNanoseconds(t: PlainTimeRecord) i128 {
+    return @as(i128, t.hour) * 3_600_000_000_000 +
+        @as(i128, t.minute) * 60_000_000_000 +
+        @as(i128, t.second) * 1_000_000_000 +
+        @as(i128, t.millisecond) * 1_000_000 +
+        @as(i128, t.microsecond) * 1_000 +
+        @as(i128, t.nanosecond);
+}
+
+/// §4.5.x Build a PlainTime from a within-day nanosecond count
+/// (0..86399999999999). The caller wraps any day overflow first.
+pub fn nanosecondsToTimeRecord(ns_in_day: i128) PlainTimeRecord {
+    var rem = ns_in_day;
+    const hour: u32 = @intCast(@divTrunc(rem, 3_600_000_000_000));
+    rem = @mod(rem, 3_600_000_000_000);
+    const minute: u32 = @intCast(@divTrunc(rem, 60_000_000_000));
+    rem = @mod(rem, 60_000_000_000);
+    const second: u32 = @intCast(@divTrunc(rem, 1_000_000_000));
+    rem = @mod(rem, 1_000_000_000);
+    const millisecond: u32 = @intCast(@divTrunc(rem, 1_000_000));
+    rem = @mod(rem, 1_000_000);
+    const microsecond: u32 = @intCast(@divTrunc(rem, 1_000));
+    const nanosecond: u32 = @intCast(@mod(rem, 1_000));
+    return .{
+        .hour = hour,
+        .minute = minute,
+        .second = second,
+        .millisecond = millisecond,
+        .microsecond = microsecond,
+        .nanosecond = nanosecond,
+    };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
+
+test "roundToIncrement: exact multiples are unchanged" {
+    inline for (.{ RoundingMode.ceil, .floor, .trunc, .expand, .half_even, .half_expand }) |m| {
+        try testing.expectEqual(@as(i128, 90), roundToIncrement(90, 30, m));
+        try testing.expectEqual(@as(i128, 0), roundToIncrement(0, 7, m));
+        try testing.expectEqual(@as(i128, -60), roundToIncrement(-60, 30, m));
+    }
+}
+
+test "roundToIncrement: directed modes" {
+    // value 100, increment 30 → lower 90, upper 120.
+    try testing.expectEqual(@as(i128, 120), roundToIncrement(100, 30, .ceil));
+    try testing.expectEqual(@as(i128, 90), roundToIncrement(100, 30, .floor));
+    try testing.expectEqual(@as(i128, 90), roundToIncrement(100, 30, .trunc));
+    try testing.expectEqual(@as(i128, 120), roundToIncrement(100, 30, .expand));
+    // value -100, increment 30 → lower -120, upper -90.
+    try testing.expectEqual(@as(i128, -90), roundToIncrement(-100, 30, .ceil));
+    try testing.expectEqual(@as(i128, -120), roundToIncrement(-100, 30, .floor));
+    try testing.expectEqual(@as(i128, -90), roundToIncrement(-100, 30, .trunc));
+    try testing.expectEqual(@as(i128, -120), roundToIncrement(-100, 30, .expand));
+}
+
+test "roundToIncrement: half modes on an exact tie" {
+    // value 15, increment 10 → lower 10, upper 20 (tie).
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(15, 10, .half_ceil));
+    try testing.expectEqual(@as(i128, 10), roundToIncrement(15, 10, .half_floor));
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(15, 10, .half_expand));
+    try testing.expectEqual(@as(i128, 10), roundToIncrement(15, 10, .half_trunc));
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(15, 10, .half_even)); // 10 is odd multiple → 20
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(25, 10, .half_even)); // 20 is even multiple → 20
+    // negative tie: value -15, increment 10 → lower -20, upper -10.
+    try testing.expectEqual(@as(i128, -10), roundToIncrement(-15, 10, .half_ceil));
+    try testing.expectEqual(@as(i128, -20), roundToIncrement(-15, 10, .half_floor));
+    try testing.expectEqual(@as(i128, -20), roundToIncrement(-15, 10, .half_expand));
+    try testing.expectEqual(@as(i128, -10), roundToIncrement(-15, 10, .half_trunc));
+    try testing.expectEqual(@as(i128, -20), roundToIncrement(-15, 10, .half_even));
+}
+
+test "roundToIncrement: half modes off a tie pick the nearer multiple" {
+    try testing.expectEqual(@as(i128, 10), roundToIncrement(12, 10, .half_expand));
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(18, 10, .half_expand));
+    try testing.expectEqual(@as(i128, 10), roundToIncrement(12, 10, .half_even));
+    try testing.expectEqual(@as(i128, 20), roundToIncrement(18, 10, .half_even));
+}
+
+test "roundToIncrement: matches the Instant halfExpand fixture" {
+    const ns: i128 = 217175010123987500; // 1976-11-18T14:23:30.1239875Z
+    try testing.expectEqual(@as(i128, 217173600000000000), roundToIncrement(ns, 3_600_000_000_000, .half_expand)); // hour
+    try testing.expectEqual(@as(i128, 217175040000000000), roundToIncrement(ns, 60_000_000_000, .half_expand)); // minute
+    try testing.expectEqual(@as(i128, 217175010000000000), roundToIncrement(ns, 1_000_000_000, .half_expand)); // second
+    try testing.expectEqual(@as(i128, 217175010124000000), roundToIncrement(ns, 1_000_000, .half_expand)); // ms
+    try testing.expectEqual(@as(i128, 217175010123988000), roundToIncrement(ns, 1_000, .half_expand)); // µs
+}
+
+test "balanceTimeDuration: caps at largestUnit, carries sign" {
+    {
+        const d = balanceTimeDuration(3_600_000_000_000, .hour);
+        try testing.expectEqual(@as(f64, 1), d.hours);
+        try testing.expectEqual(@as(f64, 0), d.minutes);
+    }
+    {
+        const d = balanceTimeDuration(90 * 60_000_000_000, .hour);
+        try testing.expectEqual(@as(f64, 1), d.hours);
+        try testing.expectEqual(@as(f64, 30), d.minutes);
+    }
+    {
+        const d = balanceTimeDuration(90 * 60_000_000_000, .minute);
+        try testing.expectEqual(@as(f64, 0), d.hours);
+        try testing.expectEqual(@as(f64, 90), d.minutes);
+    }
+    {
+        // 366-day span, matching the Instant until minutes-and-hours fixture.
+        const total: i128 = @as(i128, 366) * 86400 * 1_000_000_000;
+        try testing.expectEqual(@as(f64, 8784), balanceTimeDuration(total, .hour).hours);
+        try testing.expectEqual(@as(f64, 527040), balanceTimeDuration(total, .minute).minutes);
+    }
+    {
+        const d = balanceTimeDuration(-(1_000_000_000 + 123_456_789), .second);
+        try testing.expectEqual(@as(f64, -1), d.seconds);
+        try testing.expectEqual(@as(f64, -123), d.milliseconds);
+        try testing.expectEqual(@as(f64, -456), d.microseconds);
+        try testing.expectEqual(@as(f64, -789), d.nanoseconds);
+    }
+}
+
+test "validateRoundingIncrement: round (inclusive) vs difference (exclusive)" {
+    try testing.expect(validateRoundingIncrement(24, 24, true)); // round hour: 24 ok
+    try testing.expect(validateRoundingIncrement(4, 24, true));
+    try testing.expect(!validateRoundingIncrement(7, 24, true)); // 7 ∤ 24
+    try testing.expect(!validateRoundingIncrement(24, 24, false)); // until hour: 24 rejected
+    try testing.expect(validateRoundingIncrement(12, 24, false));
+    try testing.expect(!validateRoundingIncrement(60, 60, false)); // until minute: 60 rejected
+    try testing.expect(validateRoundingIncrement(30, 60, false));
+    try testing.expect(!validateRoundingIncrement(29, 60, false));
+}
+
+test "parseTemporalUnit + parseRoundingMode" {
+    try testing.expectEqual(@as(?LargestUnit, .hour), parseTemporalUnit("hour"));
+    try testing.expectEqual(@as(?LargestUnit, .hour), parseTemporalUnit("hours"));
+    try testing.expectEqual(@as(?LargestUnit, .nanosecond), parseTemporalUnit("nanoseconds"));
+    try testing.expectEqual(@as(?LargestUnit, null), parseTemporalUnit("fortnight"));
+    try testing.expectEqual(@as(?RoundingMode, .half_expand), parseRoundingMode("halfExpand"));
+    try testing.expectEqual(@as(?RoundingMode, .trunc), parseRoundingMode("trunc"));
+    try testing.expectEqual(@as(?RoundingMode, null), parseRoundingMode("nearest"));
+}
+
+test "roundToIncrementAsIfPositive: directed modes ignore sign" {
+    // -65261246399.5 s rounded to the second (matches Instant rounding-direction.js).
+    const v: i128 = -65261246399500000000;
+    const inc: i128 = 1_000_000_000;
+    const down: i128 = -65261246400000000000; // toward -∞
+    const up: i128 = -65261246399000000000; // toward +∞
+    try testing.expectEqual(down, roundToIncrementAsIfPositive(v, inc, .floor));
+    try testing.expectEqual(down, roundToIncrementAsIfPositive(v, inc, .trunc));
+    try testing.expectEqual(up, roundToIncrementAsIfPositive(v, inc, .ceil));
+    try testing.expectEqual(up, roundToIncrementAsIfPositive(v, inc, .expand));
+    try testing.expectEqual(up, roundToIncrementAsIfPositive(v, inc, .half_expand)); // tie → +∞
+    // Sign-aware contrast: trunc → toward zero (+∞ side), expand → away (-∞ side).
+    try testing.expectEqual(up, roundToIncrement(v, inc, .trunc));
+    try testing.expectEqual(down, roundToIncrement(v, inc, .expand));
+}
+
+test "time record <-> nanoseconds round trip" {
+    const t = PlainTimeRecord{ .hour = 14, .minute = 23, .second = 30, .millisecond = 123, .microsecond = 456, .nanosecond = 789 };
+    try testing.expectEqual(@as(i128, 51810123456789), timeRecordToNanoseconds(t));
+    const back = nanosecondsToTimeRecord(timeRecordToNanoseconds(t));
+    try testing.expectEqual(@as(u32, 14), back.hour);
+    try testing.expectEqual(@as(u32, 23), back.minute);
+    try testing.expectEqual(@as(u32, 789), back.nanosecond);
+    try testing.expectEqual(@as(i128, 0), timeRecordToNanoseconds(.{}));
+    try testing.expectEqual(@as(u32, 23), nanosecondsToTimeRecord(86_399_999_999_999).hour);
+}
 
 test "durationSign: first non-zero field decides" {
     try testing.expectEqual(@as(i32, 0), durationSign(.{}));

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -1564,6 +1564,18 @@ pub fn nanosecondsToTimeRecord(ns_in_day: i128) PlainTimeRecord {
     };
 }
 
+/// Whether a duration carries calendar units (years/months/weeks),
+/// which need a relativeTo reference to interpret.
+pub fn hasCalendarUnits(d: DurationRecord) bool {
+    return d.years != 0 or d.months != 0 or d.weeks != 0;
+}
+
+/// Total nanoseconds of a calendar-unit-free duration, each day a fixed
+/// 24 h. Callers must verify `hasCalendarUnits(d)` is false first.
+pub fn dayTimeDurationNanoseconds(d: DurationRecord) i128 {
+    return f64ToI128(d.days) * 86_400_000_000_000 + timeDurationNanoseconds(d);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -1698,6 +1710,14 @@ test "time record <-> nanoseconds round trip" {
     try testing.expectEqual(@as(u32, 789), back.nanosecond);
     try testing.expectEqual(@as(i128, 0), timeRecordToNanoseconds(.{}));
     try testing.expectEqual(@as(u32, 23), nanosecondsToTimeRecord(86_399_999_999_999).hour);
+}
+
+test "dayTimeDurationNanoseconds + hasCalendarUnits" {
+    try testing.expect(!hasCalendarUnits(.{ .days = 5, .hours = 1 }));
+    try testing.expect(hasCalendarUnits(.{ .years = 1 }));
+    try testing.expect(hasCalendarUnits(.{ .weeks = 1 }));
+    try testing.expectEqual(@as(i128, 90_000_000_000_000), dayTimeDurationNanoseconds(.{ .days = 1, .hours = 1 }));
+    try testing.expectEqual(@as(i128, -86_400_000_000_000), dayTimeDurationNanoseconds(.{ .days = -1 }));
 }
 
 test "durationSign: first non-zero field decides" {

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -1787,6 +1787,93 @@ pub fn addISODate(rec: PlainDateRecord, years: i64, months: i64, weeks: i64, day
     };
 }
 
+/// §3.5.x CompareISODate — total order on ISO dates (year, then month,
+/// then day). Compares raw integer fields so the difference constrain-loop
+/// can test an unregulated (year, month, day) tuple whose day may exceed
+/// the month's length.
+fn compareISODateTuple(ay: i64, am: i64, ad: i64, by: i64, bm: i64, bd: i64) i32 {
+    if (ay != by) return if (ay < by) -1 else 1;
+    if (am != bm) return if (am < bm) -1 else 1;
+    if (ad != bd) return if (ad < bd) -1 else 1;
+    return 0;
+}
+
+pub fn compareISODate(a: PlainDateRecord, b: PlainDateRecord) i32 {
+    return compareISODateTuple(a.iso_year, a.iso_month, a.iso_day, b.iso_year, b.iso_month, b.iso_day);
+}
+
+/// Did stepping to year-month (y0, m0) with anchor day `d0` reach or pass
+/// `target` in the direction `sign`? The per-step test inside
+/// DifferenceISODate's year/month constrain-loops: balance the year-month,
+/// then compare against the *unregulated* anchor day (compareISODateTuple
+/// tolerates a day beyond the month's length).
+fn isoDateSurpasses(sign: i32, y0: i64, m0: i64, d0: i64, target: PlainDateRecord) bool {
+    const bym = balanceISOYearMonth(y0, m0);
+    const c = compareISODateTuple(bym.year, bym.month, d0, target.iso_year, target.iso_month, target.iso_day);
+    return sign * c > 0;
+}
+
+/// §3.5.x DifferenceISODate — the ISO-calendar CalendarDateUntil: the date
+/// duration {years, months, weeks, days} from `d1` to `d2`, with the
+/// coarsest component capped at `largest`. Years and months come from an
+/// estimate-then-correct constrain-loop (so Jan-31 → Mar-01 across a short
+/// February yields one month, not two); the leftover whole days are an
+/// exact epoch-day subtraction from the day-constrained year-month anchor;
+/// weeks peel off only when `largest` is `week`. The result is
+/// sign-consistent — every field shares the direction of travel — and the
+/// time fields stay zero (a date has no time-of-day).
+pub fn differenceISODate(d1: PlainDateRecord, d2: PlainDateRecord, largest: LargestUnit) DurationRecord {
+    const cmp = compareISODate(d1, d2);
+    if (cmp == 0) return .{};
+    const sign: i32 = -cmp; // +1 when d2 is after d1
+    const sg: i64 = sign; // widened for the index arithmetic
+
+    var years: i64 = 0;
+    var months: i64 = 0;
+    if (largest == .year or largest == .month) {
+        // Year estimate: jump to the raw year delta, back off one step
+        // toward d1, then advance while we have not yet passed d2.
+        var candidate_years: i64 = @as(i64, d2.iso_year) - @as(i64, d1.iso_year);
+        if (candidate_years != 0) candidate_years -= sg;
+        while (!isoDateSurpasses(sign, @as(i64, d1.iso_year) + candidate_years, d1.iso_month, d1.iso_day, d2)) {
+            years = candidate_years;
+            candidate_years += sg;
+        }
+        // Month estimate: advance month-by-month from the year anchor.
+        var candidate_months: i64 = sg;
+        var inter = balanceISOYearMonth(@as(i64, d1.iso_year) + years, @as(i64, d1.iso_month) + candidate_months);
+        while (!isoDateSurpasses(sign, inter.year, inter.month, d1.iso_day, d2)) {
+            months = candidate_months;
+            candidate_months += sg;
+            inter = balanceISOYearMonth(inter.year, inter.month + sg);
+        }
+        if (largest == .month) {
+            months += years * 12;
+            years = 0;
+        }
+    }
+
+    // Whole days: exact epoch-day delta from the constrained year-month
+    // anchor (clamps e.g. Jan-31 + 1 month to Feb-28/29) to d2.
+    const bym = balanceISOYearMonth(@as(i64, d1.iso_year) + years, @as(i64, d1.iso_month) + months);
+    const anchor = regulateISODate(bym.year, bym.month, d1.iso_day, false).?;
+    var days: i64 = daysFromCivil(d2.iso_year, d2.iso_month, d2.iso_day) -
+        daysFromCivil(anchor.iso_year, anchor.iso_month, anchor.iso_day);
+
+    var weeks: i64 = 0;
+    if (largest == .week) {
+        weeks = @divTrunc(days, 7);
+        days -= weeks * 7;
+    }
+
+    return .{
+        .years = @floatFromInt(years),
+        .months = @floatFromInt(months),
+        .weeks = @floatFromInt(weeks),
+        .days = @floatFromInt(days),
+    };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -2059,6 +2146,69 @@ test "addISODate" {
     }
     // Out of range → null.
     try testing.expect(addISODate(base, 1_000_000, 0, 0, 0, false) == null);
+}
+
+test "differenceISODate" {
+    const mk = struct {
+        fn f(y: i32, m: u8, dd: u8) PlainDateRecord {
+            return .{ .iso_year = y, .iso_month = m, .iso_day = dd };
+        }
+    }.f;
+    // largestUnit=year: 1997-12-01 → 2001-06-18 = 3y 6m 17d (until/basic.js).
+    {
+        const r = differenceISODate(mk(1997, 12, 1), mk(2001, 6, 18), .year);
+        try testing.expectEqual(@as(f64, 3), r.years);
+        try testing.expectEqual(@as(f64, 6), r.months);
+        try testing.expectEqual(@as(f64, 0), r.weeks);
+        try testing.expectEqual(@as(f64, 17), r.days);
+    }
+    // largestUnit=month: 2000-12-01 → 2001-06-01 = 6 months.
+    {
+        const r = differenceISODate(mk(2000, 12, 1), mk(2001, 6, 1), .month);
+        try testing.expectEqual(@as(f64, 0), r.years);
+        try testing.expectEqual(@as(f64, 6), r.months);
+        try testing.expectEqual(@as(f64, 0), r.days);
+    }
+    // week/day: 2000-01-01 → 2000-10-07 = 40w / 280d.
+    {
+        const w = differenceISODate(mk(2000, 1, 1), mk(2000, 10, 7), .week);
+        try testing.expectEqual(@as(f64, 40), w.weeks);
+        try testing.expectEqual(@as(f64, 0), w.days);
+        const d = differenceISODate(mk(2000, 1, 1), mk(2000, 10, 7), .day);
+        try testing.expectEqual(@as(f64, 280), d.days);
+    }
+    // weeks/months don't mix (weeks-months.js): 1969-07-24 → 1969-09-04.
+    {
+        const w = differenceISODate(mk(1969, 7, 24), mk(1969, 9, 4), .week);
+        try testing.expectEqual(@as(f64, 6), w.weeks);
+        try testing.expectEqual(@as(f64, 0), w.days);
+        const mo = differenceISODate(mk(1969, 7, 24), mk(1969, 9, 4), .month);
+        try testing.expectEqual(@as(f64, 1), mo.months);
+        try testing.expectEqual(@as(f64, 11), mo.days);
+    }
+    // Jan-31 +1mo constrains to Feb-29: 2020-01-31 → 2020-03-01 = 1m 1d.
+    {
+        const r = differenceISODate(mk(2020, 1, 31), mk(2020, 3, 1), .month);
+        try testing.expectEqual(@as(f64, 1), r.months);
+        try testing.expectEqual(@as(f64, 1), r.days);
+    }
+    // Negative direction mirrors.
+    {
+        const d = differenceISODate(mk(1969, 10, 5), mk(1969, 7, 24), .day);
+        try testing.expectEqual(@as(f64, -73), d.days);
+        const big = differenceISODate(mk(1996, 3, 3), mk(1969, 7, 24), .day);
+        try testing.expectEqual(@as(f64, -9719), big.days);
+        const y = differenceISODate(mk(2001, 6, 18), mk(1997, 12, 1), .year);
+        try testing.expectEqual(@as(f64, -3), y.years);
+        try testing.expectEqual(@as(f64, -6), y.months);
+        try testing.expectEqual(@as(f64, -17), y.days);
+    }
+    // Equal dates → zero.
+    {
+        const r = differenceISODate(mk(2020, 5, 5), mk(2020, 5, 5), .year);
+        try testing.expectEqual(@as(f64, 0), r.years);
+        try testing.expectEqual(@as(f64, 0), r.days);
+    }
 }
 
 test "durationSign: first non-zero field decides" {

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -29,6 +29,7 @@ pub const TemporalKind = enum {
     duration,
     plain_time,
     instant,
+    plain_date,
 };
 
 /// §7.5 Temporal.Duration internal slots. Each field is the ℝ
@@ -69,6 +70,15 @@ pub const InstantRecord = struct {
     epoch_ns: i128 = 0,
 };
 
+/// §3.5 Temporal.PlainDate internal slots ([[ISOYear]], [[ISOMonth]],
+/// [[ISODay]]). The calendar is always the ISO 8601 calendar, so no
+/// calendar pointer is stored; the record carries no heap reference.
+pub const PlainDateRecord = struct {
+    iso_year: i32 = 0,
+    iso_month: u8 = 1,
+    iso_day: u8 = 1,
+};
+
 /// The side allocation a Temporal instance's `JSObject` points to
 /// through `JSObjectExtension.temporal_record`. A tagged union so
 /// the single slot serves every plain Temporal type.
@@ -76,6 +86,7 @@ pub const TemporalRecord = union(TemporalKind) {
     duration: DurationRecord,
     plain_time: PlainTimeRecord,
     instant: InstantRecord,
+    plain_date: PlainDateRecord,
 
     pub fn deinit(self: *TemporalRecord, allocator: std.mem.Allocator) void {
         // No owned heap memory inside any variant today; the record
@@ -1007,11 +1018,11 @@ pub fn civilFromDays(z_in: i64) Ymd {
     return .{ .year = y + (if (m <= 2) @as(i64, 1) else 0), .month = @intCast(m), .day = @intCast(d) };
 }
 
-fn isLeapYear(y: i64) bool {
+pub fn isLeapYear(y: i64) bool {
     return (@mod(y, 4) == 0 and @mod(y, 100) != 0) or @mod(y, 400) == 0;
 }
 
-fn daysInIsoMonth(y: i64, m: u32) u32 {
+pub fn daysInIsoMonth(y: i64, m: u32) u32 {
     return switch (m) {
         1, 3, 5, 7, 8, 10, 12 => 31,
         4, 6, 9, 11 => 30,
@@ -1117,8 +1128,11 @@ pub fn parseInstantString(input: []const u8) error{Invalid}!i128 {
         } else return error.Invalid;
     } else return error.Invalid;
 
-    // Optional annotations, then the string must end.
-    try consumeAnnotations(&c);
+    // Optional annotations, then the string must end. Instant is
+    // calendar-free, so the `u-ca` value (if any) is discarded — an
+    // unknown calendar like `[u-ca=discord]` is still a valid Instant
+    // string per the grammar.
+    _ = try consumeAnnotations(&c);
     if (!c.done()) return error.Invalid;
 
     // Fold the offset in: epoch = wall-clock-as-UTC − offset.
@@ -1287,17 +1301,22 @@ fn parseFractionNs(c: *Cursor) error{Invalid}!u32 {
     return fractionToNanos(c.s[start..c.i]);
 }
 
-/// Validate and discard the trailing `[...]` annotation blocks per the
-/// RFC 9557 grammar: an optional leading time-zone annotation (an
-/// identifier, no `=`), then zero or more `key=value` annotations. At
-/// most one time-zone and at most one `u-ca` calendar annotation; a
-/// `[!key=…]` critical flag on an unknown key is rejected. Leaves the
-/// cursor at the first non-`[` byte (the caller requires end-of-input).
-fn consumeAnnotations(c: *Cursor) error{Invalid}!void {
+/// Validate the trailing `[...]` annotation blocks per the RFC 9557
+/// grammar: an optional leading time-zone annotation (an identifier, no
+/// `=`), then zero or more `key=value` annotations. At most one
+/// time-zone and at most one `u-ca` calendar annotation; a `[!key=…]`
+/// critical flag on an unknown key is rejected. Leaves the cursor at the
+/// first non-`[` byte (the caller requires end-of-input). Returns the
+/// first `u-ca` calendar value (a slice into the input) or null when no
+/// calendar annotation is present — the calendar-aware callers (e.g.
+/// PlainDate) validate it against the supported calendars, while
+/// calendar-free callers (e.g. Instant) discard it.
+fn consumeAnnotations(c: *Cursor) error{Invalid}!?[]const u8 {
     var saw_tz = false;
     var calendars: usize = 0;
     var critical_calendar = false;
     var first = true;
+    var calendar: ?[]const u8 = null;
     while (c.peek()) |ch| {
         if (ch != '[') break;
         c.i += 1; // consume '['
@@ -1320,6 +1339,7 @@ fn consumeAnnotations(c: *Cursor) error{Invalid}!void {
             if (!isValidAnnotationKey(key) or value.len == 0) return error.Invalid;
             if (std.mem.eql(u8, key, "u-ca")) {
                 calendars += 1;
+                if (calendars == 1) calendar = value;
                 if (critical) critical_calendar = true;
                 // Two or more calendar annotations are only syntactical
                 // if none carries the critical flag.
@@ -1338,6 +1358,7 @@ fn consumeAnnotations(c: *Cursor) error{Invalid}!void {
         }
         first = false;
     }
+    return calendar;
 }
 
 /// AnnotationKey :: AKeyLeadingChar (AKeyChar)*, where AKeyLeadingChar
@@ -1576,6 +1597,147 @@ pub fn dayTimeDurationNanoseconds(d: DurationRecord) i128 {
     return f64ToI128(d.days) * 86_400_000_000_000 + timeDurationNanoseconds(d);
 }
 
+// ── §3.5 PlainDate (ISO calendar) abstract operations ─────────────────────
+
+/// Inclusive day-number bounds of a representable PlainDate
+/// (-271821-04-19 .. +275760-09-13) — one ISO day beyond the
+/// representable instant range on each side.
+const iso_date_min_days: i64 = daysFromCivil(-271821, 4, 19);
+const iso_date_max_days: i64 = daysFromCivil(275760, 9, 13);
+
+/// §3.5.x IsValidISODate — structural validity: month 1..12, day within
+/// that month (leap-aware). Independent of the representable-range limit.
+pub fn isValidISODate(year: i64, month: i64, day: i64) bool {
+    if (month < 1 or month > 12) return false;
+    return day >= 1 and day <= daysInIsoMonth(year, @intCast(month));
+}
+
+/// §3.5.x ISODateWithinLimits — the date is representable.
+pub fn isoDateWithinLimits(year: i64, month: u32, day: u32) bool {
+    const d = daysFromCivil(year, month, day);
+    return d >= iso_date_min_days and d <= iso_date_max_days;
+}
+
+/// §12.x ISO weekday, 1 = Monday … 7 = Sunday (1970-01-01 was Thursday).
+pub fn isoDayOfWeek(year: i64, month: u32, day: u32) u8 {
+    return @intCast(@mod(daysFromCivil(year, month, day) + 3, 7) + 1);
+}
+
+/// §12.x Day of the year, 1-based.
+pub fn isoDayOfYear(year: i64, month: u32, day: u32) u16 {
+    return @intCast(daysFromCivil(year, month, day) - daysFromCivil(year, 1, 1) + 1);
+}
+
+pub fn isoDaysInYear(year: i64) u16 {
+    return if (isLeapYear(year)) 366 else 365;
+}
+
+fn isoYearStartShift(y: i64) i64 {
+    return @mod(y + @divFloor(y, 4) - @divFloor(y, 100) + @divFloor(y, 400), 7);
+}
+
+/// ISO weeks in a given week-year — 53 when the year starts on a
+/// Thursday (or a leap year starting Wednesday), otherwise 52.
+fn isoWeeksInYear(year: i64) i64 {
+    return if (isoYearStartShift(year) == 4 or isoYearStartShift(year - 1) == 3) 53 else 52;
+}
+
+pub const IsoWeek = struct { week: u16, year: i32 };
+
+/// §12.x ISO 8601 week-of-year + week-year. Week 1 holds the year's
+/// first Thursday; the first/last days of a calendar year can fall in
+/// the adjacent week-year.
+pub fn isoWeekOfYear(year: i64, month: u32, day: u32) IsoWeek {
+    const dow: i64 = isoDayOfWeek(year, month, day);
+    const doy: i64 = isoDayOfYear(year, month, day);
+    var week: i64 = @divFloor(doy - dow + 10, 7);
+    var wyear: i64 = year;
+    if (week < 1) {
+        wyear = year - 1;
+        week = isoWeeksInYear(wyear);
+    } else if (week > isoWeeksInYear(year)) {
+        wyear = year + 1;
+        week = 1;
+    }
+    return .{ .week = @intCast(week), .year = @intCast(wyear) };
+}
+
+/// How the ISO calendar is rendered in a date string.
+pub const CalendarDisplay = enum { auto, always, never, critical };
+
+/// §3.5.x TemporalDateToString — `YYYY-MM-DD` (expanded year when out of
+/// 0000..9999), with the ISO calendar annotation appended per
+/// `calendar` (auto/never omit it for the ISO calendar).
+pub fn isoDateToString(rec: PlainDateRecord, buf: []u8, calendar: CalendarDisplay) []const u8 {
+    var w = Writer{ .buf = buf, .len = 0 };
+    writeIsoYear(&w, rec.iso_year);
+    w.byte('-');
+    w.pad2(rec.iso_month);
+    w.byte('-');
+    w.pad2(rec.iso_day);
+    switch (calendar) {
+        .auto, .never => {},
+        .always => w.bytes("[u-ca=iso8601]"),
+        .critical => w.bytes("[!u-ca=iso8601]"),
+    }
+    return w.buf[0..w.len];
+}
+
+/// §3.5.x ParseTemporalDateString — parse the date portion of an ISO /
+/// RFC 9557 string (`YYYY-MM-DD`, expanded `±YYYYYY`, or basic),
+/// discarding (but validating) any time / offset / annotation tail.
+pub fn parseTemporalDateString(input: []const u8) error{Invalid}!PlainDateRecord {
+    var c = Cursor{ .s = input };
+    const date = try parseIsoDate(&c);
+    if (c.eatAny("Tt ")) {
+        _ = try parseIsoTime(&c);
+        // A `Z`/`z` UTC designator is rejected: a PlainDate has no time
+        // zone, so a UTC point-in-time string is ambiguous as a date
+        // (§3.5.x — ToTemporalDate throws when [[Z]] is present).
+        if (c.eatAny("Zz")) {
+            return error.Invalid;
+        } else if (c.peek()) |ch| {
+            if (ch == '+' or ch == '-') _ = try parseUtcOffsetNs(&c);
+        }
+    }
+    const calendar = try consumeAnnotations(&c);
+    if (!c.done()) return error.Invalid;
+    // PlainDate is calendar-aware: a `[u-ca=…]` annotation must name a
+    // supported calendar. Cynic ships only the ISO 8601 calendar, so an
+    // unknown calendar (`[u-ca=notexist]`) is a parse error.
+    if (calendar) |cal| {
+        if (!std.ascii.eqlIgnoreCase(cal, "iso8601")) return error.Invalid;
+    }
+    if (!isoDateWithinLimits(date.year, date.month, date.day)) return error.Invalid;
+    return .{
+        .iso_year = @intCast(date.year),
+        .iso_month = @intCast(date.month),
+        .iso_day = @intCast(date.day),
+    };
+}
+
+/// §3.5.x RegulateISODate — apply an overflow option to raw (possibly
+/// out-of-range) fields. `reject` returns null on any out-of-range
+/// field; otherwise `constrain` clamps only the *upper* bound (month to
+/// ≤12, day to ≤ that month's length). A non-positive month or day is a
+/// RangeError even under constrain (the test262 `with/overflow.js` and
+/// `from/negative-month-or-day.js` fixtures), so those return null too.
+/// Returns null when the result leaves the representable range — which
+/// also guards the i32 year cast against a huge input year.
+pub fn regulateISODate(year: i64, month: i64, day: i64, reject: bool) ?PlainDateRecord {
+    var m = month;
+    var d = day;
+    if (reject) {
+        if (!isValidISODate(year, month, day)) return null;
+    } else {
+        if (month < 1 or day < 1) return null;
+        m = @min(month, 12);
+        d = @min(day, daysInIsoMonth(year, @intCast(m)));
+    }
+    if (!isoDateWithinLimits(year, @intCast(m), @intCast(d))) return null;
+    return .{ .iso_year = @intCast(year), .iso_month = @intCast(m), .iso_day = @intCast(d) };
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -1718,6 +1880,80 @@ test "dayTimeDurationNanoseconds + hasCalendarUnits" {
     try testing.expect(hasCalendarUnits(.{ .weeks = 1 }));
     try testing.expectEqual(@as(i128, 90_000_000_000_000), dayTimeDurationNanoseconds(.{ .days = 1, .hours = 1 }));
     try testing.expectEqual(@as(i128, -86_400_000_000_000), dayTimeDurationNanoseconds(.{ .days = -1 }));
+}
+
+test "isValidISODate + isoDateWithinLimits" {
+    try testing.expect(isValidISODate(2021, 2, 28));
+    try testing.expect(!isValidISODate(2021, 2, 29)); // not a leap year
+    try testing.expect(isValidISODate(2004, 2, 29)); // leap
+    try testing.expect(!isValidISODate(2021, 13, 1));
+    try testing.expect(!isValidISODate(2021, 4, 31));
+    try testing.expect(isoDateWithinLimits(-271821, 4, 19));
+    try testing.expect(!isoDateWithinLimits(-271821, 4, 18));
+    try testing.expect(isoDateWithinLimits(275760, 9, 13));
+    try testing.expect(!isoDateWithinLimits(275760, 9, 14));
+}
+
+test "isoDayOfWeek + isoDayOfYear + daysInYear" {
+    try testing.expectEqual(@as(u8, 4), isoDayOfWeek(1970, 1, 1)); // Thursday
+    try testing.expectEqual(@as(u8, 3), isoDayOfWeek(1969, 12, 31)); // Wednesday
+    try testing.expectEqual(@as(u16, 1), isoDayOfYear(2020, 1, 1));
+    try testing.expectEqual(@as(u16, 366), isoDayOfYear(2020, 12, 31)); // leap
+    try testing.expectEqual(@as(u16, 365), isoDayOfYear(2021, 12, 31));
+    try testing.expectEqual(@as(u16, 366), isoDaysInYear(2020));
+    try testing.expectEqual(@as(u16, 365), isoDaysInYear(2021));
+}
+
+test "isoWeekOfYear: boundary weeks (matches weekOfYear/basic.js)" {
+    {
+        const w = isoWeekOfYear(1975, 12, 29);
+        try testing.expectEqual(@as(u16, 1), w.week);
+        try testing.expectEqual(@as(i32, 1976), w.year);
+    }
+    try testing.expectEqual(@as(u16, 1), isoWeekOfYear(1976, 1, 1).week);
+    try testing.expectEqual(@as(u16, 2), isoWeekOfYear(1976, 1, 5).week);
+    try testing.expectEqual(@as(u16, 52), isoWeekOfYear(1976, 12, 26).week);
+    try testing.expectEqual(@as(u16, 53), isoWeekOfYear(1976, 12, 27).week);
+    {
+        const w = isoWeekOfYear(1977, 1, 2);
+        try testing.expectEqual(@as(u16, 53), w.week);
+        try testing.expectEqual(@as(i32, 1976), w.year);
+    }
+}
+
+test "isoDateToString" {
+    var buf: [40]u8 = undefined;
+    try testing.expectEqualStrings("2000-05-02", isoDateToString(.{ .iso_year = 2000, .iso_month = 5, .iso_day = 2 }, &buf, .auto));
+    try testing.expectEqualStrings("2000-05-02[u-ca=iso8601]", isoDateToString(.{ .iso_year = 2000, .iso_month = 5, .iso_day = 2 }, &buf, .always));
+    try testing.expectEqualStrings("-009999-01-01", isoDateToString(.{ .iso_year = -9999, .iso_month = 1, .iso_day = 1 }, &buf, .never));
+}
+
+test "parseTemporalDateString + regulateISODate" {
+    {
+        const d = try parseTemporalDateString("2020-12-24");
+        try testing.expectEqual(@as(i32, 2020), d.iso_year);
+        try testing.expectEqual(@as(u8, 12), d.iso_month);
+        try testing.expectEqual(@as(u8, 24), d.iso_day);
+    }
+    // A bare time component is fine; a UTC designator (`Z`) is not — a
+    // PlainDate is time-zone-free, so a UTC point-in-time is ambiguous.
+    try testing.expectEqual(@as(u8, 18), (try parseTemporalDateString("1976-11-18T14:23:30")).iso_day);
+    try testing.expectError(error.Invalid, parseTemporalDateString("1976-11-18T14:23:30Z"));
+    try testing.expectError(error.Invalid, parseTemporalDateString("1976-11-18T14:23:30Z[UTC]"));
+    // A `u-ca` calendar annotation must name the ISO calendar.
+    try testing.expectEqual(@as(u8, 1), (try parseTemporalDateString("2020-01-01[u-ca=iso8601]")).iso_day);
+    try testing.expectError(error.Invalid, parseTemporalDateString("2020-01-01[u-ca=notexist]"));
+    try testing.expectError(error.Invalid, parseTemporalDateString("2021-02-29"));
+    try testing.expectError(error.Invalid, parseTemporalDateString("2020-13-01"));
+    try testing.expect(regulateISODate(2021, 2, 29, true) == null);
+    try testing.expectEqual(@as(u8, 28), regulateISODate(2021, 2, 29, false).?.iso_day);
+    try testing.expectEqual(@as(u8, 12), regulateISODate(2021, 20, 1, false).?.iso_month);
+    // Non-positive month/day reject even under constrain.
+    try testing.expect(regulateISODate(2000, -1, 1, false) == null);
+    try testing.expect(regulateISODate(2000, 0, 1, false) == null);
+    try testing.expect(regulateISODate(2000, 1, -1, false) == null);
+    try testing.expect(regulateISODate(2000, 1, 0, false) == null);
+    try testing.expect(regulateISODate(1_000_000_000, 1, 1, true) == null);
 }
 
 test "durationSign: first non-zero field decides" {

--- a/src/runtime/temporal.zig
+++ b/src/runtime/temporal.zig
@@ -1874,6 +1874,110 @@ pub fn differenceISODate(d1: PlainDateRecord, d2: PlainDateRecord, largest: Larg
     };
 }
 
+/// Advance `start` by the held coarser units plus `r` of the `smallest`
+/// calendar unit — the candidate end date NudgeToCalendarUnit measures
+/// against. Returns null when the result leaves the representable range.
+fn addCalendarUnit(start: PlainDateRecord, smallest: LargestUnit, hy: i64, hm: i64, r: i64) ?PlainDateRecord {
+    return switch (smallest) {
+        .year => addISODate(start, hy + r, 0, 0, 0, false),
+        .month => addISODate(start, hy, hm + r, 0, 0, false),
+        .week => addISODate(start, hy, hm, r, 0, false),
+        else => unreachable, // irregular-length calendar units only.
+    };
+}
+
+/// §7.5.31 RoundRelativeDuration / §7.5.34 NudgeToCalendarUnit — the
+/// date-only (ISO calendar, no wall-clock time, no time zone)
+/// specialization for an irregular-length calendar `smallest` unit
+/// (year/month/week). `diff` is the unrounded DifferenceISODate(start, dest,
+/// largest) span; round its `smallest` unit to a multiple of `increment`
+/// under `mode`, then re-express the rounded span from `start` capped at
+/// `largest`. Re-differencing the rounded end date folds in
+/// BubbleRelativeDuration's promotion (e.g. 1 year 12 months → 2 years) for
+/// free. A `day` smallest unit has fixed length, so it rounds by pure
+/// day-count arithmetic in the caller (NudgeToDayOrTime), not here.
+///
+/// For a date with no time-of-day the epoch-nanosecond ratios of the spec
+/// collapse to epoch-day ratios — the 86400×10^9 ns/day factor cancels in
+/// every comparison — so progress between the two candidate end dates is
+/// measured directly in days. The nine rounding modes are reused exactly by
+/// scaling the candidate values by the (positive) day-span denominator and
+/// deferring to `roundToIncrement`.
+///
+/// Returns null when a candidate end date leaves the representable ISO date
+/// range (→ the caller raises RangeError, matching AddDate overflow).
+pub fn roundRelativeDate(
+    start: PlainDateRecord,
+    dest: PlainDateRecord,
+    diff: DurationRecord,
+    smallest: LargestUnit,
+    increment: i128,
+    mode: RoundingMode,
+    largest: LargestUnit,
+) ?DurationRecord {
+    const sign: i64 = durationSign(diff);
+    if (sign == 0) return diff; // start == dest: nothing to round.
+
+    // DifferenceISODate populates only the fields from `largest` down to
+    // day, so a year/month-capped diff carries weeks == 0 and folds the
+    // sub-month remainder into days. Pick out the unit being rounded and the
+    // coarser units held fixed while it rounds.
+    const dy: i64 = @intFromFloat(diff.years);
+    const dm: i64 = @intFromFloat(diff.months);
+    const dw: i64 = @intFromFloat(diff.weeks);
+    const dd: i64 = @intFromFloat(diff.days);
+
+    var hy: i64 = 0;
+    var hm: i64 = 0;
+    var unit_val: i64 = 0;
+    switch (smallest) {
+        .year => unit_val = dy,
+        .month => {
+            hy = dy;
+            unit_val = dm;
+        },
+        .week => {
+            hy = dy;
+            hm = dm;
+            // Whole weeks in the sub-month remainder. When `largest` is week
+            // the remainder is already split (dw weeks + dd days, |dd| < 7);
+            // when it is year/month the weeks sit unsplit inside dd.
+            unit_val = @divTrunc(dw * 7 + dd, 7);
+        },
+        else => unreachable, // irregular-length calendar units only.
+    }
+
+    // r1 = unit_val truncated toward zero to a multiple of `increment`;
+    // r2 = the next multiple one increment further in the sign direction.
+    const inc: i64 = @intCast(increment);
+    const r1: i64 = @divTrunc(unit_val, inc) * inc;
+    const r2: i64 = r1 + inc * sign;
+
+    const end1 = addCalendarUnit(start, smallest, hy, hm, r1) orelse return null;
+    const end2 = addCalendarUnit(start, smallest, hy, hm, r2) orelse return null;
+
+    // Progress of `dest` between the candidates, in epoch days, normalised so
+    // the denominator is positive regardless of travel direction. `dest`
+    // always lies between end1 and end2, so num ∈ [0, denom].
+    const e1: i128 = daysFromCivil(end1.iso_year, end1.iso_month, end1.iso_day);
+    const e2: i128 = daysFromCivil(end2.iso_year, end2.iso_month, end2.iso_day);
+    const ed: i128 = daysFromCivil(dest.iso_year, dest.iso_month, dest.iso_day);
+    const sg: i128 = sign;
+    const denom: i128 = sg * (e2 - e1); // > 0
+    const num: i128 = sg * (ed - e1); // in [0, denom]
+
+    // total = r1 + (num/denom)·increment·sign. Scale by denom so the nine
+    // rounding modes reuse roundToIncrement exactly, then divide back out:
+    // rounding total to a multiple of `inc` is rounding (total·denom) to a
+    // multiple of (inc·denom). The result is r1 or r2.
+    const scaled: i128 = @as(i128, r1) * denom + sg * @as(i128, inc) * num;
+    const rounded_scaled = roundToIncrement(scaled, @as(i128, inc) * denom, mode);
+    const rounded_unit: i64 = @intCast(@divExact(rounded_scaled, denom));
+
+    const rounded_end = addCalendarUnit(start, smallest, hy, hm, rounded_unit) orelse return null;
+    return differenceISODate(start, rounded_end, largest);
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 const testing = std.testing;
@@ -2209,6 +2313,58 @@ test "differenceISODate" {
         try testing.expectEqual(@as(f64, 0), r.years);
         try testing.expectEqual(@as(f64, 0), r.days);
     }
+}
+
+test "roundRelativeDate: calendar-unit rounding (until/since fixtures)" {
+    const mk = struct {
+        fn f(y: i32, m: u8, dd: u8) PlainDateRecord {
+            return .{ .iso_year = y, .iso_month = m, .iso_day = dd };
+        }
+    }.f;
+    // Round start→dest under (smallest, increment, mode), capped at largest,
+    // and assert the {years, months, weeks, days} of the rounded duration.
+    const check = struct {
+        fn f(
+            start: PlainDateRecord,
+            dest: PlainDateRecord,
+            smallest: LargestUnit,
+            increment: i128,
+            mode: RoundingMode,
+            largest: LargestUnit,
+            ey: f64,
+            em: f64,
+            ew: f64,
+            ed: f64,
+        ) !void {
+            const diff = differenceISODate(start, dest, largest);
+            const r = roundRelativeDate(start, dest, diff, smallest, increment, mode, largest).?;
+            try testing.expectEqual(ey, r.years);
+            try testing.expectEqual(em, r.months);
+            try testing.expectEqual(ew, r.weeks);
+            try testing.expectEqual(ed, r.days);
+        }
+    }.f;
+
+    // roundingmode-ceil.js: 2019-01-08 → 2021-09-07 (1y/31m/139w/973d raw).
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .year, 1, .ceil, .year, 3, 0, 0, 0);
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .month, 1, .ceil, .month, 0, 32, 0, 0);
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .week, 1, .ceil, .week, 0, 0, 139, 0);
+    // reverse direction (later → earlier): ceil rounds toward zero.
+    try check(mk(2021, 9, 7), mk(2019, 1, 8), .year, 1, .ceil, .year, -2, 0, 0, 0);
+    try check(mk(2021, 9, 7), mk(2019, 1, 8), .month, 1, .ceil, .month, 0, -31, 0, 0);
+    try check(mk(2021, 9, 7), mk(2019, 1, 8), .week, 1, .ceil, .week, 0, 0, -139, 0);
+
+    // roundingincrement.js: same dates, halfExpand with various increments.
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .year, 4, .half_expand, .year, 4, 0, 0, 0);
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .month, 10, .half_expand, .month, 0, 30, 0, 0);
+    try check(mk(2019, 1, 8), mk(2021, 9, 7), .week, 12, .half_expand, .week, 0, 0, 144, 0);
+
+    // round-cross-unit-boundary.js: largestUnit=year bubbles 1y 12m → 2y.
+    try check(mk(2022, 1, 1), mk(2023, 12, 25), .month, 1, .expand, .year, 2, 0, 0, 0);
+
+    // rounding-relative.js: half ties decided by the day fraction.
+    try check(mk(2019, 1, 1), mk(2019, 2, 15), .month, 1, .half_expand, .month, 0, 2, 0, 0); // 14/28 = 0.5 → up
+    try check(mk(2019, 2, 15), mk(2019, 1, 1), .month, 1, .half_expand, .month, 0, -1, 0, 0); // 14/31 < 0.5 → toward zero
 }
 
 test "durationSign: first non-zero field decides" {

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -2398,6 +2398,21 @@ fn classifyAndRun(
 
     var test_threw = run_result == .thrown;
 
+    // Root a synchronously-thrown error across the microtask drain
+    // below. `run_result.thrown` lives only in this native local —
+    // `evaluateScript` hands the exception back and clears
+    // `realm.pending_exception`, so the realm root walk can't see
+    // it. Under `--gc-threshold=1` the drain's allocations would
+    // otherwise sweep the error object before the failure-message
+    // read further down dereferences it. Held open for the rest of
+    // `classifyAndRun` via the deferred close.
+    const thrown_scope: ?*cynic.runtime.heap.HandleScope = if (run_result == .thrown)
+        (realm.heap.openScope() catch null)
+    else
+        null;
+    defer if (thrown_scope) |s| s.close();
+    if (thrown_scope) |s| s.push(run_result.thrown) catch {};
+
     // Drain any microtasks queued during the test body. This
     // matches §9.4 — every host completes the current Job before
     // returning to the runner. Microtask exceptions go to the

--- a/tools/test262/ses_divergent.zig
+++ b/tools/test262/ses_divergent.zig
@@ -273,6 +273,23 @@ pub const divergent_paths = [_]struct { path: []const u8, category: Category }{
         .path = "built-ins/ShadowRealm/prototype/evaluate/wrapped-functions-share-no-properties-extended.js",
         .category = .frozen_intrinsic_typeerror,
     },
+    .{
+        // §8.4.4 / §8.4.5 `Temporal.Instant.prototype.epochMilliseconds`
+        // / `epochNanoseconds` getters — the fixture asserts
+        // `desc.configurable === true` directly. Cynic's SES freeze
+        // demotes every intrinsic accessor to `configurable: false`
+        // (verified: hardened → false, `--unhardened` → true, exactly
+        // matching every other Temporal getter), so the assert fires
+        // the generic `Expected SameValue(«false», «true») to be true`.
+        // Generic-shape message — path-classify, like the Iterator
+        // accessor entries above.
+        .path = "built-ins/Temporal/Instant/prototype/epochMilliseconds/prop-desc.js",
+        .category = .descriptor_assertion,
+    },
+    .{
+        .path = "built-ins/Temporal/Instant/prototype/epochNanoseconds/prop-desc.js",
+        .category = .descriptor_assertion,
+    },
 };
 
 /// Path-based divergence lookup — the escape hatch for
@@ -362,6 +379,10 @@ test "classifyByPath: known generic-message divergent path" {
     try std.testing.expectEqual(
         @as(?Category, .frozen_intrinsic_typeerror),
         classifyByPath("language/global-code/decl-lex-configurable-global.js"),
+    );
+    try std.testing.expectEqual(
+        @as(?Category, .descriptor_assertion),
+        classifyByPath("built-ins/Temporal/Instant/prototype/epochMilliseconds/prop-desc.js"),
     );
 }
 

--- a/tools/test262/ses_divergent.zig
+++ b/tools/test262/ses_divergent.zig
@@ -290,6 +290,28 @@ pub const divergent_paths = [_]struct { path: []const u8, category: Category }{
         .path = "built-ins/Temporal/Instant/prototype/epochNanoseconds/prop-desc.js",
         .category = .descriptor_assertion,
     },
+    // §3.3.x `Temporal.PlainDate.prototype` getters — each fixture
+    // asserts `desc.configurable === true` directly. Cynic's SES freeze
+    // demotes every intrinsic accessor to `configurable: false`
+    // (verified: hardened → false, `--unhardened` → true), so each
+    // fires the generic `Expected SameValue(«false», «true») to be true`.
+    // Generic-shape message — path-classify, like the Instant getters.
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/calendarId/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/year/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/month/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/monthCode/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/day/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/dayOfWeek/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/dayOfYear/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/weekOfYear/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/yearOfWeek/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/daysInWeek/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/daysInMonth/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/daysInYear/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/monthsInYear/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/inLeapYear/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/era/prop-desc.js", .category = .descriptor_assertion },
+    .{ .path = "built-ins/Temporal/PlainDate/prototype/eraYear/prop-desc.js", .category = .descriptor_assertion },
 };
 
 /// Path-based divergence lookup — the escape hatch for
@@ -383,6 +405,10 @@ test "classifyByPath: known generic-message divergent path" {
     try std.testing.expectEqual(
         @as(?Category, .descriptor_assertion),
         classifyByPath("built-ins/Temporal/Instant/prototype/epochMilliseconds/prop-desc.js"),
+    );
+    try std.testing.expectEqual(
+        @as(?Category, .descriptor_assertion),
+        classifyByPath("built-ins/Temporal/PlainDate/prototype/year/prop-desc.js"),
     );
 }
 

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -1150,22 +1150,30 @@ pub const single_realm_path_contains = [_][]const u8{
 // scoreboard in 0 / N noise.
 
 pub const deferred_path_prefixes = [_][]const u8{
-    // Temporal is a large Stage 4 surface (Duration / PlainTime /
-    // Instant / PlainDate / Calendar / TimeZone / ZonedDateTime / …).
-    // The implementation is being carried on a dedicated branch;
-    // on `main` the whole `built-ins/Temporal/` tree is skipped so
-    // the partial in-progress surface (constructors + a few methods,
-    // with the arithmetic-heavy `round` / `total` / `until` / `since`
-    // / `add` / `subtract` / `compare` paths unfinished) doesn't
-    // drown the runtime scoreboard in failing-method noise. The
-    // committed Temporal source stays in the tree — it's just not
-    // scored here until the dedicated effort lands the full surface
-    // and re-narrows this skip per-type.
-    "built-ins/Temporal/",
-    // `Date.prototype.toTemporalInstant` is part of the Temporal
-    // proposal surface; skipped on the same rationale until Temporal
-    // lands. ~7 fixtures.
-    "built-ins/Date/prototype/toTemporalInstant/",
+    // Temporal is a large Stage 4 surface (Calendar / TimeZone /
+    // PlainDate / …). On `main` the whole `built-ins/Temporal/` tree
+    // is blanket-skipped while the full implementation is carried here
+    // on the dedicated branch; this branch re-narrows the skip
+    // per-type as each lands. Cynic ships the self-contained,
+    // calendar- and time-zone-free value types so far —
+    // `Temporal.Duration` (§7), `Temporal.PlainTime` (§4), and
+    // `Temporal.Instant` (§8) — and those subtrees run; the remaining
+    // types stay skipped per-subtree until their implementation lands.
+    // As each type ships, drop its line.
+    "built-ins/Temporal/Now/",
+    "built-ins/Temporal/PlainDate/",
+    "built-ins/Temporal/PlainDateTime/",
+    "built-ins/Temporal/PlainMonthDay/",
+    "built-ins/Temporal/PlainYearMonth/",
+    "built-ins/Temporal/ZonedDateTime/",
+    // `built-ins/Temporal/getOwnPropertyNames.js` asserts every one
+    // of the nine type names is an own property of the `Temporal`
+    // namespace. Cynic installs only Duration + PlainTime + Instant
+    // so far, so this one fixture fails until the namespace is
+    // complete. The sibling `prop-desc.js` / `keys.js` (which only
+    // probe the namespace's own descriptor + that it has no
+    // enumerable keys) pass and stay in scope.
+    "built-ins/Temporal/getOwnPropertyNames.js",
 };
 
 // ── --allow=eval-dependent ──────────────────────────────────────────

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -1156,12 +1156,12 @@ pub const deferred_path_prefixes = [_][]const u8{
     // on the dedicated branch; this branch re-narrows the skip
     // per-type as each lands. Cynic ships the self-contained,
     // calendar- and time-zone-free value types so far —
-    // `Temporal.Duration` (§7), `Temporal.PlainTime` (§4), and
-    // `Temporal.Instant` (§8) — and those subtrees run; the remaining
-    // types stay skipped per-subtree until their implementation lands.
-    // As each type ships, drop its line.
+    // `Temporal.Duration` (§7), `Temporal.PlainTime` (§4),
+    // `Temporal.Instant` (§8), and `Temporal.PlainDate` (§3, ISO
+    // calendar only) — and those subtrees run; the remaining types
+    // stay skipped per-subtree until their implementation lands. As
+    // each type ships, drop its line.
     "built-ins/Temporal/Now/",
-    "built-ins/Temporal/PlainDate/",
     "built-ins/Temporal/PlainDateTime/",
     "built-ins/Temporal/PlainMonthDay/",
     "built-ins/Temporal/PlainYearMonth/",
@@ -1169,7 +1169,7 @@ pub const deferred_path_prefixes = [_][]const u8{
     // `built-ins/Temporal/getOwnPropertyNames.js` asserts every one
     // of the nine type names is an own property of the `Temporal`
     // namespace. Cynic installs only Duration + PlainTime + Instant
-    // so far, so this one fixture fails until the namespace is
+    // + PlainDate so far, so this one fixture fails until the namespace is
     // complete. The sibling `prop-desc.js` / `keys.js` (which only
     // probe the namespace's own descriptor + that it has no
     // enumerable keys) pass and stay in scope.
@@ -1420,7 +1420,7 @@ test "skip: main-spec paths not OOS" {
 
 test "skip: Temporal out of scope" {
     try testing.expect(pathIsCynicOutOfScope("built-ins/Temporal/Now/extensible.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Temporal/PlainDate/prototype/add/branding.js"));
+    try testing.expect(pathIsCynicOutOfScope("built-ins/Temporal/PlainDateTime/prototype/add/branding.js"));
 }
 
 test "skip: ShadowRealm is not path-skipped (feature-gated)" {


### PR DESCRIPTION
## Summary

Ships the TC39 **Temporal** proposal — the full value-type surface plus
`Temporal.Now`, on the ISO-8601 calendar with UTC / fixed-offset time
zones.

The eight value types — `Instant`, `PlainTime`, `PlainDate`,
`PlainDateTime`, `PlainYearMonth`, `PlainMonthDay`, `Duration`,
`ZonedDateTime` — each land with their constructor, getters,
`from` / `compare`, `with*`, the arithmetic chain
(`add` / `subtract` / `until` / `since`), `round` / `total`, the
`toString` / `toJSON` / `toLocaleString` family with precision +
rounding options, and ISO-8601 string parsing. Plus `Temporal.Now`
(§2) and `Date.prototype.toTemporalInstant`.

Arithmetic and rounding run through the spec abstract operations
(RoundNumberToIncrement, the duration balance / round / difference
chain, NudgeToCalendarUnit / BubbleRelativeDuration for calendar-unit
rounding, RoundRelativeDuration), named to match proposal-temporal so
test262 failures map to spec steps.

## Scope

- **ISO-8601 calendar only.** Non-ISO calendars need the CLDR/ICU stack
  the default edge build omits — deferred.
- **UTC + fixed-offset time zones only.** No vendored IANA `tzdata`, so
  named zones (`"America/New_York"`) and DST transitions are deferred.
  Every offset lookup routes through one `getOffsetNanosecondsFor` seam,
  so a tzdata provider drops in at a single place later (see ROADMAP
  "Intl").

## Conformance (test262, runtime mode)

- `built-ins/Temporal`: **3885 pass / 0 fail / 0 skip**, 703 divergent
  (SES policy, 100% / 100%).
- Overall corpus: 84.36% -> **94.56%** SES-adjusted (delta **+4596** pass);
  unhardened 94.56%.
- SES witnesses: **10 / 10**.
- The 9 remaining corpus fails are the pre-existing libregexp Annex-B /
  `/v` carve-outs — unrelated to Temporal, present on `main` before this
  branch.

## Test plan

- [x] `zig build` — CI gate 1
- [x] `zig build test` — CI gate 2 (unit tests)
- [x] `zig build test262 -- --quiet --write-results` — full sweep, 0 Temporal fails
- [x] Filtered `--top-rss` leak check in the healthy band