### PR TITLE
refactor: consolidate native-method registration onto a shared primitive

### DIFF
--- a/src/runtime/builtins/async_iterator.zig
+++ b/src/runtime/builtins/async_iterator.zig
@@ -34,24 +34,13 @@ pub fn ensureAsyncFromSyncIteratorPrototype(realm: *Realm) !*JSObject {
     const proto = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(proto, try lantern.ensureAsyncIteratorPrototype(realm));
 
-    try installMethod(realm, proto, "next", afsiNext, 1);
-    try installMethod(realm, proto, "return", afsiReturn, 1);
-    try installMethod(realm, proto, "throw", afsiThrow, 1);
+    try intrinsics_mod.installNativeMethodOnProto(realm, proto, "next", afsiNext, 1);
+    try intrinsics_mod.installNativeMethodOnProto(realm, proto, "return", afsiReturn, 1);
+    try intrinsics_mod.installNativeMethodOnProto(realm, proto, "throw", afsiThrow, 1);
 
     realm.intrinsics.async_from_sync_iterator_prototype = proto;
     @import("harden.zig").freezeLazyIntrinsic(realm, proto) catch return error.OutOfMemory;
     return proto;
-}
-
-fn installMethod(realm: *Realm, proto: *JSObject, name: []const u8, native: anytype, params: u8) !void {
-    const fn_obj = try realm.heap.allocateFunctionNative(native, params, name);
-    fn_obj.has_construct = false;
-    fn_obj.proto = realm.intrinsics.function_prototype;
-    try proto.setWithFlags(realm.allocator, name, heap_mod.taggedFunction(fn_obj), .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    });
 }
 
 /// §27.6.1.1 CreateAsyncFromSyncIterator — wrap `sync_iter` in a

--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -1538,9 +1538,7 @@ pub fn installSet(realm: *Realm) !void {
     // §24.2.3 — `Set.prototype.values`, `.keys`, and `@@iterator`
     // are required to be the *same* function object. Allocate
     // once and install it under all three names.
-    const values_fn = try realm.heap.allocateFunctionNative(setValuesMethod, 0, "values");
-    values_fn.has_construct = false;
-    values_fn.proto = realm.intrinsics.function_prototype;
+    const values_fn = try intrinsics.makeNativeFunction(realm, setValuesMethod, 0, "values");
     const values_v = heap_mod.taggedFunction(values_fn);
     try proto.setWithFlags(realm.allocator, "values", values_v, .{ .writable = true, .enumerable = false, .configurable = true });
     try proto.setWithFlags(realm.allocator, "keys", values_v, .{ .writable = true, .enumerable = false, .configurable = true });

--- a/src/runtime/builtins/iterator.zig
+++ b/src/runtime/builtins/iterator.zig
@@ -346,23 +346,8 @@ fn ensureWrapForValidIteratorPrototype(realm: *Realm) !*JSObject {
     const proto = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(proto, ctor.prototype); // %Iterator.prototype%
 
-    const next_fn = try realm.heap.allocateFunctionNative(wrappedNext, 0, "next");
-    next_fn.has_construct = false;
-    next_fn.proto = realm.intrinsics.function_prototype;
-    try proto.setWithFlags(realm.allocator, "next", heap_mod.taggedFunction(next_fn), .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    });
-
-    const return_fn = try realm.heap.allocateFunctionNative(wrappedReturn, 0, "return");
-    return_fn.has_construct = false;
-    return_fn.proto = realm.intrinsics.function_prototype;
-    try proto.setWithFlags(realm.allocator, "return", heap_mod.taggedFunction(return_fn), .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    });
+    try intrinsics.installNativeMethodOnProto(realm, proto, "next", wrappedNext, 0);
+    try intrinsics.installNativeMethodOnProto(realm, proto, "return", wrappedReturn, 0);
 
     realm.intrinsics.wrap_for_valid_iterator_prototype = proto;
     // SES: lock the lazy proto so user JS can't monkey-patch its

--- a/src/runtime/builtins/json.zig
+++ b/src/runtime/builtins/json.zig
@@ -118,28 +118,15 @@ pub fn install(realm: *Realm) !void {
     const json_obj = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(json_obj, realm.intrinsics.object_prototype);
     try installToStringTag(realm, json_obj, "JSON");
-    // §17 — built-in methods are non-enumerable (writable +
-    // configurable). The default `set` would mark them
-    // enumerable, which the prop-desc tests reject.
-    const method_flags: @import("../object.zig").PropertyFlags = .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    };
-    const stringify_fn = try realm.heap.allocateFunctionNative(jsonStringify, 3, "stringify");
-    stringify_fn.has_construct = false;
-    try json_obj.setWithFlags(realm.allocator, "stringify", heap_mod.taggedFunction(stringify_fn), method_flags);
-    const parse_fn = try realm.heap.allocateFunctionNative(jsonParse, 2, "parse");
-    parse_fn.has_construct = false;
-    try json_obj.setWithFlags(realm.allocator, "parse", heap_mod.taggedFunction(parse_fn), method_flags);
+    // §17 — built-in methods install non-enumerable, non-
+    // constructor, with `[[Realm]]` set; `installNativeMethodOnProto`
+    // stamps that canonical shape so each site doesn't re-spell it.
+    try intrinsics.installNativeMethodOnProto(realm, json_obj, "stringify", jsonStringify, 3);
+    try intrinsics.installNativeMethodOnProto(realm, json_obj, "parse", jsonParse, 2);
     // §25.5.4 / §25.5.3 — JSON.rawJSON / JSON.isRawJSON
     // (json-parse-with-source, Stage 4 ES2025).
-    const raw_json_fn = try realm.heap.allocateFunctionNative(jsonRawJSON, 1, "rawJSON");
-    raw_json_fn.has_construct = false;
-    try json_obj.setWithFlags(realm.allocator, "rawJSON", heap_mod.taggedFunction(raw_json_fn), method_flags);
-    const is_raw_json_fn = try realm.heap.allocateFunctionNative(jsonIsRawJSON, 1, "isRawJSON");
-    is_raw_json_fn.has_construct = false;
-    try json_obj.setWithFlags(realm.allocator, "isRawJSON", heap_mod.taggedFunction(is_raw_json_fn), method_flags);
+    try intrinsics.installNativeMethodOnProto(realm, json_obj, "rawJSON", jsonRawJSON, 1);
+    try intrinsics.installNativeMethodOnProto(realm, json_obj, "isRawJSON", jsonIsRawJSON, 1);
     try realm.globals.put(realm.allocator, "JSON", heap_mod.taggedObject(json_obj));
 }
 

--- a/src/runtime/builtins/math.zig
+++ b/src/runtime/builtins/math.zig
@@ -93,17 +93,11 @@ pub fn install(realm: *Realm) !void {
         // summation over an iterable of Numbers.
         .{ .name = "sumPrecise", .fn_ptr = mathSumPrecise, .params = 1 },
     };
-    // §17 — built-in methods are `[[Writable]]: true`,
-    // `[[Enumerable]]: false`, `[[Configurable]]: true`.
-    const method_flags: @import("../object.zig").PropertyFlags = .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    };
+    // §17 — built-in methods install non-enumerable, non-
+    // constructor, `[[Realm]]`-stamped; the shared helper spells
+    // that canonical shape once.
     for (methods) |m| {
-        const fn_obj = try realm.heap.allocateFunctionNative(m.fn_ptr, m.params, m.name);
-        fn_obj.has_construct = false; // §17 — Math.* aren't constructors.
-        try math_obj.setWithFlags(realm.allocator, m.name, heap_mod.taggedFunction(fn_obj), method_flags);
+        try intrinsics.installNativeMethodOnProto(realm, math_obj, m.name, m.fn_ptr, m.params);
     }
     try realm.globals.put(realm.allocator, "Math", heap_mod.taggedObject(math_obj));
 }

--- a/src/runtime/builtins/number.zig
+++ b/src/runtime/builtins/number.zig
@@ -60,13 +60,12 @@ pub fn install(realm: *Realm) !void {
     // `Number.parseFloat === parseFloat`: the SAME function
     // object on both bindings. Install once, then alias on
     // Number with the spec-mandated `{ w, !e, c }` flags.
-    const pi = try realm.heap.allocateFunctionNative(parseIntNative, 2, "parseInt");
-    // §20.1.1 — built-in function objects don't implement [[Construct]]
-    // unless explicitly specified. `new parseInt(...)` must throw.
-    pi.has_construct = false;
+    // §20.1.1 — built-in function objects don't implement
+    // [[Construct]] unless explicitly specified (`new parseInt(...)`
+    // throws); `makeNativeFunction` stamps that shape plus [[Realm]].
+    const pi = try intrinsics.makeNativeFunction(realm, parseIntNative, 2, "parseInt");
     try realm.globals.put(realm.allocator, "parseInt", heap_mod.taggedFunction(pi));
-    const pf = try realm.heap.allocateFunctionNative(parseFloatNative, 1, "parseFloat");
-    pf.has_construct = false;
+    const pf = try intrinsics.makeNativeFunction(realm, parseFloatNative, 1, "parseFloat");
     try realm.globals.put(realm.allocator, "parseFloat", heap_mod.taggedFunction(pf));
     if (heap_mod.valueAsFunction(realm.globals.get("Number").?)) |num_ctor| {
         try num_ctor.setWithFlags(realm.allocator, "parseInt", heap_mod.taggedFunction(pi), .{
@@ -80,11 +79,9 @@ pub fn install(realm: *Realm) !void {
             .configurable = true,
         });
     }
-    const inn = try realm.heap.allocateFunctionNative(globalIsNaN, 1, "isNaN");
-    inn.has_construct = false;
+    const inn = try intrinsics.makeNativeFunction(realm, globalIsNaN, 1, "isNaN");
     try realm.globals.put(realm.allocator, "isNaN", heap_mod.taggedFunction(inn));
-    const ifn = try realm.heap.allocateFunctionNative(globalIsFinite, 1, "isFinite");
-    ifn.has_construct = false;
+    const ifn = try intrinsics.makeNativeFunction(realm, globalIsFinite, 1, "isFinite");
     try realm.globals.put(realm.allocator, "isFinite", heap_mod.taggedFunction(ifn));
 }
 

--- a/src/runtime/builtins/regexp.zig
+++ b/src/runtime/builtins/regexp.zig
@@ -78,17 +78,17 @@ pub fn install(realm: *Realm) !void {
     // subclass behaviour mostly works through the back door.
     // §17 — the spec mandates that well-known-symbol-keyed methods
     // have a `name` property of `"[Symbol.X]"`, not the internal
-    // canonical `"@@X"` key Cynic uses for dispatch. Install via a
-    // helper that registers the function under the `"@@X"` key but
-    // sets its `name` property to the bracketed form.
-    try installSymbolMethod(realm, proto, "@@match", "[Symbol.match]", regexpProtoMatch, 1);
-    try installSymbolMethod(realm, proto, "@@replace", "[Symbol.replace]", regexpProtoReplace, 2);
-    try installSymbolMethod(realm, proto, "@@search", "[Symbol.search]", regexpProtoSearch, 1);
-    try installSymbolMethod(realm, proto, "@@split", "[Symbol.split]", regexpProtoSplit, 2);
+    // canonical `"@@X"` key Cynic uses for dispatch.
+    // `installNativeMethodOnProto` registers under the `"@@X"` key
+    // and derives the bracketed `name` form from it.
+    try installNativeMethodOnProto(realm, proto, "@@match", regexpProtoMatch, 1);
+    try installNativeMethodOnProto(realm, proto, "@@replace", regexpProtoReplace, 2);
+    try installNativeMethodOnProto(realm, proto, "@@search", regexpProtoSearch, 1);
+    try installNativeMethodOnProto(realm, proto, "@@split", regexpProtoSplit, 2);
     // §22.2.5.9 RegExp.prototype[@@matchAll] — step-by-step traversal
     // of the spec algorithm so the species-ctor, flag-cloning, and
     // cached-lastIndex side effects line up with the fixtures.
-    try installSymbolMethod(realm, proto, "@@matchAll", "[Symbol.matchAll]", regexpProtoMatchAll, 1);
+    try installNativeMethodOnProto(realm, proto, "@@matchAll", regexpProtoMatchAll, 1);
 
     // §22.2.6.{3, 4, 5, 6, 7, 9, 10, 11, 13, 14} — accessors on
     // RegExp.prototype that surface the instance's
@@ -135,26 +135,6 @@ fn regexpSpeciesGetter(realm: *Realm, this_value: Value, args: []const Value) Na
 /// Install a method whose property key is Cynic's `"@@<name>"`
 /// canonical form for a well-known Symbol, but whose `name`
 /// property reports the spec-mandated `"[Symbol.<name>]"`.
-/// §17 — built-in function `name` must match the spec table.
-fn installSymbolMethod(
-    realm: *Realm,
-    proto: *JSObject,
-    key: []const u8,
-    display_name: []const u8,
-    native: @import("../function.zig").NativeFn,
-    params: u8,
-) !void {
-    // Allocate the function with the spec-mandated display name so
-    // `f.name` and the `name` own-property point at the same JSString.
-    const fn_obj = try realm.heap.allocateFunctionNative(native, params, display_name);
-    fn_obj.has_construct = false;
-    try proto.setWithFlags(realm.allocator, key, heap_mod.taggedFunction(fn_obj), .{
-        .writable = true,
-        .enumerable = false,
-        .configurable = true,
-    });
-}
-
 /// §22.2.5.8 RegExp.prototype [ @@match ] ( string ). A step-by-
 /// step traversal of the spec algorithm so each observable side
 /// effect (`Get(rx, "flags")`, the global-only `Get(rx,

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -911,16 +911,31 @@ fn stubConstructorNative(realm: *Realm, this_value: Value, args: []const Value) 
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-pub fn installNativeMethod(realm: *Realm, target: *JSFunction, name: []const u8, native: NativeFn, params: u8) !void {
+/// Allocate a built-in callable with the shape every §17 built-in
+/// function shares, but install it nowhere. The caller decides
+/// where the resulting object lives — a global binding, a
+/// constructor static, a prototype method, or several of those at
+/// once (e.g. `parseInt === Number.parseInt`, or the single
+/// `Set.prototype.values` function aliased onto `keys` and
+/// `@@iterator`). Use `installNativeMethod` /
+/// `installNativeMethodOnProto` when the function lands on exactly
+/// one target with the standard `{w:t,e:f,c:t}` data descriptor.
+///
+///   - `[[Construct]]` absent — §17 built-ins aren't constructors
+///     unless explicitly identified as such; `new parseInt()` throws.
+///   - `[[Realm]]` = the installing realm (§10.2.5) — the cross-realm
+///     species / brand carve-outs read this back.
+///   - `[[Prototype]]` = `%Function.prototype%` (§20.2.3) — already
+///     wired by `allocateFunctionNative`.
+pub fn makeNativeFunction(realm: *Realm, native: NativeFn, params: u8, name: []const u8) !*JSFunction {
     const fn_obj = try realm.heap.allocateFunctionNative(native, params, name);
-    // §17 — these are built-in static methods (e.g. `Object.keys`,
-    // `Promise.all`); spec says they don't have `[[Construct]]`
-    // unless explicitly identified as constructors.
     fn_obj.has_construct = false;
-    // §10.2.5 — the function's realm is the one whose intrinsics
-    // it was installed into. ArraySpeciesCreate and the rest of
-    // the cross-realm carve-outs read this back.
     fn_obj.realm = realm;
+    return fn_obj;
+}
+
+pub fn installNativeMethod(realm: *Realm, target: *JSFunction, name: []const u8, native: NativeFn, params: u8) !void {
+    const fn_obj = try makeNativeFunction(realm, native, params, name);
     // §17 — built-in own data property descriptors are non-
     // enumerable by default. Enumerable methods cause the
     // test262 `prop-desc.js` and `not-a-constructor.js` checks
@@ -1086,13 +1101,7 @@ pub fn installNativeMethodOnProto(realm: *Realm, proto: *JSObject, name: []const
         std.fmt.allocPrint(realm.classAllocator(), "[Symbol.{s}]", .{name[2..]}) catch return error.OutOfMemory
     else
         name;
-    const fn_obj = try realm.heap.allocateFunctionNative(native, params, fn_name);
-    // §17 — built-in prototype methods are not constructors.
-    fn_obj.has_construct = false;
-    // §10.2.5 — proto methods carry the realm they were installed
-    // into (e.g. `Array.prototype.map` installed on Realm A always
-    // returns Realm A's `%Array%` from ArraySpeciesCreate).
-    fn_obj.realm = realm;
+    const fn_obj = try makeNativeFunction(realm, native, params, fn_name);
     // §17 — built-in methods install with `enumerable: false`
     // so they don't surface in `for-in` over user objects that
     // inherit from these prototypes. `writable` and

--- a/src/runtime/surface_audit_test.zig
+++ b/src/runtime/surface_audit_test.zig
@@ -330,3 +330,107 @@ test "surface audit: intrinsic prototypes expose only spec-defined names" {
 
     try testing.expect(all_ok);
 }
+
+const heap_mod = @import("heap.zig");
+
+/// Assert that `target[key]` is a built-in *method* with the
+/// canonical §17 / §10.2.5 shape that the shared
+/// `intrinsics.installNativeMethod*` helpers produce:
+///
+///   - the value is a callable function object;
+///   - `[[Construct]]` is absent (`has_construct == false`) — §17
+///     built-in methods are not constructors;
+///   - `[[Prototype]]` is `%Function.prototype%` (§20.2.3);
+///   - `[[Realm]]` is the installing realm (§10.2.5) — the raw
+///     `allocateFunctionNative` + manual-flag sites this audit
+///     guards historically *forgot* to set this, leaving cross-
+///     realm species/brand checks to read `null`;
+///   - the own data descriptor is `{ w:true, e:false, c:true }`.
+///
+/// `expected_name` pins the function's `name` slot (for symbol-keyed
+/// methods the spec form is `"[Symbol.<descr>]"`, not the `@@<descr>`
+/// storage key).
+fn expectCanonicalMethod(
+    realm: *Realm,
+    target: *JSObject,
+    key: []const u8,
+    expected_name: []const u8,
+) !void {
+    const v = target.lookupOwn(key) orelse {
+        std.debug.print("[method-shape] missing own method \"{s}\"\n", .{key});
+        return error.MissingMethod;
+    };
+    const fn_obj = heap_mod.valueAsFunction(v) orelse {
+        std.debug.print("[method-shape] \"{s}\" is not a function\n", .{key});
+        return error.NotAFunction;
+    };
+
+    try testing.expect(!fn_obj.has_construct);
+    // Pointer identity via `==` (not `expectEqual`) so a mismatch
+    // doesn't dump the entire Realm / JSObject struct to stderr.
+    try testing.expect(fn_obj.proto == realm.intrinsics.function_prototype);
+    try testing.expect(fn_obj.realm == realm);
+
+    const flags = target.flagsFor(key);
+    try testing.expect(flags.writable);
+    try testing.expect(!flags.enumerable);
+    try testing.expect(flags.configurable);
+
+    try testing.expect(fn_obj.name != null);
+    try testing.expectEqualStrings(expected_name, fn_obj.name.?);
+}
+
+test "method-registration shape: built-in object methods carry the canonical §17/§10.2.5 descriptor" {
+    // Unhardened so the SES freeze pass doesn't rewrite the
+    // descriptors out from under the audit — this pins the shape
+    // the install helpers *produce*, before any hardening.
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    const json_v = realm.globals.get("JSON") orelse return error.NoJSON;
+    const json_obj = heap_mod.valueAsPlainObject(json_v) orelse return error.JSONNotObject;
+
+    try expectCanonicalMethod(&realm, json_obj, "stringify", "stringify");
+    try expectCanonicalMethod(&realm, json_obj, "parse", "parse");
+    try expectCanonicalMethod(&realm, json_obj, "rawJSON", "rawJSON");
+    try expectCanonicalMethod(&realm, json_obj, "isRawJSON", "isRawJSON");
+}
+
+test "method-registration shape: global built-in functions carry [[Realm]] and aren't constructors" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    // §19.2 — `parseInt` / `parseFloat` / `isNaN` / `isFinite` are
+    // ordinary built-in functions installed straight onto the global
+    // object, allocated via `makeNativeFunction`.
+    const target: *JSObject = realm.globals.target.?;
+    try expectCanonicalMethod(&realm, target, "parseInt", "parseInt");
+    try expectCanonicalMethod(&realm, target, "parseFloat", "parseFloat");
+    try expectCanonicalMethod(&realm, target, "isNaN", "isNaN");
+    try expectCanonicalMethod(&realm, target, "isFinite", "isFinite");
+}
+
+test "method-registration shape: Set.prototype values/keys/@@iterator are the same function object" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    const set_v = realm.globals.get("Set") orelse return error.NoSet;
+    const set_ctor = heap_mod.valueAsFunction(set_v) orelse return error.SetNotFn;
+    const set_proto = set_ctor.prototype orelse return error.NoSetProto;
+
+    // §24.2.3 — `Set.prototype.values`, `.keys`, and `@@iterator` are
+    // required to be the *same* function object. The migration to
+    // `makeNativeFunction` must preserve that identity.
+    try expectCanonicalMethod(&realm, set_proto, "values", "values");
+    const values = set_proto.lookupOwn("values").?;
+    const keys = set_proto.lookupOwn("keys").?;
+    const iter = set_proto.lookupOwn("@@iterator").?;
+    try testing.expect(heap_mod.valueAsFunction(values).? == heap_mod.valueAsFunction(keys).?);
+    try testing.expect(heap_mod.valueAsFunction(values).? == heap_mod.valueAsFunction(iter).?);
+}


### PR DESCRIPTION
## Summary

Extracts a single primitive, `makeNativeFunction(realm, native, params, name)`, and migrates the hand-rolled built-in method installs onto it (and the existing `installNativeMethod` / `installNativeMethodOnProto` helpers, which now route through it).

`makeNativeFunction` allocates a §17 built-in callable with `has_construct=false` and `[[Realm]]` set (§10.2.5), installed nowhere — callers place it themselves (globals, ctor statics, multi-key aliases).

### Migrations
- **json, math, async_iterator, iterator, regexp** → `installNativeMethodOnProto`, deleting three redundant local helpers (`installMethod`, `installSymbolMethod`).
- **regexp**: the dropped `installSymbolMethod` omitted `[[Realm]]`, so this is also a **§10.2.5 conformance fix** on the `@@`-symbol methods (`@@match`, `@@replace`, `@@search`, `@@split`, `@@matchAll`).
- **number, collections** → `makeNativeFunction` for the multi-key-identity cases (`parseInt===Number.parseInt`; `Set.prototype values===keys===@@iterator`), preserving shared-object identity.

### Tests
Three characterization tests in `surface_audit_test.zig` pin the canonical §17/§10.2.5 descriptor shape, the `[[Realm]]`/non-constructor invariant, and Set iterator identity.

### Out of scope (deliberately — each a behavior change)
- Accessor-pair `has_construct` semantics (`installNativeGetter`, iterator getters)
- `@@`-symbol methods with non-standard flags (`Date`/`Symbol` `@@toPrimitive`, `Function` `@@hasInstance`)
- Constructor consolidation; promise-trampoline routing

## Verification
- `zig build test` → exit 0
- Full test262 sweep → **0 fail**
- `built-ins/RegExp` → **1887/1887**

Net: +159 / −116 across 9 files.