### PR TITLE
test262: policy-classification scoring model + 3-posture rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,8 +291,7 @@ jobs:
     # plus paths-ignore on the bot push doesn't always interact
     # cleanly with concurrency: cancel-in-progress). Refresh
     # `test262-results.md` locally with `zig build test262 --
-    # --mode=runtime --write-results` and commit it like any
-    # other source change.
+    # --write-results` and commit it like any other source change.
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@v2
@@ -311,37 +310,27 @@ jobs:
         # Drop `--quiet` so the per-bucket tally lands in the CI
         # log. Step timeout caps it in case the harness wedges.
         #
-        # Three floors gate the job — two per-phase score floors
-        # plus the SES-witness floor.
+        # Three floors gate the job — two per-row `pass%` floors plus
+        # the SES-witness floor. `pass%` = (passing + correctly handled
+        # fails) / total; see the legend in `test262-results.md`.
         #
-        #   --min-spec-pct=82.5          unhardened `pass%` floor.
-        #                                Today 83.16 % under the
-        #                                tech-debt-honest corpus
-        #                                (planned-feature paths
-        #                                — Temporal, cross-realm,
-        #                                etc. — now register as
-        #                                `skip` instead of being
-        #                                excluded). ~0.6pp
-        #                                headroom.
-        #   --min-hardened-spec-pct=82.5 SES-posture `runtime_hardened`
-        #                                `pass%` (the row's
-        #                                `(pass + divergent) /
-        #                                corpus` per Layout A in
-        #                                `docs/handbook/ses-test262-policy.md`).
-        #                                Today 83.16 %, same as
-        #                                unhardened.
-        #   --min-ses-witness-pct=100    Phase 3 witness inversion.
-        #                                Every fixture in
+        #   --min-spec-pct=98.2          unhardened `pass%` floor.
+        #                                Today 98.82 %; ~0.6pp headroom.
+        #   --min-hardened-spec-pct=98.2 hardened `pass%` floor. Today
+        #                                98.83 %; same headroom. Both
+        #                                count correctly-handled fails
+        #                                toward the numerator.
+        #   --min-ses-witness-pct=100    Every fixture in
         #                                `tools/test262/ses_witnesses.zig`
-        #                                MUST classify as divergent
-        #                                under the hardened phase.
+        #                                MUST classify under the SES
+        #                                policy in the hardened phase.
         #                                Drift either way (a witness
         #                                now passes — SES enforcement
         #                                weakened; or a witness fails
-        #                                for a non-divergence reason
-        #                                — pattern miss or engine
-        #                                regression in the SES throw
-        #                                path) fails the build.
+        #                                for a non-SES reason — pattern
+        #                                miss or engine regression in
+        #                                the SES throw path) fails the
+        #                                build.
         #
         # Any floor tripping exits 2 — see the per-phase diagnostic
         # block in `tools/test262.zig` for the failure report.
@@ -352,9 +341,9 @@ jobs:
         timeout-minutes: 8
         run: |
           zig build test262 -- \
-            --mode=runtime --threads=4 --top-rss=20 \
-            --min-spec-pct=82.5 \
-            --min-hardened-spec-pct=82.5 \
+            --threads=4 --top-rss=20 \
+            --min-spec-pct=98.2 \
+            --min-hardened-spec-pct=98.2 \
             --min-ses-witness-pct=100
 
       - name: Filtered sweep with top-rss
@@ -371,7 +360,7 @@ jobs:
         timeout-minutes: 5
         continue-on-error: true
         run: |
-          zig build test262 -- --quiet --mode=runtime --threads=4 \
+          zig build test262 -- --quiet --threads=4 \
             --filter=language/expressions --top-rss=10
 
   test262-gc-stress:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,27 +355,27 @@ look moderate. Forces `--threads=1`),
 `--min-ses-witness-pct=<f>` (per-row floors — the unhardened
 row, the hardened row, and the SES-witness side channel
 respectively. The first two gate the row's headline `pass%`
-(= `(passing + correctly handled) / total` — see the legend
-in `test262-results.md`); the witness floor gates
+(= `(passing + correctly handled fails) / total` — see the
+legend in `test262-results.md`); the witness floor gates
 `tools/test262/ses_witnesses.zig`'s curated set — every listed
 path MUST classify under the SES policy in the hardened phase.
 Exit 2 when any floor trips. Skipped under `--filter=`. CI
 wires all three at published baselines so a regression in
 either row or in witness fidelity fails the build — see
-`.github/workflows/ci.yml`). The harness scores against the
-**Layout-B corpus**: every test262 fixture except (a) `harness/`
-and `staging/` walk-time skips and (b) pre-Stage-4 proposals
-(both unshipped — decorators, import-defer, source-phase-imports,
-import-bytes, immutable-arraybuffer, await-dictionary — and
-shipped — joint-iteration, ShadowRealm; the shipped ones get
-their own dedicated per-feature scoreboard). Annex B / intl402 /
-eval-dependent / `noStrict` fixtures all RUN; any failure
-classifies as **correctly handled** under the matching policy
-(annex_b > no_strict > intl402 > eval > SES, first match wins;
-SES is hardened-only and matched against the runtime error
-pattern). Re-running for the same `(date, mode)` replaces that
-day's row. Each row records `passing`, `failing`, `correctly
-handled`, `total`, and `pass%`. `test262-results.md` opens with
+`.github/workflows/ci.yml`). The harness scores every test262
+fixture except (a) `harness/` and `staging/` walk-time skips and
+(b) pre-Stage-4 proposals (both unshipped — decorators,
+import-defer, source-phase-imports, import-bytes,
+immutable-arraybuffer, await-dictionary — and shipped —
+joint-iteration, ShadowRealm; the shipped ones get their own
+dedicated per-feature scoreboard). Annex B / intl402 /
+eval-dependent / `noStrict` fixtures all RUN; any failure is a
+**correctly handled fail** under the matching policy (annex_b >
+no_strict > intl402 > eval > SES, first match wins; SES is
+hardened-only and matched against the runtime error pattern).
+Re-running for the same `(date, mode)` replaces that day's row.
+Each row records `passing`, `failing`, `correctly handled
+fails`, `total`, and `pass%`. `test262-results.md` opens with
 a `## Current scores` snapshot (3 rows: `unhardened, --allow=eval`
 as a placeholder until the eval opt-in ships, then `unhardened`,
 then `hardened`), a `## Legend`, a `## Where the engine fails,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -355,7 +355,7 @@ look moderate. Forces `--threads=1`),
 `--min-ses-witness-pct=<f>` (per-row floors — the unhardened
 row, the hardened row, and the SES-witness side channel
 respectively. The first two gate the row's headline `pass%`
-(= `(passing + correctly handled fails) / total` — see the
+(= `(passing + expected fails) / total` — see the
 legend in `test262-results.md`); the witness floor gates
 `tools/test262/ses_witnesses.zig`'s curated set — every listed
 path MUST classify under the SES policy in the hardened phase.
@@ -370,12 +370,12 @@ immutable-arraybuffer, await-dictionary — and shipped —
 joint-iteration, ShadowRealm; the shipped ones get their own
 dedicated per-feature scoreboard). Annex B / intl402 /
 eval-dependent / `noStrict` fixtures all RUN; any failure is a
-**correctly handled fail** under the matching policy (annex_b >
+**expected fail** under the matching policy (annex_b >
 no_strict > intl402 > eval > SES, first match wins; SES is
 hardened-only and matched against the runtime error pattern).
 Re-running for the same `(date, mode)` replaces that day's row.
-Each row records `passing`, `failing`, `correctly handled
-fails`, `total`, and `pass%`. `test262-results.md` opens with
+Each row records `passing`, `failing`, `expected fails`,
+`total`, and `pass%`. `test262-results.md` opens with
 a `## Current scores` snapshot (3 rows: `unhardened, --allow=eval`
 as a placeholder until the eval opt-in ships, then `unhardened`,
 then `hardened`), a `## Legend`, a `## Where the engine fails,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,13 +284,14 @@ sweeps.
 
 `zig build test262` accepts forwarded flags after `--`:
 `--filter=<substring>`, `--list-failures=<n>`, `--quiet`, `--verbose`,
-`--phase=<spec>` (`main` runs the headline ECMA-262 sweep with
-pre-Stage-4 fixtures excluded; `feature:<name>` runs only that
-proposal's dedicated isolated sweep — only its realm flag on,
-only its tagged fixtures included. Default: just main, unless
-`--write-results` is set — then main + every tracked feature
-run in sequence), `--no-harness` (disable the
-`sta.js` + `assert.js` preamble in runtime mode),
+`--phase=<spec>` (`main` runs the hardened ECMA-262 sweep with
+pre-Stage-4 fixtures excluded; `unhardened` runs the same
+fixture set with `realm.hardened = false`; `feature:<name>` runs
+only that proposal's dedicated isolated sweep — only its realm
+flag on, only its tagged fixtures included. Default: main +
+unhardened; `--write-results` additionally runs every tracked
+feature in sequence), `--no-harness` (disable the `sta.js` +
+`assert.js` preamble in runtime mode),
 `--write-results` (updates `test262-results.md`),
 `--only-failing` (skip-as-pass any test path listed in
 `.test262-pass-cache.txt` — iterative-dev shortcut; cache is
@@ -352,49 +353,39 @@ fixtures whose wall-time is dominated by GC even when bytes
 look moderate. Forces `--threads=1`),
 `--min-spec-pct=<f>` / `--min-hardened-spec-pct=<f>` /
 `--min-ses-witness-pct=<f>` (per-row floors — the unhardened
-legacy baseline, the SES-posture row, and the SES-witness
-side channel respectively. The first two gate the row's
-headline `spec%` (for hardened that's the SES-adjusted
-`(pass + divergent) / total` per Layout A in
-`docs/handbook/ses-test262-policy.md`); the witness floor
-gates `tools/test262/ses_witnesses.zig`'s curated set —
-every listed path MUST classify as `divergent` under
-`.main`. Exit 2 when any floor trips. Skipped under
-`--filter=`. CI wires all three at the published baselines
-(82.5 / 82.5 / 100) so a regression in any of: unhardened
-score, SES-adjusted score, or witness fidelity fails the
-build — see `.github/workflows/ci.yml`). The harness
-scores against the **Cynic-targeted scope**: paths under
-`harness/`, `staging/`, `intl402/`, Annex B language extensions,
-the browser-era built-ins Cynic doesn't ship, and the feature
-tags for pre-Stage-4 proposals Cynic hasn't implemented yet
-(decorators, import-defer, source-phase-imports, import-bytes,
-immutable-arraybuffer, await-dictionary) are dropped from `total`
-entirely. The pre-Stage-4 trim (reason `pre_stage4`) pins the
-denominator to the published ECMAScript edition: an unimplemented
-proposal's fixtures stay out of `total` until it reaches Stage 4
-(then they re-enter as in-scope counted skips) or Cynic ships it
-(then they move to a dedicated `feature:<name>` phase — like
-today's `joint-iteration` / `ShadowRealm`). This keeps the headline
-from silently decaying as TC39 lands new proposal fixtures upstream.
-(`intl402/` is dropped for the *default* build;
-a future Intl-enabled build flavour — opt-in, linking a CLDR/ICU
-+ IANA `tzdata` stack — would bring it back into scope, along
-with named time zones and non-ISO calendars. See
-[docs/ROADMAP.md](docs/ROADMAP.md) under "Intl".) Re-running for
-the same `(date, mode)` replaces
-that day's row. Each row records `spec%` (pass / total) and
-`attempted%` (pass / (pass + fail)). `test262-results.md` opens
-with a `## Current scores` snapshot, a `## Legend` explaining the
-columns, a `## Where the runtime stands, by area` per-bucket
-scoreboard sorted by raw fail count (so the top of the list is
-where the most fixtures move with the least work), and a
-`## History` section of per-day mini-tables — newest day first.
-Each history row shows the `Δ pass` against the previous run of
-the same mode and the `elapsed` wall-clock time of that run (full
-sweeps only; partial / filtered runs leave it blank). The most
-recent row also gets a "Biggest movers" sub-list naming the
-buckets that shifted most.
+row, the hardened row, and the SES-witness side channel
+respectively. The first two gate the row's headline `pass%`
+(= `(passing + correctly handled) / total` — see the legend
+in `test262-results.md`); the witness floor gates
+`tools/test262/ses_witnesses.zig`'s curated set — every listed
+path MUST classify under the SES policy in the hardened phase.
+Exit 2 when any floor trips. Skipped under `--filter=`. CI
+wires all three at published baselines so a regression in
+either row or in witness fidelity fails the build — see
+`.github/workflows/ci.yml`). The harness scores against the
+**Layout-B corpus**: every test262 fixture except (a) `harness/`
+and `staging/` walk-time skips and (b) pre-Stage-4 proposals
+(both unshipped — decorators, import-defer, source-phase-imports,
+import-bytes, immutable-arraybuffer, await-dictionary — and
+shipped — joint-iteration, ShadowRealm; the shipped ones get
+their own dedicated per-feature scoreboard). Annex B / intl402 /
+eval-dependent / `noStrict` fixtures all RUN; any failure
+classifies as **correctly handled** under the matching policy
+(annex_b > no_strict > intl402 > eval > SES, first match wins;
+SES is hardened-only and matched against the runtime error
+pattern). Re-running for the same `(date, mode)` replaces that
+day's row. Each row records `passing`, `failing`, `correctly
+handled`, `total`, and `pass%`. `test262-results.md` opens with
+a `## Current scores` snapshot (3 rows: `unhardened, --allow=eval`
+as a placeholder until the eval opt-in ships, then `unhardened`,
+then `hardened`), a `## Legend`, a `## Where the engine fails,
+by area` per-bucket scoreboard sourced from the hardened sweep
+and sorted by raw fail count, a `## Pre-Stage-4 proposals
+shipped` table for the per-feature scoreboard, and a `## History`
+section of per-day mini-tables — newest day first. Each history
+row shows `Δ pass` against the previous run of the same mode
+and the `elapsed` wall-clock time of that run (full sweeps only;
+partial / filtered runs leave it blank).
 
 **Build mode.** The test262 harness binary is built `ReleaseFast`
 by default (interpreters are 5-10× slower in Debug; the harness

--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Ohaimark) and generational GC are future work. See
 ### Conformance
 
 Current scores, history, and per-bucket breakdown live in
-[`test262-results.md`](test262-results.md). `spec%` is coverage
-of the (Cynic-targeted) corpus; `attempted%` is the quality of
-what's shipped, ignoring skips. The unit-test suite (`zig build
+[`test262-results.md`](test262-results.md). `pass%` is
+`(passing + correctly handled) / total` — a "correctly handled"
+fixture is one Cynic refuses *by design* (Annex B not shipped,
+strict-only, no Intl, eval-off, or SES throw). The `failing`
+column is real engine work left. The unit-test suite (`zig build
 test`) runs alongside.
 
 ### Build targets

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Ohaimark) and generational GC are future work. See
 
 Current scores, history, and per-bucket breakdown live in
 [`test262-results.md`](test262-results.md). `pass%` is
-`(passing + correctly handled) / total` — a "correctly handled"
-fixture is one Cynic refuses *by design* (Annex B not shipped,
-strict-only, no Intl, eval-off, or SES throw). The `failing`
-column is real engine work left. The unit-test suite (`zig build
-test`) runs alongside.
+`(passing + correctly handled fails) / total` — a "correctly
+handled fail" is a fixture Cynic fails *by design* (Annex B not
+shipped, strict-only, no Intl, eval-off, or SES throw). The
+`failing` column is real engine work left. The unit-test suite
+(`zig build test`) runs alongside.
 
 ### Build targets
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Ohaimark) and generational GC are future work. See
 
 Current scores, history, and per-bucket breakdown live in
 [`test262-results.md`](test262-results.md). `pass%` is
-`(passing + correctly handled fails) / total` — a "correctly
+`(passing + expected fails) / total` — a "correctly
 handled fail" is a fixture Cynic fails *by design* (Annex B not
 shipped, strict-only, no Intl, eval-off, or SES throw). The
 `failing` column is real engine work left. The unit-test suite

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -153,8 +153,9 @@ code construction (aligns with SES).
   (constructor + `.evaluate` + the §3.8.3.4 callable boundary)
   ship; full Compartments are still deferred. The test262 sweep
   scores both modes — the
-  `runtime` row tracks the legacy ECMAScript baseline (unhardened),
-  the `runtime-hardened` row tracks the SES posture. Brand bet
+  `unhardened` row tracks the legacy ECMAScript baseline (the
+  `--unhardened` opt-out), the `hardened` row tracks the
+  SES posture. Brand bet
   delivered: Cynic ships the SES baseline natively, no
   `@endo/ses` import or `lockdown()` call required. Design +
   phase notes in [docs/ses-alignment.md](ses-alignment.md).

--- a/docs/handbook/ses-test262-policy.md
+++ b/docs/handbook/ses-test262-policy.md
@@ -2,11 +2,11 @@
 
 > **Current model (2026-06).** `test262-results.md` runs every
 > fixture except `harness/`, `staging/`, and Stage ≤ 3 proposals
-> (shipped or not). Each failure classifies as **correctly handled**
+> (shipped or not). A failure is either a **correctly handled fail**
 > under one of five design policies — `annex_b` > `no_strict` >
-> `intl402` > `eval` > `ses`, first match wins — or stays a plain
-> `failing`. The headline `pass%` is
-> `(passing + correctly_handled) / total`. The SES bucket described
+> `intl402` > `eval` > `ses`, first match wins — or a plain
+> `failing` (real engine work). The headline `pass%` is
+> `(passing + correctly handled fails) / total`. The SES bucket described
 > below is one of the five policies; the same machinery generalises
 > to the other four (which used to be walked-out skips). This doc
 > still focuses on the SES bucket because it's the only policy with

--- a/docs/handbook/ses-test262-policy.md
+++ b/docs/handbook/ses-test262-policy.md
@@ -1,9 +1,22 @@
 # SES + test262 scoring policy
 
+> **Current model (2026-06).** `test262-results.md` runs every
+> fixture except `harness/`, `staging/`, and Stage ≤ 3 proposals
+> (shipped or not). Each failure classifies as **correctly handled**
+> under one of five design policies — `annex_b` > `no_strict` >
+> `intl402` > `eval` > `ses`, first match wins — or stays a plain
+> `failing`. The headline `pass%` is
+> `(passing + correctly_handled) / total`. The SES bucket described
+> below is one of the five policies; the same machinery generalises
+> to the other four (which used to be walked-out skips). This doc
+> still focuses on the SES bucket because it's the only policy with
+> a runtime-error matcher (the rest are path / frontmatter classified
+> by `skip_rules.pathPolicyKind`).
+
 Cynic ships SES posture by default (frozen primordials, override-mistake
 fix, `harden()` global) and runs both modes through every score sweep —
-the `runtime` row tracks the legacy ECMAScript baseline (`--unhardened`),
-the `runtime_hardened` row tracks the SES posture. The two rows share
+the `unhardened` row tracks the legacy ECMAScript baseline (`--unhardened`),
+the `hardened` row tracks the SES posture. The two rows share
 the same test262 corpus, but **the corpus was written against pre-SES
 ECMAScript**: many fixtures assert invariants that SES intentionally
 invalidates (`Math.abs.length` is `configurable: true`,
@@ -12,7 +25,7 @@ invalidates (`Math.abs.length` is `configurable: true`,
 *correct* behaviour, not a bug.
 
 This doc is the durable plan for separating "SES is doing its job" from
-"Cynic has a real bug" in the `runtime_hardened` score. A fresh session
+"Cynic has a real bug" in the `hardened` score. A fresh session
 should be able to pick up the next sub-step from here without re-deriving
 the design. Sister docs:
 
@@ -26,7 +39,7 @@ the design. Sister docs:
 
 ## Problem in one paragraph
 
-The current `runtime_hardened` row at ~84.77% spec% looks ~8 pp worse
+The current `hardened` row at ~84.77% spec% looks ~8 pp worse
 than the unhardened baseline (92.90%). The ~3258-fixture delta isn't
 mostly Cynic bugs — it's intentional SES divergence. Real engine bugs
 under SES are ~9 fixtures (the same Annex B regex divergence the
@@ -38,11 +51,11 @@ reasonable floor, so CI can't catch it cleanly.
 
 ## Goals
 
-1. The `runtime_hardened` headline number reflects **real Cynic
+1. The `hardened` headline number reflects **real Cynic
    bugs**, not intentional SES divergence — directly comparable
-   to `runtime`. **Hardened mode is the primary signal**: Cynic's
+   to `unhardened`. **Hardened mode is the primary signal**: Cynic's
    brand bet is hardened-by-default and that's where engineering
-   effort should go. `runtime` (unhardened) is the continuity /
+   effort should go. The `unhardened` row is the continuity /
    reference baseline, not the optimisation target. A bug fix
    that only moves unhardened doesn't earn the same priority as
    one that moves hardened too.
@@ -192,8 +205,8 @@ way.
 |                    | spec%   | attempted% | pass / total     | pass / attempted | divergent |
 |--------------------|---------|------------|------------------|------------------|----------:|
 | parser             | 73.32 % | 100.00 %   | 30311 / 41339    | 30311 / 30311    |         — |
-| runtime            | 92.90 % | 99.98 %    | 37241 / 40089    | 37241 / 37250    |         — |
-| runtime_hardened   | 92.90 % | 99.97 %    | 37241 / 40089    | 33983 / 33992    |      3258 |
+| unhardened         | 92.90 % | 99.98 %    | 37241 / 40089    | 37241 / 37250    |         — |
+| hardened           | 92.90 % | 99.97 %    | 37241 / 40089    | 33983 / 33992    |      3258 |
 | ses-witness        | 100.00 %| 100.00 %   |    87 / 87       |    87 / 87       |         — |
 | annex-b-rejection  | 100.00 %| 100.00 %   |   142 / 142      |   142 / 142      |         — |
 ```
@@ -211,8 +224,8 @@ Per-day `## History` rows pick up the same five columns plus
 
 |                    | spec%   | attempted% | pass / total     | pass / attempted | divergent | Δ pass | elapsed |
 |--------------------|---------|------------|------------------|------------------|----------:|-------:|--------:|
-| runtime            | 92.90 % | 99.98 %    | 37241 / 40089    | 37241 / 37250    |         — |    ±0  |   35.6s |
-| runtime_hardened   | 92.90 % | 99.97 %    | 37241 / 40089    | 33983 / 33992    |      3258 |    ±0  |   38.4s |
+| unhardened         | 92.90 % | 99.98 %    | 37241 / 40089    | 37241 / 37250    |         — |    ±0  |   35.6s |
+| hardened           | 92.90 % | 99.97 %    | 37241 / 40089    | 33983 / 33992    |      3258 |    ±0  |   38.4s |
 | ses-witness        | 100.00 %| 100.00 %   |    87 / 87       |    87 / 87       |         — |    ±0  |    0.2s |
 | annex-b-rejection  | 100.00 %| 100.00 %   |   142 / 142      |   142 / 142      |         — |    ±0  |    0.5s |
 ```
@@ -234,16 +247,16 @@ shows up in the `divergent` column only.
 
 `## Legend` in `test262-results.md` picks up these entries:
 
-- **divergent** (`runtime_hardened` only) — fixtures whose test262-
+- **divergent** (`hardened` only) — fixtures whose test262-
   written assertion conflicts with SES enforcement (frozen
   primordials, locked descriptors, non-extensible namespaces).
   The engine throws on the offending operation, which is correct
   under SES; the fixture's "expected pass" is invalidated. Counted
   separately from `fail`. See [docs/handbook/ses-test262-policy.md].
-- **spec%** (`runtime_hardened`) — `(pass + divergent) / total`.
+- **spec%** (`hardened`) — `(pass + divergent) / total`.
   Divergent counts as engine-correct because SES is part of the
-  spec Cynic ships. Directly comparable to the `runtime` row.
-- **attempted%** (`runtime_hardened`) — `pass / (pass + fail)`.
+  spec Cynic ships. Directly comparable to the `unhardened` row.
+- **attempted%** (`hardened`) — `pass / (pass + fail)`.
   Excludes divergent from both numerator and denominator. This is
   the real-engine-conformance gauge — drops on any genuine
   failure regardless of SES policy.
@@ -284,13 +297,13 @@ number) with three floors:
   negative-coverage row (per "Annex B negative coverage"
   above). **Hard gate, 100.0.** A drop means Cynic accidentally
   shipped an Annex B feature.
-- `--min-spec-pct=<f>` — floor on `runtime` (unhardened) row.
+- `--min-spec-pct=<f>` — floor on `unhardened` (unhardened) row.
   Continuity gate. Set conservatively so a real catastrophic
   regression still trips it, but don't tighten ahead of
   hardened — engineering effort goes to hardened first.
 
 CI workflow updates in lockstep — `.github/workflows/ci.yml`.
-A PR that improves only `runtime` and leaves `runtime_hardened`
+A PR that improves only `unhardened` and leaves `hardened`
 flat is still mergeable, but reviewers should ask whether the
 fix is portable to hardened mode.
 
@@ -608,7 +621,7 @@ comment) before landing the bump.
 
 - Not a contribution-back to upstream test262. That's a separate
   TC39/SES-working-group effort, on a separate timeline.
-- Not a replacement for the existing `runtime` row. The legacy
+- Not a replacement for the existing `unhardened` row. The legacy
   baseline stays exactly as it is — unchanged column shape,
   unchanged scoring math, unchanged floor.
 - Not blocking on lazy-bag Phase 3 — orthogonal work.
@@ -952,10 +965,10 @@ Final post-Phase-2 numbers:
 
 | metric | pre-Phase 2 | post-Phase 2 |
 |---|---:|---:|
-| `runtime_hardened` headline `spec%` | 86.64 % (raw) | **92.90 % (adj)** |
+| `hardened` headline `spec%` | 86.64 % (raw) | **92.90 % (adj)** |
 | Divergent reclassifications | 0 | **2515** |
 | Real engine fails | 2527 | **12** |
-| Gap vs `runtime` baseline | -6.27 pp | **-0.01 pp** |
+| Gap vs `unhardened` baseline | -6.27 pp | **-0.01 pp** |
 
 Within 0.01 pp of the unhardened headline. The 12 remaining
 real hardened-only failures break down:
@@ -1196,7 +1209,7 @@ the original spec called for. The original Phase 5 sketch
 proposed a dual-mode reshape — two columns per bucket
 (`runtime (pass / fail)` and `hardened (pass / fail /
 divergent)`) plus dual spec% — but with the headlines now
-matching (`runtime` and `runtime_hardened` both at 37313 /
+matching (`unhardened` and `hardened` both at 37313 /
 40161, 92.91 %), the dual columns would duplicate themselves
 across ~60 buckets and the only signal-carrying delta is
 "how many fixtures reclassified as divergent in this bucket."

--- a/docs/handbook/ses-test262-policy.md
+++ b/docs/handbook/ses-test262-policy.md
@@ -2,11 +2,11 @@
 
 > **Current model (2026-06).** `test262-results.md` runs every
 > fixture except `harness/`, `staging/`, and Stage ≤ 3 proposals
-> (shipped or not). A failure is either a **correctly handled fail**
+> (shipped or not). A failure is either a **expected fail**
 > under one of five design policies — `annex_b` > `no_strict` >
 > `intl402` > `eval` > `ses`, first match wins — or a plain
 > `failing` (real engine work). The headline `pass%` is
-> `(passing + correctly handled fails) / total`. The SES bucket described
+> `(passing + expected fails) / total`. The SES bucket described
 > below is one of the five policies; the same machinery generalises
 > to the other four (which used to be walked-out skips). This doc
 > still focuses on the SES bucket because it's the only policy with

--- a/docs/ses-alignment.md
+++ b/docs/ses-alignment.md
@@ -321,7 +321,7 @@ remember the captured value at the call site so the hot
 function `.name` / `.length` descriptors as `configurable: true`
 per §17 regress because the freeze locks them
 non-configurable. These are the dominant cluster of regressions
-under the `runtime-hardened` score row; the `runtime` row
+under the `hardened` score row; the `unhardened` row
 recovers them in full.
 
 ### Phase 4 — `--unhardened` flag wiring

--- a/test262-results.md
+++ b/test262-results.md
@@ -3,24 +3,25 @@
 **Cynic passes 98.83 % of its 50894-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
 
 - **40178 passing** — Cynic produced the spec-expected result.
-- **10120 correctly handled** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
+- **10120 correctly handled fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
 - **593 failing** — real engine failures with no policy bucket. Work to do.
 - **Out of total**, dropped before `corpus`: the upstream `harness/` and `staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary, plus shipped joint-iteration / ShadowRealm — those get their own dedicated scoreboard).
 
 ## Current scores
 
-| posture | passing | failing | correctly handled | total | pass% |
+| posture | passing | failing | correctly handled fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | **unhardened, `--allow=eval`** | n/a | n/a | n/a | n/a | n/a |
 | **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6217 | 50894 | 98.82 % |
 | **hardened** (default — `cynic run`) | 40178 | 593 | 10120 | 50894 | 98.83 % |
 
-> **pass%** = `(passing + correctly handled) / total`. A
-> fixture that fails because of a Cynic design policy
+> **pass%** = `(passing + correctly handled fails) / total`.
+> A fixture that fails because of a Cynic design policy
 > (Annex B not shipped, strict-only, no Intl, eval-off, SES
-> throw) counts as **correctly handled** rather than a
-> real engine bug. Plain **failing** is what's left over —
-> real engine work to do.
+> throw) is a **correctly handled fail** rather than a real
+> engine bug. Plain **failing** is what's left over — real
+> engine work to do. The `--allow=eval` row is always `n/a`
+> until that opt-in ships.
 
 *SES witness fidelity*: **10 / 10** witnesses classify as SES-correctly-handled (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
 
@@ -33,20 +34,19 @@ refer to the same parse → compile → run sweep.
 
 - **unhardened, `--allow=eval`** — unhardened plus the
   eval surface (`eval()`, `new Function(string)`, …) opted
-  in. Placeholder today: `--allow=eval` isn't shipped (see
-  `docs/ses-alignment.md`), so no sweep populates this row
-  and every cell reads `n/a`. When the opt-in lands, eval
-  fixtures move from "correctly handled" to plain passing.
+  in. **Always `n/a`**: `--allow=eval` isn't shipped (see
+  `docs/ses-alignment.md`), so no sweep populates this row.
+  The row is reserved so the layout stays stable when the
+  opt-in lands (eval fails would then become passes).
 - **unhardened** — `cynic --unhardened` opt-out. Eval off
-  (so eval-dependent fixtures fail and classify as
-  correctly handled), Annex B / Intl / noStrict failures
-  also classify as correctly handled. SES posture off —
-  no SES throws.
+  (so eval-dependent fixtures fail and count as correctly
+  handled fails), Annex B / Intl / noStrict failures too.
+  SES posture off — no SES throws.
 - **hardened** — the default posture (`cynic run`). All
   the unhardened policies plus SES — primordials frozen,
   override-mistake fix on, locked descriptors. Fixtures
   whose expectation conflicts with SES enforcement throw
-  by design and classify as correctly handled.
+  by design and count as correctly handled fails.
 
 ### Columns
 
@@ -54,7 +54,7 @@ refer to the same parse → compile → run sweep.
   the spec-expected result.
 - **`failing`** — engine-true failures that *don't* match
   any design policy. Real work to do.
-- **`correctly handled`** — failures that hit a Cynic
+- **`correctly handled fails`** — failures that hit a Cynic
   design policy: Annex B not shipped, strict-only,
   no Intl, eval-off, or SES throw. Counted with passes
   under `pass%` because Cynic's deliberate "no" is the
@@ -64,7 +64,7 @@ refer to the same parse → compile → run sweep.
 - **`total`** — every fixture except pre-Stage-4
   proposals (Stage ≤ 3, shipped or not) and the upstream
   `staging/` / `harness/` paths.
-- **`pass%`** — `(passing + correctly handled) / total`.
+- **`pass%`** — `(passing + correctly handled fails) / total`.
   The headline.
 - **SES witness fidelity** (the italic note above) —
   positive-coverage signal. The curated witness set in
@@ -128,13 +128,13 @@ first two path components (`built-ins/Set`,
   The remainder (~13 fixtures) is the
   cross-realm cluster awaiting `--allow=eval` and multi-realm
   error attribution.
-- The **0-fails tier** is sorted by `correctly handled ↓` so
+- The **0-fails tier** is sorted by `correctly handled fails ↓` so
   the heaviest policy buckets cluster first. `intl402/`
   trees dominate (no Intl), then the SES-hot built-ins
   (`Array`, `Object`, `TypedArray`, `String`, `Date`,
   `Math`), then the Annex B / eval / noStrict tails.
 
-| area | passing | failing | correctly handled | total | pass% |
+| area | passing | failing | correctly handled fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | **_100–999 fails — engine-work tier_** | | | | | |
 | `built-ins/Atomics` | 0 | 382 | 0 | 382 | 0 % |
@@ -150,7 +150,7 @@ first two path components (`built-ins/Set`,
 | `built-ins/ThrowTypeError` | 13 | 1 | 0 | 14 | 93 % |
 | `built-ins/TypedArray` | 1104 | 7 | 327 | 1438 | 100 % |
 | `language/expressions` | 10017 | 1 | 661 | 10682 | 100 % |
-| **_0 fails — passing / all-policy (sorted by correctly handled ↓)_** | | | | | |
+| **_0 fails — passing / all-policy (sorted by correctly handled fails ↓)_** | | | | | |
 | `intl402/Temporal` | 48 | 0 | 1958 | 2006 | 100 % |
 | `annexB/language` | 82 | 0 | 763 | 845 | 100 % |
 | `built-ins/Temporal` | 3885 | 0 | 703 | 4588 | 100 % |
@@ -258,13 +258,13 @@ Per-feature scores for the TC39 proposals Cynic ships at
 Stage 1–3, ahead of their inclusion in the published
 edition. Each proposal gets a **(hardened)** row — the
 as-shipped SES posture under `--enable=<flag>`, with SES
-throws counted as correctly handled — and an
+throws counted as correctly handled fails — and an
 **(unhardened)** row against bare ECMA-262. Same column
 shape as the main `## Current scores` table:
-`passing | failing | correctly handled | total | pass%`.
+`passing | failing | correctly handled fails | total | pass%`.
 These fixtures are excluded from the top-line score.
 
-| feature | passing | failing | correctly handled | total | pass% |
+| feature | passing | failing | correctly handled fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | `joint-iteration` (hardened) | 78 | 0 | 3 | 81 | 100 % |
 | `joint-iteration` (unhardened) | 76 | 0 | 3 | 81 | 94 % |
@@ -274,10 +274,10 @@ These fixtures are excluded from the top-line score.
 
 ## History
 
-### 2026-06-01 — cynic `c1b7e7a`, test262 `d0c1b4555b`
+### 2026-06-01 — cynic `3de4345`, test262 `d0c1b4555b`
 
-|         | passing | failing | correctly handled | total | pass% | Δ pass | elapsed |
+|         | passing | failing | correctly handled fails | total | pass% | Δ pass | elapsed |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | n/a | 40.1 s |
-| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | n/a | 50.1 s |
+| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | n/a | 35.1 s |
+| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | n/a | 40.1 s |
 

--- a/test262-results.md
+++ b/test262-results.md
@@ -1,89 +1,77 @@
 # test262 conformance — Cynic
 
-**Cynic passes 100.00 % of its 43029-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
+**Cynic passes 98.83 % of its 50894-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
 
-- **39171 pass** at the engine-true level (engine% = 100.00 % — see Legend).
-- **3858 SES-policy divergences** — Cynic's hardened posture throws by design where test262 expects the spec-literal success (frozen primordials, locked descriptors, override-mistake fix). Counted as engine-correct in the headline `pass%` per Layout A; see `docs/handbook/ses-test262-policy.md`.
-- **0 real engine failures** — Cynic returns the wrong answer or throws where the spec expects success. (libregexp Annex B / `/v` carve-outs are documented in [AGENTS.md](../AGENTS.md).)
-- **0 skipped** — *in-corpus* skips that should eventually pass: single-realm Cynic (`$262.createRealm()` cross-realm fixtures, which need multi-realm support) plus a handful of eval-dependent fixtures awaiting `--allow=eval`.
-- **Out of scope, dropped before `corpus`:** sloppy-mode (`flags: [noStrict]`) fixtures — Cynic is strict-only — the Annex B / browser-era feature tags (`__proto__`, `legacy-regexp`, `IsHTMLDDA`, …), the `annexB/` tree, `intl402/`, `staging/`, SES carve-outs, and the feature tags for pre-Stage-4 proposals Cynic hasn't implemented yet (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary). The denominator is pinned to the published ECMAScript edition; an unimplemented proposal's fixtures re-enter `corpus` once it reaches Stage 4. Implemented pre-Stage-4 proposals (joint-iteration, ShadowRealm) are scored separately behind `--enable=`, not here.
+- **40178 passing** — Cynic produced the spec-expected result.
+- **10120 correctly handled** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
+- **593 failing** — real engine failures with no policy bucket. Work to do.
+- **Out of total**, dropped before `corpus`: the upstream `harness/` and `staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary, plus shipped joint-iteration / ShadowRealm — those get their own dedicated scoreboard).
 
 ## Current scores
 
-| posture | pass% | engine% | passes / corpus | divergent |
-|---|---:|---:|---:|---:|
-| **hardened** (default — `cynic run`) | 100.00 % | 100.00 % | 43029 / 43029 | 3858 |
-| **unhardened** (`cynic --unhardened`) | 100.00 % | 100.00 % | 43029 / 43029 | — |
+| posture | passing | failing | correctly handled | total | pass% |
+|---|---:|---:|---:|---:|---:|
+| **unhardened, `--allow=eval`** | n/a | n/a | n/a | n/a | n/a |
+| **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6217 | 50894 | 98.82 % |
+| **hardened** (default — `cynic run`) | 40178 | 593 | 10120 | 50894 | 98.83 % |
 
-> **pass%** is the headline — `pass / corpus` (a fixture
-> Cynic doesn't ship counts as a `skip`, lowering this).
-> **engine%** = `pass / (pass + fail)` — of fixtures the
-> engine attempted, the fraction that passed at the
-> spec-literal level (skips and SES divergences drop
-> out). **The engine-quality gauge** — moves only when
-> a real fixture flips engine pass/fail, independent of
-> what's left unimplemented or how SES policy weighs in.
+> **pass%** = `(passing + correctly handled) / total`. A
+> fixture that fails because of a Cynic design policy
+> (Annex B not shipped, strict-only, no Intl, eval-off, SES
+> throw) counts as **correctly handled** rather than a
+> real engine bug. Plain **failing** is what's left over —
+> real engine work to do.
 
-*SES witness fidelity*: **10 / 10** witnesses classify as `divergent` (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
+*SES witness fidelity*: **10 / 10** witnesses classify as SES-correctly-handled (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
 
 ## Legend
 
 ### Rows (postures)
 
-Same engine path, different SES posture. Both numbers
+Same engine path, different policy mask. All three rows
 refer to the same parse → compile → run sweep.
 
-- **hardened** — the default posture (`cynic run`).
-  Primordials frozen, override-mistake fix on, locked
-  descriptors on every built-in `.name` / `.length`.
-  Fixtures that check spec-mandated `configurable: true`
-  on those slots reclassify as **divergent** (the engine
-  throws correctly; the test's expectation is the part
-  invalidated by SES).
-- **unhardened** — `cynic --unhardened` opt-out. Same
-  engine, but `realm.hardened = false` — primordials
-  stay mutable, globalThis extensible, no
-  override-mistake fix. The pre-SES ECMAScript baseline.
-  No fixtures get divergent-reclassified here.
+- **unhardened, `--allow=eval`** — unhardened plus the
+  eval surface (`eval()`, `new Function(string)`, …) opted
+  in. Placeholder today: `--allow=eval` isn't shipped (see
+  `docs/ses-alignment.md`), so no sweep populates this row
+  and every cell reads `n/a`. When the opt-in lands, eval
+  fixtures move from "correctly handled" to plain passing.
+- **unhardened** — `cynic --unhardened` opt-out. Eval off
+  (so eval-dependent fixtures fail and classify as
+  correctly handled), Annex B / Intl / noStrict failures
+  also classify as correctly handled. SES posture off —
+  no SES throws.
+- **hardened** — the default posture (`cynic run`). All
+  the unhardened policies plus SES — primordials frozen,
+  override-mistake fix on, locked descriptors. Fixtures
+  whose expectation conflicts with SES enforcement throw
+  by design and classify as correctly handled.
 
 ### Columns
 
-- **`pass%`** — `pass / corpus`. Under **hardened**, the
-  numerator is `(pass + divergent)` per Layout A: divergent
-  fixtures fail by the strict ECMA-262 letter (SES rejects
-  writes the spec allows) but Cynic's default posture
-  ships the SES policy, so they count as engine-correct.
-  **This is what an embedder running `cynic run` sees
-  succeed.** Under **unhardened**, the numerator is plain
-  `pass`.
-- **`engine%`** — `pass / (pass + fail)`. Of fixtures the
-  engine actually attempted, the fraction that passed at
-  the spec-literal engine level (no SES weighting). The
-  pass numerator excludes `divergent`, so a hardened
-  regression that flips a real fixture from pass to fail
-  moves this column even when the divergent count masks
-  the headline `pass%`. **This is the actual engine-
-  quality gauge** — today >99.9 % both rows.
-- **`passes / corpus`** — raw counts for `pass%`. Under
-  hardened, `passes` includes divergent.
-- **`divergent`** (hardened-only) — fixtures whose
-  test262-written assertion conflicts with SES enforcement
-  (frozen primordials, locked descriptors, override-mistake
-  fix). The engine throws on the offending operation; the
-  fixture's "expected pass" is invalidated by Cynic's SES
-  policy. **These are spec-failures by ECMA-262's letter**,
-  accepted as policy-correct under the hardened posture.
-  Counted separately from `fail`. See
-  `docs/handbook/ses-test262-policy.md`.
+- **`passing`** — engine-true successes. Cynic produced
+  the spec-expected result.
+- **`failing`** — engine-true failures that *don't* match
+  any design policy. Real work to do.
+- **`correctly handled`** — failures that hit a Cynic
+  design policy: Annex B not shipped, strict-only,
+  no Intl, eval-off, or SES throw. Counted with passes
+  under `pass%` because Cynic's deliberate "no" is the
+  spec-correct answer for the policy Cynic ships.
+  First-match priority: annex_b > no_strict > intl402 >
+  eval > SES.
+- **`total`** — every fixture except pre-Stage-4
+  proposals (Stage ≤ 3, shipped or not) and the upstream
+  `staging/` / `harness/` paths.
+- **`pass%`** — `(passing + correctly handled) / total`.
+  The headline.
 - **SES witness fidelity** (the italic note above) —
-  Phase 3 positive-coverage signal. The curated witness
-  set in `tools/test262/ses_witnesses.zig` is a small
-  list of paths that MUST classify as `divergent` under
-  hardened runs. Drift either way (witness now passes —
-  SES enforcement weakened; or witness fails for a
-  non-divergence reason — pattern miss or engine
-  regression in the SES throw path) is a hard signal.
-  CI gates the floor at 100 %.
+  positive-coverage signal. The curated witness set in
+  `tools/test262/ses_witnesses.zig` is a small list of
+  paths that MUST classify under the SES policy under
+  hardened runs. Drift either way is a hard signal. CI
+  gates the floor at 100 %.
 - **`Δ pass`** (history) — change in `pass` versus the
   previous row of the same posture.
 - **`elapsed`** (history) — wall-clock time of the run
@@ -104,46 +92,24 @@ is right for "did anything regress?" tracking, but it's
 a lower bound on spec coverage — a fixture not in
 `corpus` doesn't get a verdict either way.
 
-### Scope (what's in `corpus`)
+### Scope (what's in `total`)
 
-Two-tier skiplist in
-[`tools/test262/skip.zig`](../tools/test262/skip.zig)
-(see the per-group comments there for the full list):
+Every test262 fixture runs except:
 
-- **Filtered out** (not in `corpus`): sloppy-mode
-  fixtures (`flags: [noStrict]`) — Cynic is strict-only;
-  Annex B language extensions + browser-era built-ins
-  (both the `annexB/` tree and the `__proto__` /
-  `legacy-regexp` / `IsHTMLDDA` feature tags);
-  `intl402/`, `harness/`, `staging/`, SES carve-outs
-  (`eval()` until `--allow=eval` ships, SharedArrayBuffer
-  / Atomics); and the feature tags for pre-Stage-4
-  proposals Cynic hasn't implemented yet (decorators,
+- the upstream `harness/` and `staging/` paths (helpers
+  and WIP grounds, not portable spec fixtures); and
+- every Stage ≤ 3 proposal — both unshipped (decorators,
   import-defer, source-phase-imports, import-bytes,
-  immutable-arraybuffer, await-dictionary). The
-  denominator is pinned to the published ECMAScript
-  edition: an unimplemented proposal's fixtures stay out
-  of `corpus` (reason `pre_stage4`) until it reaches
-  Stage 4, so the headline only moves when Cynic does, not
-  when TC39 lands new proposal fixtures upstream. Pre-
-  Stage-4 proposals Cynic *has* implemented (joint-
-  iteration, ShadowRealm) ship behind `--enable=<name>`
-  and get their own phase sweep in `## Pre-Stage-4
-  proposals shipped` below. The harness reports the
-  frontmatter-driven trim (`noStrict` + Annex B +
-  pre-Stage-4 feature tags) as `oos` in its per-run tally.
-- **In `corpus` as `skip`** — *tech debt*, should
-  eventually pass: cross-realm fixtures
-  (`$262.createRealm()` — single-realm Cynic doesn't
-  expose multi-realm to user JS yet) and eval-dependent
-  fixtures awaiting `--allow=eval`. (A specced feature
-  blocked on a vendored dependency would land here too;
-  none today — Perlex covers the regex surface.) These
-  count toward `corpus` so `pass%` reflects the actual
-  work left instead of a trimmed-denominator headline.
+  immutable-arraybuffer, await-dictionary) and shipped
+  (joint-iteration, ShadowRealm). Shipped pre-Stage-4
+  proposals get their own scoreboard in `## Pre-Stage-4
+  proposals shipped` below.
 
-Today: test262 ships ~52k fixtures; `corpus` is ~44k.
-## Where the engine fails (and where SES diverges), by area
+Annex B / `noStrict` / `intl402/` / the eval surface
+are NOT skipped — they run and any failure classifies
+as **correctly handled** under the matching policy.
+
+## Where the engine fails, by area
 
 Per-bucket breakdown sourced from the **hardened (default)**
 sweep so the numbers match `cynic run`. Bucketed on the
@@ -152,301 +118,166 @@ first two path components (`built-ins/Set`,
 
 **Reading guide:**
 
-- The **top tier** (`1+ fails`) is the engine-work list.
-  Today the only entry is `built-ins/RegExp` with 9
-  libregexp Annex B / `/v` grammar gaps — fixtures that
-  compile patterns the vendored libregexp matcher
-  (QuickJS-NG) doesn't accept. All 9 are documented
-  carve-outs in AGENTS.md ("Acknowledged exception —
-  regex Annex B §B.1.4"). Closing them means patching
-  vendored libregexp or switching matchers.
-- The **0-fails tier** is sorted by `divergent ↓` so
-  SES-hot buckets cluster at the top of the tail — that's
-  where Cynic's frozen primordials / locked descriptors /
-  override-mistake fix concentrate. `built-ins/Array`,
-  `Object`, `TypedArray`, `String`, `Date`, `Math` are
-  the heaviest — every primordial method's `.length` /
-  `.name` slot SES locks down trips fixtures that read
-  those descriptors back expecting `configurable: true`.
-- ~~Strikethrough~~ rows are buckets we skip wholesale
-  (out of scope per the Cynic-targeted skiplist — Annex B
-  language extensions, `intl402`, `staging`,
-  browser-era built-ins, …).
+- The **`1+ fails` tiers** are the engine-work list — real
+  failures with no policy bucket. Today the bulk is the
+  SAB/Atomics surface (`built-ins/Atomics`,
+  `built-ins/SharedArrayBuffer`, plus the `-sab.js`
+  generated siblings under TypedArrayConstructors / DataView
+  / TypedArray). Cynic doesn't ship shared memory, but
+  could — so these are plain fails, not a policy bucket.
+  The remainder (~13 fixtures) is the
+  cross-realm cluster awaiting `--allow=eval` and multi-realm
+  error attribution.
+- The **0-fails tier** is sorted by `correctly handled ↓` so
+  the heaviest policy buckets cluster first. `intl402/`
+  trees dominate (no Intl), then the SES-hot built-ins
+  (`Array`, `Object`, `TypedArray`, `String`, `Date`,
+  `Math`), then the Annex B / eval / noStrict tails.
 
-| area | pass | fail | skip | divergent | pass% | engine% |
-|---|---:|---:|---:|---:|---:|---:|
-| **_0 fails — passing / wholly OOS (sorted by divergent ↓)_** | | | | | | |
-| `built-ins/Temporal` | 3885 | 0 | 0 | 703 | 100 % | 100 % |
-| `built-ins/Array` | 2481 | 0 | 0 | 564 | 100 % | 100 % |
-| `built-ins/Object` | 2784 | 0 | 0 | 536 | 100 % | 100 % |
-| `built-ins/TypedArray` | 1104 | 0 | 0 | 319 | 100 % | 100 % |
-| `built-ins/String` | 1028 | 0 | 0 | 177 | 100 % | 100 % |
-| `built-ins/Date` | 439 | 0 | 0 | 155 | 100 % | 100 % |
-| `built-ins/Math` | 214 | 0 | 0 | 113 | 100 % | 100 % |
-| `built-ins/Promise` | 525 | 0 | 0 | 104 | 100 % | 100 % |
-| `built-ins/RegExp` | 1769 | 0 | 0 | 101 | 100 % | 100 % |
-| `language/expressions` | 9747 | 0 | 0 | 99 | 100 % | 100 % |
-| `built-ins/TypedArrayConstructors` | 572 | 0 | 0 | 93 | 100 % | 100 % |
-| `language/statements` | 8520 | 0 | 0 | 89 | 100 % | 100 % |
-| `built-ins/Set` | 311 | 0 | 0 | 71 | 100 % | 100 % |
-| `built-ins/Iterator` | 368 | 0 | 0 | 64 | 100 % | 100 % |
-| `built-ins/DataView` | 455 | 0 | 0 | 56 | 100 % | 100 % |
-| `built-ins/Map` | 151 | 0 | 0 | 52 | 100 % | 100 % |
-| `built-ins/ArrayBuffer` | 133 | 0 | 0 | 50 | 100 % | 100 % |
-| `built-ins/Reflect` | 111 | 0 | 0 | 41 | 100 % | 100 % |
-| `built-ins/Number` | 302 | 0 | 0 | 38 | 100 % | 100 % |
-| `built-ins/NativeErrors` | 58 | 0 | 0 | 36 | 100 % | 100 % |
-| `built-ins/Function` | 233 | 0 | 0 | 29 | 100 % | 100 % |
-| `built-ins/JSON` | 136 | 0 | 0 | 28 | 100 % | 100 % |
-| `built-ins/WeakMap` | 114 | 0 | 0 | 27 | 100 % | 100 % |
-| `built-ins/AsyncDisposableStack` | 80 | 0 | 0 | 24 | 100 % | 100 % |
-| `built-ins/DisposableStack` | 69 | 0 | 0 | 24 | 100 % | 100 % |
-| `built-ins/Symbol` | 73 | 0 | 0 | 23 | 100 % | 100 % |
-| `built-ins/WeakSet` | 65 | 0 | 0 | 20 | 100 % | 100 % |
-| `built-ins/BigInt` | 59 | 0 | 0 | 18 | 100 % | 100 % |
-| `built-ins/Uint8Array` | 50 | 0 | 0 | 18 | 100 % | 100 % |
-| `built-ins/Error` | 43 | 0 | 0 | 14 | 100 % | 100 % |
-| `language/module-code` | 575 | 0 | 0 | 13 | 100 % | 100 % |
-| `built-ins/RegExpStringIteratorPrototype` | 5 | 0 | 0 | 12 | 100 % | 100 % |
-| `built-ins/AsyncGeneratorPrototype` | 37 | 0 | 0 | 11 | 100 % | 100 % |
-| `built-ins/FinalizationRegistry` | 36 | 0 | 0 | 11 | 100 % | 100 % |
-| `built-ins/GeneratorPrototype` | 50 | 0 | 0 | 11 | 100 % | 100 % |
-| `built-ins/WeakRef` | 21 | 0 | 0 | 8 | 100 % | 100 % |
-| `language/global-code` | 28 | 0 | 0 | 8 | 100 % | 100 % |
-| `built-ins/AsyncGeneratorFunction` | 2 | 0 | 0 | 7 | 100 % | 100 % |
-| `built-ins/Boolean` | 43 | 0 | 0 | 7 | 100 % | 100 % |
-| `built-ins/GeneratorFunction` | 2 | 0 | 0 | 7 | 100 % | 100 % |
-| `language/types` | 90 | 0 | 0 | 7 | 100 % | 100 % |
-| `built-ins/AggregateError` | 18 | 0 | 0 | 6 | 100 % | 100 % |
-| `built-ins/AsyncIteratorPrototype` | 7 | 0 | 0 | 6 | 100 % | 100 % |
-| `built-ins/Proxy` | 288 | 0 | 0 | 6 | 100 % | 100 % |
-| `built-ins/SuppressedError` | 16 | 0 | 0 | 6 | 100 % | 100 % |
-| `built-ins/AsyncFunction` | 9 | 0 | 0 | 5 | 100 % | 100 % |
-| `built-ins/ArrayIteratorPrototype` | 15 | 0 | 0 | 4 | 100 % | 100 % |
-| `built-ins/MapIteratorPrototype` | 8 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/SetIteratorPrototype` | 8 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/StringIteratorPrototype` | 4 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/decodeURI` | 52 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/decodeURIComponent` | 53 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/encodeURI` | 28 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/encodeURIComponent` | 28 | 0 | 0 | 3 | 100 % | 100 % |
-| `built-ins/global` | 6 | 0 | 0 | 3 | 100 % | 100 % |
-| `language/function-code` | 91 | 0 | 0 | 3 | 100 % | 100 % |
-| `language/arguments-object` | 202 | 0 | 0 | 2 | 100 % | 100 % |
-| `language/identifier-resolution` | 7 | 0 | 0 | 2 | 100 % | 100 % |
-| `built-ins/isFinite` | 14 | 0 | 0 | 1 | 100 % | 100 % |
-| `built-ins/isNaN` | 14 | 0 | 0 | 1 | 100 % | 100 % |
-| `built-ins/parseFloat` | 53 | 0 | 0 | 1 | 100 % | 100 % |
-| `built-ins/parseInt` | 54 | 0 | 0 | 1 | 100 % | 100 % |
-| `language/import` | 20 | 0 | 0 | 1 | 100 % | 100 % |
-| `language/punctuators` | 10 | 0 | 0 | 1 | 100 % | 100 % |
-| `built-ins/AsyncFromSyncIteratorPrototype` | 38 | 0 | 0 | 0 | 100 % | 100 % |
-| `built-ins/Infinity` | 4 | 0 | 0 | 0 | 100 % | 100 % |
-| `built-ins/NaN` | 4 | 0 | 0 | 0 | 100 % | 100 % |
-| `built-ins/ThrowTypeError` | 13 | 0 | 0 | 0 | 100 % | 100 % |
-| `built-ins/undefined` | 4 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/asi` | 102 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/block-scope` | 145 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/comments` | 44 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/computed-property-names` | 48 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/destructuring` | 18 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/directive-prologue` | 5 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/export` | 3 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/future-reserved-words` | 48 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/identifiers` | 268 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/keywords` | 25 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/line-terminators` | 32 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/literals` | 467 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/reserved-words` | 27 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/rest-parameters` | 11 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/source-text` | 1 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/statementList` | 40 | 0 | 0 | 0 | 100 % | 100 % |
-| `language/white-space` | 51 | 0 | 0 | 0 | 100 % | 100 % |
+| area | passing | failing | correctly handled | total | pass% |
+|---|---:|---:|---:|---:|---:|
+| **_100–999 fails — engine-work tier_** | | | | | |
+| `built-ins/Atomics` | 0 | 382 | 0 | 382 | 0 % |
+| `built-ins/SharedArrayBuffer` | 0 | 104 | 0 | 104 | 0 % |
+| **_10–99 fails — engine-work tier_** | | | | | |
+| `built-ins/DataView` | 455 | 39 | 56 | 550 | 93 % |
+| `built-ins/TypedArrayConstructors` | 572 | 48 | 116 | 736 | 93 % |
+| **_1–9 fails — engine-work tier_** | | | | | |
+| `built-ins/Error` | 43 | 1 | 14 | 58 | 98 % |
+| `built-ins/Function` | 315 | 5 | 189 | 509 | 99 % |
+| `built-ins/Proxy` | 290 | 3 | 18 | 311 | 99 % |
+| `built-ins/String` | 1029 | 2 | 192 | 1223 | 100 % |
+| `built-ins/ThrowTypeError` | 13 | 1 | 0 | 14 | 93 % |
+| `built-ins/TypedArray` | 1104 | 7 | 327 | 1438 | 100 % |
+| `language/expressions` | 10017 | 1 | 661 | 10682 | 100 % |
+| **_0 fails — passing / all-policy (sorted by correctly handled ↓)_** | | | | | |
+| `intl402/Temporal` | 48 | 0 | 1958 | 2006 | 100 % |
+| `annexB/language` | 82 | 0 | 763 | 845 | 100 % |
+| `built-ins/Temporal` | 3885 | 0 | 703 | 4588 | 100 % |
+| `built-ins/Object` | 2785 | 0 | 626 | 3411 | 100 % |
+| `built-ins/Array` | 2490 | 0 | 591 | 3081 | 100 % |
+| `language/statements` | 8753 | 0 | 570 | 9323 | 100 % |
+| `language/eval-code` | 73 | 0 | 274 | 347 | 100 % |
+| `intl402/NumberFormat` | 0 | 0 | 253 | 253 | 100 % |
+| `intl402/DateTimeFormat` | 0 | 0 | 248 | 248 | 100 % |
+| `annexB/built-ins` | 3 | 0 | 238 | 241 | 100 % |
+| `built-ins/Date` | 439 | 0 | 155 | 594 | 100 % |
+| `intl402/Locale` | 0 | 0 | 152 | 152 | 100 % |
+| `built-ins/Math` | 214 | 0 | 113 | 327 | 100 % |
+| `intl402/DurationFormat` | 0 | 0 | 111 | 111 | 100 % |
+| `built-ins/RegExp` | 1770 | 0 | 109 | 1879 | 100 % |
+| `built-ins/Promise` | 533 | 0 | 107 | 640 | 100 % |
+| `intl402/ListFormat` | 0 | 0 | 81 | 81 | 100 % |
+| `language/function-code` | 136 | 0 | 81 | 217 | 100 % |
+| `intl402/RelativeTimeFormat` | 0 | 0 | 80 | 80 | 100 % |
+| `intl402/Segmenter` | 0 | 0 | 79 | 79 | 100 % |
+| `built-ins/Set` | 311 | 0 | 72 | 383 | 100 % |
+| `intl402/Intl` | 0 | 0 | 66 | 66 | 100 % |
+| `intl402/Collator` | 0 | 0 | 65 | 65 | 100 % |
+| `built-ins/Iterator` | 368 | 0 | 64 | 432 | 100 % |
+| `built-ins/ArrayBuffer` | 133 | 0 | 59 | 192 | 100 % |
+| `intl402/DisplayNames` | 0 | 0 | 57 | 57 | 100 % |
+| `built-ins/Map` | 151 | 0 | 53 | 204 | 100 % |
+| `intl402/PluralRules` | 0 | 0 | 52 | 52 | 100 % |
+| `built-ins/Reflect` | 111 | 0 | 42 | 153 | 100 % |
+| `language/arguments-object` | 223 | 0 | 40 | 263 | 100 % |
+| `language/statementList` | 40 | 0 | 40 | 80 | 100 % |
+| `built-ins/Number` | 302 | 0 | 38 | 340 | 100 % |
+| `built-ins/NativeErrors` | 58 | 0 | 36 | 94 | 100 % |
+| `built-ins/JSON` | 136 | 0 | 29 | 165 | 100 % |
+| `built-ins/WeakMap` | 114 | 0 | 27 | 141 | 100 % |
+| `built-ins/Symbol` | 73 | 0 | 25 | 98 | 100 % |
+| `language/directive-prologue` | 37 | 0 | 25 | 62 | 100 % |
+| `built-ins/AsyncDisposableStack` | 80 | 0 | 24 | 104 | 100 % |
+| `built-ins/DisposableStack` | 69 | 0 | 24 | 93 | 100 % |
+| `language/types` | 90 | 0 | 23 | 113 | 100 % |
+| `intl402` | 0 | 0 | 22 | 22 | 100 % |
+| `built-ins/AsyncGeneratorFunction` | 2 | 0 | 21 | 23 | 100 % |
+| `built-ins/GeneratorFunction` | 2 | 0 | 21 | 23 | 100 % |
+| `built-ins/WeakSet` | 65 | 0 | 20 | 85 | 100 % |
+| `language/module-code` | 576 | 0 | 19 | 595 | 100 % |
+| `built-ins/BigInt` | 59 | 0 | 18 | 77 | 100 % |
+| `built-ins/Uint8Array` | 50 | 0 | 18 | 68 | 100 % |
+| `language/white-space` | 52 | 0 | 15 | 67 | 100 % |
+| `intl402/String` | 5 | 0 | 14 | 19 | 100 % |
+| `language/global-code` | 28 | 0 | 14 | 42 | 100 % |
+| `language/literals` | 521 | 0 | 13 | 534 | 100 % |
+| `built-ins/RegExpStringIteratorPrototype` | 5 | 0 | 12 | 17 | 100 % |
+| `built-ins/AsyncGeneratorPrototype` | 37 | 0 | 11 | 48 | 100 % |
+| `built-ins/FinalizationRegistry` | 36 | 0 | 11 | 47 | 100 % |
+| `built-ins/GeneratorPrototype` | 50 | 0 | 11 | 61 | 100 % |
+| `built-ins/global` | 18 | 0 | 11 | 29 | 100 % |
+| `intl402/BigInt` | 1 | 0 | 10 | 11 | 100 % |
+| `intl402/Date` | 2 | 0 | 10 | 12 | 100 % |
+| `built-ins/AsyncFunction` | 9 | 0 | 9 | 18 | 100 % |
+| `language/line-terminators` | 32 | 0 | 9 | 41 | 100 % |
+| `built-ins/Boolean` | 43 | 0 | 8 | 51 | 100 % |
+| `built-ins/WeakRef` | 21 | 0 | 8 | 29 | 100 % |
+| `language/comments` | 45 | 0 | 7 | 52 | 100 % |
+| `language/future-reserved-words` | 48 | 0 | 7 | 55 | 100 % |
+| `language/identifier-resolution` | 7 | 0 | 7 | 14 | 100 % |
+| `built-ins/AggregateError` | 19 | 0 | 6 | 25 | 100 % |
+| `built-ins/AsyncIteratorPrototype` | 7 | 0 | 6 | 13 | 100 % |
+| `built-ins/SuppressedError` | 16 | 0 | 6 | 22 | 100 % |
+| `intl402/Number` | 1 | 0 | 6 | 7 | 100 % |
+| `built-ins/ArrayIteratorPrototype` | 23 | 0 | 4 | 27 | 100 % |
+| `built-ins/undefined` | 4 | 0 | 4 | 8 | 100 % |
+| `built-ins/MapIteratorPrototype` | 8 | 0 | 3 | 11 | 100 % |
+| `built-ins/SetIteratorPrototype` | 8 | 0 | 3 | 11 | 100 % |
+| `built-ins/StringIteratorPrototype` | 4 | 0 | 3 | 7 | 100 % |
+| `built-ins/decodeURI` | 52 | 0 | 3 | 55 | 100 % |
+| `built-ins/decodeURIComponent` | 53 | 0 | 3 | 56 | 100 % |
+| `built-ins/encodeURI` | 28 | 0 | 3 | 31 | 100 % |
+| `built-ins/encodeURIComponent` | 28 | 0 | 3 | 31 | 100 % |
+| `built-ins/eval` | 7 | 0 | 3 | 10 | 100 % |
+| `built-ins/Infinity` | 4 | 0 | 2 | 6 | 100 % |
+| `built-ins/NaN` | 4 | 0 | 2 | 6 | 100 % |
+| `built-ins/isFinite` | 14 | 0 | 1 | 15 | 100 % |
+| `built-ins/isNaN` | 14 | 0 | 1 | 15 | 100 % |
+| `built-ins/parseFloat` | 53 | 0 | 1 | 54 | 100 % |
+| `built-ins/parseInt` | 54 | 0 | 1 | 55 | 100 % |
+| `intl402/Array` | 1 | 0 | 1 | 2 | 100 % |
+| `language/destructuring` | 18 | 0 | 1 | 19 | 100 % |
+| `language/import` | 20 | 0 | 1 | 21 | 100 % |
+| `language/punctuators` | 10 | 0 | 1 | 11 | 100 % |
+| `built-ins/AsyncFromSyncIteratorPrototype` | 38 | 0 | 0 | 38 | 100 % |
+| `intl402/TypedArray` | 1 | 0 | 0 | 1 | 100 % |
+| `language/asi` | 102 | 0 | 0 | 102 | 100 % |
+| `language/block-scope` | 145 | 0 | 0 | 145 | 100 % |
+| `language/computed-property-names` | 48 | 0 | 0 | 48 | 100 % |
+| `language/export` | 3 | 0 | 0 | 3 | 100 % |
+| `language/identifiers` | 268 | 0 | 0 | 268 | 100 % |
+| `language/keywords` | 25 | 0 | 0 | 25 | 100 % |
+| `language/reserved-words` | 27 | 0 | 0 | 27 | 100 % |
+| `language/rest-parameters` | 11 | 0 | 0 | 11 | 100 % |
+| `language/source-text` | 1 | 0 | 0 | 1 | 100 % |
 
 ## Pre-Stage-4 proposals shipped
 
 Per-feature scores for the TC39 proposals Cynic ships at
 Stage 1–3, ahead of their inclusion in the published
-edition. **Each proposal gets two rows** from dedicated
-phase sweeps that run only the fixtures whose frontmatter
-`features:` list names the proposal, in a realm where only
-that proposal's flag is enabled: a **(hardened)** row — the
-as-shipped SES posture (`--enable=<flag>`), SES-adjusted so
-`pass` counts divergent fixtures the same way the headline
-hardened row does — and an **(unhardened)** row against bare
-ECMA-262, mirroring the main / unhardened split.
-**These fixtures are excluded entirely from the top-line
-`## Current scores` and the per-area scoreboard** — they
-are not in the Cynic corpus and not in any bucket, so the
-headline number tracks stable ECMA-262 conformance only.
-When a proposal advances to Stage 4 the row stays here
-until its features ship in mainline ECMA-262.
+edition. Each proposal gets a **(hardened)** row — the
+as-shipped SES posture under `--enable=<flag>`, with SES
+throws counted as correctly handled — and an
+**(unhardened)** row against bare ECMA-262. Same column
+shape as the main `## Current scores` table:
+`passing | failing | correctly handled | total | pass%`.
+These fixtures are excluded from the top-line score.
 
-| feature | pass | fail | skip | pass% | engine% |
+| feature | passing | failing | correctly handled | total | pass% |
 |---|---:|---:|---:|---:|---:|
-| `joint-iteration` (hardened) | 76 | 0 | 0 | 100 % | 100 % |
-| `joint-iteration` (unhardened) | 76 | 0 | 0 | 100 % | 100 % |
-| `ShadowRealm` (hardened) | 63 | 0 | 0 | 100 % | 100 % |
-| `ShadowRealm` (unhardened) | 63 | 0 | 0 | 100 % | 100 % |
+| `joint-iteration` (hardened) | 78 | 0 | 3 | 81 | 100 % |
+| `joint-iteration` (unhardened) | 76 | 0 | 3 | 81 | 94 % |
+| `ShadowRealm` (hardened) | 64 | 0 | 3 | 67 | 100 % |
+| `ShadowRealm` (unhardened) | 63 | 0 | 3 | 67 | 94 % |
 
 
 ## History
 
-### 2026-06-01 — cynic `7f012dd`, test262 `d0c1b4555b`
+### 2026-06-01 — cynic `c1b7e7a`, test262 `d0c1b4555b`
 
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 100.00 % | 100.00 % | 43029 / 43029 | 43029 / 43029 | — | -1 | 30.5 s |
-| **runtime_hardened** | 100.00 % | 100.00 % | 43029 / 43029 | 39171 / 39171 | 3858 | -1 | 30.5 s |
-
-### 2026-05-31 — cynic `5343638`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 100.00 % | 100.00 % | 43030 / 43030 | 43030 / 43030 | — | +79 | 40.5 s |
-| **runtime_hardened** | 100.00 % | 100.00 % | 43030 / 43030 | 39172 / 39172 | 3858 | +79 | 40.5 s |
-
-### 2026-05-30 — cynic `ca71b7e`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 99.78 % | 100.00 % | 42951 / 43045 | 42951 / 42951 | — | +4956 | 30.9 s |
-| **runtime_hardened** | 99.78 % | 100.00 % | 42951 / 43045 | 39093 / 39093 | 3858 | +4956 | 35.7 s |
-
-### 2026-05-29 — cynic `7ce0853`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 84.36 % | 99.98 % | 37995 / 45039 | 37995 / 38004 | — | ±0 | 40.5 s |
-| **runtime_hardened** | 84.36 % | 99.97 % | 37995 / 45039 | 34843 / 34852 | 3152 | ±0 | 1m 00s |
-
-### 2026-05-28 — cynic `82cb66e`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 84.36 % | 99.98 % | 37995 / 45039 | 37995 / 38004 | — | +42 | 55.5 s |
-| **runtime_hardened** | 84.36 % | 99.97 % | 37995 / 45039 | 34843 / 34852 | 3152 | +44 | 1m 05s |
-
-### 2026-05-27 — cynic `618f795`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 84.16 % | 99.96 % | 37953 / 45096 | 37953 / 37968 | — | +20 | 1m 05s |
-| **runtime_hardened** | 84.16 % | 99.95 % | 37951 / 45096 | 34806 / 34823 | 3145 | +18 | 1m 10s |
-
-### 2026-05-26 — cynic `14c1e01`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 84.12 % | 99.91 % | 37933 / 45096 | 37933 / 37968 | — | +620 | 50.6 s |
-| **runtime_hardened** | 84.12 % | 99.90 % | 37933 / 45096 | 34841 / 34876 | 3092 | +3601 | 55.6 s |
-
-### 2026-05-25 — cynic `8e311c3`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.91 % | 99.98 % | 37313 / 40161 | 37313 / 37320 | — | +72 |  |
-| **runtime_hardened** | 85.49 % | 91.99 % | 34332 / 40161 | 34332 / 37321 | — | n/a |  |
-
-### 2026-05-24 — cynic `b49572e`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.90 % | 99.98 % | 37241 / 40089 | 37241 / 37248 | — | +47 |  |
-
-### 2026-05-23 — cynic `a8caaf8`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.78 % | 99.93 % | 37194 / 40090 | 37194 / 37220 | — | -17 |  |
-
-### 2026-05-22 — cynic `99b6566`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.82 % | 99.98 % | 37211 / 40090 | 37211 / 37218 | — | +3 |  |
-
-### 2026-05-21 — cynic `0ad1d25`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.81 % | 99.97 % | 37208 / 40091 | 37208 / 37219 | — | +33 |  |
-
-### 2026-05-20 — cynic `1708084`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.72 % | 99.87 % | 37175 / 40094 | 37175 / 37223 | — | +82 |  |
-
-### 2026-05-19 — cynic `b2efa16`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.51 % | 99.64 % | 37093 / 40098 | 37093 / 37227 | — | +117 |  |
-
-### 2026-05-18 — cynic `debcfcf`, test262 `b1f9a0aea3`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 92.17 % | 99.28 % | 36976 / 40115 | 36976 / 37244 | — | +314 |  |
-
-### 2026-05-17 — cynic `400fbae`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 91.28 % | 98.25 % | 36662 / 40164 | 36662 / 37315 | — | +786 |  |
-
-### 2026-05-16 — cynic `452bafa`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 88.78 % | 95.58 % | 35876 / 40411 | 35876 / 37535 | — | +1004 |  |
-
-### 2026-05-15 — cynic `2b05c51`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 85.12 % | 91.56 % | 34872 / 40969 | 34872 / 38087 | — | +1623 |  |
-
-### 2026-05-14 — cynic `aca1903`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 80.12 % | 85.56 % | 33249 / 41501 | 33249 / 38860 | — | +474 |  |
-
-### 2026-05-13 — cynic `550a57e`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 70.79 % | 85.00 % | 32775 / 46296 | 32775 / 38559 | — | +1007 |  |
-
-### 2026-05-12 — cynic `6800720`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 68.62 % | 82.38 % | 31768 / 46296 | 31768 / 38563 | — | +1877 |  |
-
-### 2026-05-11 — cynic `feb8709`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 64.53 % | 78.37 % | 29891 / 46320 | 29891 / 38141 | — | +4713 |  |
-
-### 2026-05-10 — cynic `c5c12a0`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 54.36 % | 66.01 % | 25178 / 46320 | 25178 / 38143 | — | +1265 |  |
-
-### 2026-05-09 — cynic `fcc5543`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 51.58 % | 62.65 % | 23913 / 46357 | 23913 / 38169 | — | +6048 |  |
-
-### 2026-05-08 — cynic `unknown`, test262 `d0c1b455`
-
-|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-|---|---|---|---|---|---:|---:|---:|
-| **runtime** | 34.60 % | 46.64 % | 17865 / 51639 | 17865 / 38304 | — | n/a |  |
+|         | passing | failing | correctly handled | total | pass% | Δ pass | elapsed |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | n/a | 40.1 s |
+| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | n/a | 50.1 s |
 

--- a/test262-results.md
+++ b/test262-results.md
@@ -3,27 +3,27 @@
 **Cynic passes 98.83 % of its 50894-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
 
 - **40178 passing** — Cynic produced the spec-expected result.
-- **10120 correctly handled fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
+- **10120 expected fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
 - **593 failing** — real engine failures with no policy bucket. Work to do.
 - **Out of total**, dropped before `corpus`: the upstream `harness/` and `staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary, plus shipped joint-iteration / ShadowRealm — those get their own dedicated scoreboard).
 
 ## Current scores
 
-| posture | passing | failing | correctly handled fails | total | pass% |
+| posture | passing | failing | expected fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | **unhardened, `--allow=eval`** | n/a | n/a | n/a | n/a | n/a |
 | **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6217 | 50894 | 98.82 % |
 | **hardened** (default — `cynic run`) | 40178 | 593 | 10120 | 50894 | 98.83 % |
 
-> **pass%** = `(passing + correctly handled fails) / total`.
+> **pass%** = `(passing + expected fails) / total`.
 > A fixture that fails because of a Cynic design policy
 > (Annex B not shipped, strict-only, no Intl, eval-off, SES
-> throw) is a **correctly handled fail** rather than a real
+> throw) is a **expected fail** rather than a real
 > engine bug. Plain **failing** is what's left over — real
 > engine work to do. The `--allow=eval` row is always `n/a`
 > until that opt-in ships.
 
-*SES witness fidelity*: **10 / 10** witnesses classify as SES-correctly-handled (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
+*SES witness fidelity*: **10 / 10** witnesses are SES expected fails (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
 
 ## Legend
 
@@ -46,7 +46,7 @@ refer to the same parse → compile → run sweep.
   the unhardened policies plus SES — primordials frozen,
   override-mistake fix on, locked descriptors. Fixtures
   whose expectation conflicts with SES enforcement throw
-  by design and count as correctly handled fails.
+  by design and count as expected fails.
 
 ### Columns
 
@@ -54,7 +54,7 @@ refer to the same parse → compile → run sweep.
   the spec-expected result.
 - **`failing`** — engine-true failures that *don't* match
   any design policy. Real work to do.
-- **`correctly handled fails`** — failures that hit a Cynic
+- **`expected fails`** — failures that hit a Cynic
   design policy: Annex B not shipped, strict-only,
   no Intl, eval-off, or SES throw. Counted with passes
   under `pass%` because Cynic's deliberate "no" is the
@@ -64,7 +64,7 @@ refer to the same parse → compile → run sweep.
 - **`total`** — every fixture except pre-Stage-4
   proposals (Stage ≤ 3, shipped or not) and the upstream
   `staging/` / `harness/` paths.
-- **`pass%`** — `(passing + correctly handled fails) / total`.
+- **`pass%`** — `(passing + expected fails) / total`.
   The headline.
 - **SES witness fidelity** (the italic note above) —
   positive-coverage signal. The curated witness set in
@@ -107,7 +107,7 @@ Every test262 fixture runs except:
 
 Annex B / `noStrict` / `intl402/` / the eval surface
 are NOT skipped — they run and any failure classifies
-as **correctly handled** under the matching policy.
+as an **expected fail** under the matching policy.
 
 ## Where the engine fails, by area
 
@@ -128,13 +128,13 @@ first two path components (`built-ins/Set`,
   The remainder (~13 fixtures) is the
   cross-realm cluster awaiting `--allow=eval` and multi-realm
   error attribution.
-- The **0-fails tier** is sorted by `correctly handled fails ↓` so
+- The **0-fails tier** is sorted by `expected fails ↓` so
   the heaviest policy buckets cluster first. `intl402/`
   trees dominate (no Intl), then the SES-hot built-ins
   (`Array`, `Object`, `TypedArray`, `String`, `Date`,
   `Math`), then the Annex B / eval / noStrict tails.
 
-| area | passing | failing | correctly handled fails | total | pass% |
+| area | passing | failing | expected fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | **_100–999 fails — engine-work tier_** | | | | | |
 | `built-ins/Atomics` | 0 | 382 | 0 | 382 | 0 % |
@@ -150,7 +150,7 @@ first two path components (`built-ins/Set`,
 | `built-ins/ThrowTypeError` | 13 | 1 | 0 | 14 | 93 % |
 | `built-ins/TypedArray` | 1104 | 7 | 327 | 1438 | 100 % |
 | `language/expressions` | 10017 | 1 | 661 | 10682 | 100 % |
-| **_0 fails — passing / all-policy (sorted by correctly handled fails ↓)_** | | | | | |
+| **_0 fails — passing / all-policy (sorted by expected fails ↓)_** | | | | | |
 | `intl402/Temporal` | 48 | 0 | 1958 | 2006 | 100 % |
 | `annexB/language` | 82 | 0 | 763 | 845 | 100 % |
 | `built-ins/Temporal` | 3885 | 0 | 703 | 4588 | 100 % |
@@ -258,13 +258,13 @@ Per-feature scores for the TC39 proposals Cynic ships at
 Stage 1–3, ahead of their inclusion in the published
 edition. Each proposal gets a **(hardened)** row — the
 as-shipped SES posture under `--enable=<flag>`, with SES
-throws counted as correctly handled fails — and an
+throws counted as expected fails — and an
 **(unhardened)** row against bare ECMA-262. Same column
 shape as the main `## Current scores` table:
-`passing | failing | correctly handled fails | total | pass%`.
+`passing | failing | expected fails | total | pass%`.
 These fixtures are excluded from the top-line score.
 
-| feature | passing | failing | correctly handled fails | total | pass% |
+| feature | passing | failing | expected fails | total | pass% |
 |---|---:|---:|---:|---:|---:|
 | `joint-iteration` (hardened) | 78 | 0 | 3 | 81 | 100 % |
 | `joint-iteration` (unhardened) | 76 | 0 | 3 | 81 | 94 % |
@@ -274,10 +274,10 @@ These fixtures are excluded from the top-line score.
 
 ## History
 
-### 2026-06-01 — cynic `3de4345`, test262 `d0c1b4555b`
+### 2026-06-01 — cynic `fed859f`, test262 `d0c1b4555b`
 
-|         | passing | failing | correctly handled fails | total | pass% | Δ pass | elapsed |
+|         | passing | failing | expected fails | total | pass% | Δ pass | elapsed |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | n/a | 35.1 s |
-| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | n/a | 40.1 s |
+| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | n/a | 1m 30s |
+| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | n/a | 1m 25s |
 

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -51,7 +51,7 @@
 //!   --min-hardened-spec-pct=<f>
 //!                           Companion floor on the **main (hardened)** phase
 //!                           — the SES-posture sweep, scored as the
-//!                           `runtime_hardened` row. Independent of
+//!                           `hardened` row. Independent of
 //!                           `--min-spec-pct` so a hardened regression fails
 //!                           CI even when the legacy baseline is intact.
 //!
@@ -423,15 +423,14 @@ const Outcome = enum {
     fail_false_reject, // we rejected legal code
     fail_false_accept, // we accepted code that should be a parse error
     skip,
-    /// SES-divergent — the test262 fixture's expectation is
-    /// invalidated by Cynic's hardened SES posture (frozen
-    /// primordials, locked descriptors, override-mistake fix).
-    /// Only emitted under `phase == .main` after the thrown
-    /// error message matches a known divergence pattern in
-    /// `tools/test262/ses_divergent.zig`. Counted into the
-    /// `divergent` bucket — neither pass nor fail. See
-    /// `docs/handbook/ses-test262-policy.md`.
-    fail_divergent,
+    /// Fixture failure that hits a Cynic design policy: Annex B
+    /// not shipped, strict-only, no Intl, eval-off, or SES throw
+    /// (the last is hardened-only and matched against the runtime
+    /// error pattern in `tools/test262/ses_divergent.zig`; the rest
+    /// are path / frontmatter classified via `skip_rules.pathPolicyKind`).
+    /// Counted into the `correctly_handled` bucket — neither
+    /// passing nor failing for `pass%` purposes.
+    fail_correctly_handled,
 };
 
 const SkipReason = enum {
@@ -440,22 +439,18 @@ const SkipReason = enum {
     raw_flag,
     has_includes,
     unsupported_feature,
-    /// Fixture is tagged with an Annex B / SES-carve-out feature
-    /// (`skip_rules.featureIsOutOfScope`). Permanently out of scope
-    /// for a strict-only, SES-hardened, non-browser engine — dropped
-    /// from the `corpus` denominator entirely, like the `annexB/`
-    /// path tree, instead of counted as an in-corpus skip. See
-    /// `recordOutcome` and `Stats.oos`.
+    /// Legacy slot — `annex_b` skips are no longer emitted
+    /// (Annex B fixtures run and classify as `correctly
+    /// handled` post-run). Kept in the enum for history-file parser
+    /// compatibility but never produced by the current `classifyAndRun`.
     annex_b,
-    /// Fixture is tagged with a pre-Stage-4 proposal Cynic hasn't
-    /// implemented (`skip_rules.featureIsUnimplementedProposal` —
-    /// decorators, import-defer, …). Not part of any published
-    /// ECMA-262 edition, so out of scope and dropped from the `corpus`
-    /// denominator (like `annex_b`), NOT counted as an in-corpus skip.
-    /// Recoverable, unlike `annex_b`: when the proposal reaches Stage 4
-    /// it becomes an in-scope counted skip, and when Cynic ships it the
-    /// fixtures move to a dedicated `feature:<flag>` phase. See
-    /// `recordOutcome` and `Stats.oos`.
+    /// Fixture is tagged with a pre-Stage-4 proposal — Cynic ships
+    /// shipped ones (joint-iteration, ShadowRealm) only in their
+    /// dedicated feature phases, and unshipped ones (decorators,
+    /// import-defer, …) drop here. Removed from `total` entirely;
+    /// the headline only moves when Cynic does, not when TC39 lands
+    /// new proposal fixtures upstream. Recoverable: a Stage 4
+    /// advance promotes the fixtures back into `total`.
     pre_stage4,
     no_frontmatter,
     malformed_frontmatter,
@@ -476,19 +471,25 @@ const Mode = enum {
     /// Legacy ECMAScript baseline — `realm.hardened = false`,
     /// primordials mutable, globalThis extensible. Opt into via
     /// `cynic --unhardened`. Sweep phase = `.unhardened`.
-    runtime,
+    unhardened,
     /// Default SES posture — `realm.hardened = true`, primordials
     /// frozen + override-mistake fix + locked descriptors. Sweep
     /// phase = `.main`. What `cynic run` ships.
-    runtime_hardened,
+    hardened,
+    /// Unhardened + the eval surface opted in. Placeholder until
+    /// `--allow=eval` ships (see `docs/ses-alignment.md`): no sweep
+    /// populates this row today, so it renders as `n/a` in
+    /// `test262-results.md`. Reserved here so the row layout in
+    /// `## Current scores` stays stable when eval lands.
+    unhardened_allow_eval,
 
     /// Render the mode as it appears in `test262-results.md`
-    /// score rows and headers. Matches the historical labels
-    /// where they exist.
+    /// score rows and headers.
     fn label(self: Mode) []const u8 {
         return switch (self) {
-            .runtime => "runtime",
-            .runtime_hardened => "runtime-hardened",
+            .unhardened => "unhardened",
+            .hardened => "hardened",
+            .unhardened_allow_eval => "unhardened-allow-eval",
         };
     }
 };
@@ -632,11 +633,10 @@ const Options = struct {
     min_spec_pct: f64 = 0.0,
     /// Minimum acceptable `pass%` for the **main (hardened)** phase
     /// — the SES-posture sweep that `test262-results.md`'s
-    /// `runtime_hardened` row tracks. Same enforcement shape as
+    /// `hardened` row tracks. Same enforcement shape as
     /// `min_spec_pct`, distinct flag so both postures gate
-    /// independently. For hardened, `pass%` includes divergent
-    /// reclassifications per Layout A — the math is
-    /// `(pass + divergent) / corpus`.
+    /// independently. `pass%` here is
+    /// `(passing + correctly_handled) / total`.
     ///
     /// Flag name is `--min-hardened-spec-pct` for backwards-compat
     /// with existing CI configs.
@@ -644,7 +644,7 @@ const Options = struct {
     /// Minimum acceptable pass rate on the **SES witness set**
     /// (`tools/test262/ses_witnesses.zig`). Default 0 disables;
     /// CI sets 100 so any drift in a curated witness fixture
-    /// (a previously-divergent witness now passing or failing
+    /// (a previously-correctly_handled witness now passing or failing
     /// for a non-divergence reason) fails the build. Phase 3
     /// of `docs/handbook/ses-test262-policy.md`.
     min_ses_witness_pct: f64 = 0.0,
@@ -663,21 +663,20 @@ const Stats = struct {
     skip: u32 = 0,
     pos_attempted: u32 = 0,
     neg_attempted: u32 = 0,
-    /// SES-divergent fixtures — failures the hardened-mode SES
-    /// posture intentionally produces (descriptor-shape
-    /// mismatches, frozen-primordial mutation rejected, etc.).
-    /// Set only on `.main` phase runs via the divergence-list
-    /// classifier in `tools/test262/ses_divergent.zig`. Counted
-    /// in `total` like `skip`; excluded from `fail()`. See
-    /// `docs/handbook/ses-test262-policy.md` Layout A for how
-    /// this feeds the `runtime_hardened` row's adjusted spec%.
-    divergent: u32 = 0,
+    /// Correctly-handled fixtures — failures Cynic produces by design
+    /// (SES throw, Annex B not shipped, strict-only, no Intl, eval
+    /// off). SES is matched against the thrown-error pattern in
+    /// `tools/test262/ses_divergent.zig`; the rest via
+    /// `skip_rules.pathPolicyKind`. Counted in `total` but neither
+    /// `pass()` nor `fail()`; feeds the headline
+    /// `(passing + correctly_handled) / total`.
+    correctly_handled: u32 = 0,
     /// SES-witness fixture counters — curated subset of paths
     /// (`tools/test262/ses_witnesses.zig`) that MUST classify as
-    /// `divergent` under hardened-mode runs. Drift either way
+    /// `correctly_handled` under hardened-mode runs. Drift either way
     /// (pass / fail) signals an SES enforcement regression and
     /// fails CI via `--min-ses-witness-pct=100`. The witness
-    /// fixtures are still part of the main `total` / `divergent`
+    /// fixtures are still part of the main `total` / `correctly_handled`
     /// counts — these are additional positive-coverage counters
     /// on top, not an alternative classification. Phase 3 of
     /// `docs/handbook/ses-test262-policy.md`.
@@ -690,15 +689,12 @@ const Stats = struct {
     /// roadmap work — `by_path` is policy-set, `unsupported_feature`
     /// is feature-flag-set, the rest are corpus-shape skips.
     skip_by_reason: [skip_reason_count]u32 = std.mem.zeroes([skip_reason_count]u32),
-    /// Fixtures dropped from the `corpus` denominator as out of scope —
-    /// `flags: [noStrict]` (strict-only engine), Annex B / SES-carve-out
-    /// feature tags (permanent), and unimplemented pre-Stage-4 proposal
-    /// tags (recoverable — not in any published edition yet). NOT part
-    /// of `total`, `skip`, or any bucket; tracked here purely so the
-    /// tally can report how much the corpus was trimmed and why. The
-    /// frontmatter analogue of the path-based
-    /// `pathIsPermanentlyOutOfScope` walk filter (those never reach
-    /// `recordOutcome` at all).
+    /// Fixtures dropped from `total` as out of scope. Today only
+    /// unimplemented pre-Stage-4 proposal tags land here (reason
+    /// `.pre_stage4`); the `.no_strict` / `.annex_b` arms are legacy
+    /// (those fixtures now run and classify as `correctly_handled`).
+    /// NOT part of `total`, `skip`, or any bucket; tracked purely so
+    /// the tally can report how much the corpus was trimmed and why.
     oos: u32 = 0,
     /// Per-reason histogram of `oos`. Indexed by `SkipReason`; only
     /// `.no_strict`, `.annex_b`, and `.pre_stage4` are ever non-zero.
@@ -717,7 +713,7 @@ const skip_reason_count: usize = @typeInfo(SkipReason).@"enum".fields.len;
 
 /// What kind of outcome to record for a bucket. Mirrors the
 /// three-way grouping the rolled-up `Stats` already uses.
-const BucketKind = enum { pass, fail, skip, divergent };
+const BucketKind = enum { pass, fail, skip, correctly_handled };
 
 /// Per-area counters. The `name` is the first two path
 /// components of the test262 fixture (e.g. `built-ins/Set`,
@@ -728,13 +724,13 @@ const Bucket = struct {
     pass: u32 = 0,
     fail: u32 = 0,
     skip: u32 = 0,
-    /// SES-divergent count under the hardened phase (Phase 2 of
+    /// SES-correctly_handled count under the hardened phase (Phase 2 of
     /// `docs/handbook/ses-test262-policy.md`). Always zero for
     /// buckets sourced from non-hardened sweeps — only the
-    /// `.main` phase emits divergent classifications. Counted
+    /// `.main` phase emits correctly_handled classifications. Counted
     /// separately from `pass`, `fail`, `skip`; the four together
     /// sum to `total`.
-    divergent: u32 = 0,
+    correctly_handled: u32 = 0,
     total: u32 = 0,
 };
 
@@ -774,7 +770,7 @@ const BucketMap = struct {
             .pass => gop.value_ptr.pass += 1,
             .fail => gop.value_ptr.fail += 1,
             .skip => gop.value_ptr.skip += 1,
-            .divergent => gop.value_ptr.divergent += 1,
+            .correctly_handled => gop.value_ptr.correctly_handled += 1,
         }
         gop.value_ptr.total += 1;
     }
@@ -816,9 +812,9 @@ const BucketMap = struct {
                 // a reader scanning "what does SES enforce?" sees
                 // the hot buckets first. Other tiers stay
                 // alphabetical (engine-bug work follows raw fail
-                // count, not the divergent side-channel).
-                if (ta == 4 and a.divergent != b.divergent) {
-                    return a.divergent > b.divergent;
+                // count, not the correctly_handled side-channel).
+                if (ta == 4 and a.correctly_handled != b.correctly_handled) {
+                    return a.correctly_handled > b.correctly_handled;
                 }
                 return std.mem.order(u8, a.name, b.name) == .lt;
             }
@@ -902,7 +898,7 @@ const PreStage4Stats = struct {
 const Phase = union(enum) {
     main,
     /// A dedicated per-proposal sweep, run twice per tracked flag —
-    /// once hardened (the as-shipped SES posture, with divergent
+    /// once hardened (the as-shipped SES posture, with correctly_handled
     /// classification) and once unhardened (bare ECMA-262) — so each
     /// proposal is measured the same two ways as the headline corpus.
     feature: FeaturePhase,
@@ -940,7 +936,7 @@ const Phase = union(enum) {
     /// default); `.unhardened` is the freeze-off headline sweep;
     /// each `.feature` sweep carries its own posture so a proposal
     /// is scored both hardened (as `--enable=<flag>` ships, with
-    /// divergent classification) and unhardened (bare ECMA-262).
+    /// correctly_handled classification) and unhardened (bare ECMA-262).
     fn realmHardened(self: Phase) bool {
         return switch (self) {
             .unhardened => false,
@@ -1174,8 +1170,8 @@ pub fn main(init: std.process.Init) !void {
     // unhardened path.
     if (opts.write_results) {
         // Per-feature scoreboard: each tracked proposal gets a
-        // hardened row (SES-adjusted — divergent fixtures count
-        // toward pass, same (pass + divergent) headline as the main
+        // hardened row (SES-adjusted — correctly_handled fixtures count
+        // toward pass, same (pass + correctly_handled) headline as the main
         // hardened row) and an unhardened row (bare ECMA-262).
         var pre_stage4_hardened: PreStage4Stats = .{};
         var pre_stage4_unhardened: PreStage4Stats = .{};
@@ -1183,7 +1179,7 @@ pub fn main(init: std.process.Init) !void {
             if (maybe_r) |r| {
                 pre_stage4_hardened.slots[i] = .{
                     .name = tracked_pre_stage4_features[i],
-                    .pass = r.stats.pass() + r.stats.divergent,
+                    .pass = r.stats.pass() + r.stats.correctly_handled,
                     .fail = r.stats.fail(),
                     .skip = r.stats.skip,
                     .total = r.stats.total,
@@ -1205,17 +1201,17 @@ pub fn main(init: std.process.Init) !void {
         const now_ts = std.Io.Clock.now(.real, io);
         // SES-posture (hardened, default) row from the `.main` phase
         // result. The per-feature scoreboard is written only on the
-        // unhardened (`.runtime`) pass below, so the hardened row
+        // unhardened (`.unhardened`) pass below, so the hardened row
         // gets empty per-feature stats to avoid restamping it twice.
         if (main_result) |*mr| {
             const elapsed_for_row: ?u64 = if (is_full and mr.elapsed_ms > 0) @intCast(mr.elapsed_ms) else null;
             const empty_pre_stage4: PreStage4Stats = .{};
-            try writeResults(gpa, io, &mr.stats, &mr.buckets, &empty_pre_stage4, &empty_pre_stage4, now_ts.toSeconds(), .runtime_hardened, elapsed_for_row);
+            try writeResults(gpa, io, &mr.stats, &mr.buckets, &empty_pre_stage4, &empty_pre_stage4, now_ts.toSeconds(), .hardened, elapsed_for_row);
         }
         // Unhardened (legacy) row + the two-row-per-feature scoreboard.
         if (unhardened_result) |*ur| {
             const elapsed_for_row: ?u64 = if (is_full and ur.elapsed_ms > 0) @intCast(ur.elapsed_ms) else null;
-            try writeResults(gpa, io, &ur.stats, &ur.buckets, &pre_stage4_hardened, &pre_stage4_unhardened, now_ts.toSeconds(), .runtime, elapsed_for_row);
+            try writeResults(gpa, io, &ur.stats, &ur.buckets, &pre_stage4_hardened, &pre_stage4_unhardened, now_ts.toSeconds(), .unhardened, elapsed_for_row);
         }
     }
 
@@ -1242,14 +1238,12 @@ pub fn main(init: std.process.Init) !void {
         const evalPhase = struct {
             fn f(below: *bool, pr: *const PhaseResult, floor: f64, flag_name: []const u8) void {
                 if (pr.stats.total == 0) return;
-                // Match the row's headline `spec%` per Layout A
-                // (`docs/handbook/ses-test262-policy.md`): divergent
-                // counts as engine-correct because SES is part of
-                // the spec Cynic ships in hardened mode. Equals
-                // `pass / total` for any phase with no divergence
-                // (parser, unhardened) so the legacy gate semantics
-                // are preserved there.
-                const headline_pass = pr.stats.pass() + pr.stats.divergent;
+                // Headline `pass%` = `(passing + correctly_handled)
+                // / total` — a policy failure (SES throw, Annex B,
+                // strict-only, no Intl, eval off) is the right answer
+                // for the policy Cynic ships, so it counts toward the
+                // floor.
+                const headline_pass = pr.stats.pass() + pr.stats.correctly_handled;
                 const pct = 100.0 * @as(f64, @floatFromInt(headline_pass)) / @as(f64, @floatFromInt(pr.stats.total));
                 if (pct < floor) {
                     std.debug.print(
@@ -1269,7 +1263,7 @@ pub fn main(init: std.process.Init) !void {
         // Witness floor — Phase 3 of the SES policy. The
         // witness set's pass rate must stay above
         // `--min-ses-witness-pct`. CI sets 100 % so any drift
-        // (a witness that stopped being divergent — either
+        // (a witness that stopped being correctly_handled — either
         // it's now passing, signalling SES enforcement
         // weakened, or it's now failing for a non-divergence
         // reason, signalling a pattern miss or engine
@@ -1392,18 +1386,15 @@ fn runSweep(
                 if (std.mem.indexOf(u8, entry.path, needle) == null) continue;
             }
             if (skip_rules.pathIsSkipped(entry.path)) continue;
-            // Walk-time filter: only exclude **permanently** out
-            // of scope (Annex B browser-era extensions, SES
-            // carve-outs like `eval`, etc.) — these Cynic
-            // refuses to ship, so they're not tech debt and
-            // shouldn't inflate the corpus denominator. Planned
-            // / pre-Stage-4 / vendor-gap fixtures
-            // (`pathIsCurrentlySkipped`) DO flow through to
-            // `classifyAndRun`, where they get marked as
-            // `.skip` — they show up in corpus and the skip
-            // count, honestly representing the work left to
-            // close out.
-            if (skip_rules.pathIsPermanentlyOutOfScope(entry.path)) continue;
+            // The only walk-time exclusions are `harness/` and
+            // `staging/` (handled above) plus pre-Stage-4 proposals
+            // (handled in `classifyAndRun` via the `out_of_phase` /
+            // `pre_stage4` skip reasons). Annex B, intl402, eval,
+            // noStrict, SES carve-outs all RUN — their failures
+            // classify as **correctly handled** via the policy
+            // classifier, so the corpus shape reflects the full
+            // ECMA-262 surface Cynic targets and the headline
+            // credits Cynic for the policies it ships.
             try paths.append(gpa, try gpa.dupe(u8, entry.path));
         }
     }
@@ -1773,25 +1764,12 @@ const PhaseResult = struct {
 };
 
 /// Skip reasons that take a fixture *out of the corpus denominator*
-/// rather than counting as an in-corpus skip. These mirror the
-/// path-based `pathIsPermanentlyOutOfScope` filter for frontmatter-
-/// derived exclusions:
-///   - `.no_strict` — `flags: [noStrict]` fixtures exercise sloppy
-///     mode, which Cynic does not implement (strict-only by design).
-///   - `.annex_b`   — feature tags for browser-only Annex B / SES
-///     carve-outs Cynic intentionally omits (`__proto__`,
-///     `legacy-regexp`, `IsHTMLDDA`, …).
-///   - `.pre_stage4` — feature tags for pre-Stage-4 proposals Cynic
-///     hasn't implemented yet (decorators, import-defer, …). Unlike
-///     the first two this is *recoverable*: the denominator is pinned
-///     to the published ECMAScript edition, so a proposal's fixtures
-///     stay out of `total` until it reaches Stage 4 and Cynic ships
-///     it — at which point the tag leaves this set and its fixtures
-///     re-enter the corpus. Keeps the headline from silently decaying
-///     as TC39 lands new proposal fixtures upstream.
-/// `.no_strict` / `.annex_b` are permanent design boundaries; all
-/// three are dropped from `total` like `intl402/` and the `annexB/`
-/// tree.
+/// rather than counting as an in-corpus skip. Only `.pre_stage4` is
+/// emitted today (decorators, import-defer, joint-iteration,
+/// ShadowRealm, …) — `noStrict` and Annex B fixtures now run and
+/// classify as `correctly_handled` post-run. The `.no_strict` /
+/// `.annex_b` arms stay here for backward compatibility with the
+/// rolled-up tally on historical runs.
 fn isOutOfScopeReason(r: SkipReason) bool {
     return switch (r) {
         .no_strict, .annex_b, .pre_stage4 => true,
@@ -1826,14 +1804,11 @@ fn recordOutcome(
             // Out-of-phase fixtures are ignored entirely (phase
             // filtering): no stats, no bucket, no failures, no cache.
             if (reason == .out_of_phase) return;
-            // Out-of-scope frontmatter skips (strict-only
-            // `flags: [noStrict]`, Annex B / SES-carve-out feature
-            // tags, and unimplemented pre-Stage-4 proposal tags) are
-            // dropped from the corpus denominator like the path-based
-            // `pathIsPermanentlyOutOfScope` filter, but tallied under
-            // `oos` so the tally can show the trim. The first two are
-            // permanent; pre-Stage-4 is recoverable (see
-            // `isOutOfScopeReason`).
+            // Out-of-scope frontmatter skips (unimplemented
+            // pre-Stage-4 proposal tags today; the legacy noStrict /
+            // Annex B arms are no longer emitted) are dropped from
+            // `total` but tallied under `oos` so the tally can show
+            // the trim. See `isOutOfScopeReason`.
             if (isOutOfScopeReason(reason)) {
                 stats.oos += 1;
                 stats.oos_by_reason[@intFromEnum(reason)] += 1;
@@ -1847,12 +1822,12 @@ fn recordOutcome(
         .pass_positive, .pass_negative => .pass,
         .fail_false_reject, .fail_false_accept => .fail,
         .skip => .skip,
-        // Phase 5 (`docs/handbook/ses-test262-policy.md`) — divergent
+        // Phase 5 (`docs/handbook/ses-test262-policy.md`) — correctly_handled
         // fixtures get their own bucket column instead of being lumped
         // into `skip`. Visible in the per-area scoreboard as a fourth
         // column so a reader can tell at a glance which buckets
         // accumulate SES reclassification vs which are truly skipped.
-        .fail_divergent => .divergent,
+        .fail_correctly_handled => .correctly_handled,
     };
     switch (outcome.kind) {
         .pass_positive => stats.pass_pos += 1,
@@ -1877,15 +1852,15 @@ fn recordOutcome(
                 stats.skip_by_reason[@intFromEnum(reason)] += 1;
             }
         },
-        .fail_divergent => stats.divergent += 1,
+        .fail_correctly_handled => stats.correctly_handled += 1,
     }
     // SES witness side-channel — curated paths that MUST
-    // classify as `divergent` under hardened-mode runs. Drift
-    // (pass or non-divergent fail) is logged as
-    // `witness_fail`; staying divergent is `witness_pass`.
+    // classify as `correctly_handled` under hardened-mode runs. Drift
+    // (pass or non-correctly_handled fail) is logged as
+    // `witness_fail`; staying correctly_handled is `witness_pass`.
     // Phase 3 of `docs/handbook/ses-test262-policy.md`.
     if (ses_witnesses.isWitness(rel)) {
-        if (outcome.kind == .fail_divergent) {
+        if (outcome.kind == .fail_correctly_handled) {
             stats.witness_pass += 1;
         } else if (outcome.kind == .skip) {
             // Witnessed-but-skipped (e.g. filtered out, or
@@ -1894,12 +1869,10 @@ fn recordOutcome(
             stats.witness_fail += 1;
         }
     }
-    // Bucket as `.skip` for divergent — the per-area scoreboard
-    // doesn't grow a fourth column today; reclassified failures
-    // visually look like "skipped" in the bucket totals, which
-    // is the right shape for Phase 2 (the per-bucket divergence
-    // breakdown is a follow-up). The headline divergent count
-    // sits in `Stats.divergent` for the score-row math.
+    // Bump the per-area bucket (`pass` / `fail` / `skip` /
+    // `correctly_handled`) so the scoreboard reflects this fixture's
+    // outcome. The headline correctly-handled count sits in
+    // `Stats.correctly_handled` for the score-row math.
     if (bucket_kind) |bk| try buckets.bump(bucketName(rel), bk);
     if (outcome.kind == .pass_positive or outcome.kind == .fail_false_reject) {
         stats.pos_attempted += 1;
@@ -2083,7 +2056,7 @@ fn mergeStats(dst: *Stats, src: *const Stats) void {
     dst.skip += src.skip;
     dst.pos_attempted += src.pos_attempted;
     dst.neg_attempted += src.neg_attempted;
-    dst.divergent += src.divergent;
+    dst.correctly_handled += src.correctly_handled;
     dst.witness_pass += src.witness_pass;
     dst.witness_fail += src.witness_fail;
     dst.oos += src.oos;
@@ -2105,7 +2078,7 @@ fn mergeBuckets(dst: *BucketMap, src: *const BucketMap) !void {
         gop.value_ptr.pass += v.pass;
         gop.value_ptr.fail += v.fail;
         gop.value_ptr.skip += v.skip;
-        gop.value_ptr.divergent += v.divergent;
+        gop.value_ptr.correctly_handled += v.correctly_handled;
         gop.value_ptr.total += v.total;
     }
 }
@@ -2114,20 +2087,19 @@ fn mergeBuckets(dst: *BucketMap, src: *const BucketMap) !void {
 /// (compile error or runtime throw at script eval). When a
 /// hardened phase is running (the headline `.main` sweep or a
 /// hardened per-feature sweep) and the path is in the curated
-/// `ses_divergent.divergent_paths` list, return `.fail_divergent`
-/// so the fixture lands in the divergent bucket instead of being
-/// scored as a real engine bug. Unhardened phases skip this —
+/// `ses_divergent.divergent_paths` list, return `.fail_correctly_handled`
+/// so the fixture lands in the correctly-handled bucket instead of
+/// being scored as a real engine bug. Unhardened phases skip this —
 /// with the freeze pass off, the fixture passes outright.
 ///
 /// Only applied to the test source itself — harness preamble
 /// failures (sta.js, assert.js, $DONE setup, installBuiltins)
-/// stay as `.fail_false_reject` because a divergent-list hit
-/// there would mask a real engine regression in the SES
-/// preamble path.
+/// stay as `.fail_false_reject` because a CH-list hit there would
+/// mask a real engine regression in the SES preamble path.
 fn testSourceFailureOutcome(phase: Phase, rel: []const u8) RunResult {
     if (phase.realmHardened()) {
         if (ses_divergent.classifyByPath(rel) != null) {
-            return .{ .kind = .fail_divergent };
+            return .{ .kind = .fail_correctly_handled };
         }
     }
     return .{ .kind = .fail_false_reject };
@@ -2204,7 +2176,9 @@ fn classifyAndRun(
         return .{ .kind = .skip, .skip_reason = .out_of_phase };
     }
 
-    if (fm.flags.no_strict) return .{ .kind = .skip, .skip_reason = .no_strict };
+    // `flags: [noStrict]` fixtures run; a failure classifies as
+    // `correctly handled` under the no_strict policy via the sticky
+    // policy lookup below.
     // §test262 `flags: [raw]` — the harness MUST NOT prepend any
     // preamble (sta.js + assert.js + includes). The fixture either
     // wants byte 0 to start with its own source (hashbang
@@ -2232,29 +2206,40 @@ fn classifyAndRun(
     // effect: parser `pass%` becomes a real "what fraction of
     // the corpus does the parser handle" gauge instead of a
     // heuristic-skipped underestimate.
-    // Split the feature gate three ways; a tag in none of them falls
-    // through and runs:
-    //   - Out-of-scope tags (Annex B / SES carve-outs Cynic never
-    //     implements) → `.annex_b`; `recordOutcome` drops these from
-    //     the corpus denominator.
-    //   - Unimplemented pre-Stage-4 proposals (decorators, import-defer,
-    //     …) → `.pre_stage4`; also dropped — they aren't in any
-    //     published edition, so they're out of scope until they reach
-    //     Stage 4 (then an in-corpus skip) or Cynic ships them (then a
-    //     dedicated `feature:` phase).
-    //   - Vendor-blocked *specced* tags → `.unsupported_feature`; stay
-    //     in-corpus so they keep dragging `pass%` until the gap closes.
+    // Annex B / SES carve-out feature-tagged fixtures run; a failure
+    // classifies as `correctly handled` under the matching policy via
+    // the sticky policy lookup below.
+    //
+    // Pre-Stage-4 (Stage ≤ 3) proposals stay dropped: shipped ones
+    // (joint-iteration, ShadowRealm) are filtered above via the
+    // `out_of_phase` gate so they only run in their dedicated feature
+    // sweeps; unshipped ones (decorators, import-defer, …) drop here
+    // via `.pre_stage4`. Per the user's scope decision the per-row
+    // total excludes Stage ≤ 3 entirely.
     for (fm.features) |feat| {
-        if (skip_rules.featureIsOutOfScope(feat)) {
-            return .{ .kind = .skip, .skip_reason = .annex_b };
-        }
         if (skip_rules.featureIsUnimplementedProposal(feat)) {
             return .{ .kind = .skip, .skip_reason = .pre_stage4 };
         }
-        if (skip_rules.featureIsCurrentlySkipped(feat)) {
-            return .{ .kind = .skip, .skip_reason = .unsupported_feature };
-        }
     }
+
+    // Sticky policy classification — looked up once from path +
+    // frontmatter, consulted at every `.fail_*` return point so a
+    // policy-induced failure (Annex B / strict-only / Intl absent /
+    // eval-off) classifies as `correctly_handled` instead of `fail`.
+    // SES classification is still post-run (runtime error pattern)
+    // and lives in the throw-handling block below.
+    const path_policy: ?skip_rules.PolicyKind = skip_rules.pathPolicyKind(rel, fm.features, fm.flags.no_strict);
+    // The allow-eval row (when wired) would gate out `.eval` here.
+    // Today both real phases (`.main`, `.unhardened`) admit eval.
+    const sticky_policy: ?skip_rules.PolicyKind = path_policy;
+    const fail_reject_or_ch: RunResult = if (sticky_policy != null)
+        .{ .kind = .fail_correctly_handled }
+    else
+        .{ .kind = .fail_false_reject };
+    const fail_accept_or_ch: RunResult = if (sticky_policy != null)
+        .{ .kind = .fail_correctly_handled }
+    else
+        .{ .kind = .fail_false_accept };
     const expected_negative: ?frontmatter.Negative = blk: {
         if (fm.negative) |n| break :blk n;
         break :blk null;
@@ -2285,11 +2270,11 @@ fn classifyAndRun(
     if (parse_failed) {
         if (expected_negative) |neg| {
             if (neg.type_name.len > 0 and !diagnosticsMatchClass(diags.items, neg.type_name)) {
-                return .{ .kind = .fail_false_accept };
+                return fail_accept_or_ch;
             }
             return .{ .kind = .pass_negative };
         }
-        return .{ .kind = .fail_false_reject };
+        return fail_reject_or_ch;
     }
 
     var realm = cynic.runtime.Realm.initWithBytesAllocator(arena, bytes_allocator);
@@ -2323,12 +2308,12 @@ fn classifyAndRun(
     // even when they regress under the hardened-default main
     // sweep.
     realm.hardened = phase.realmHardened();
-    realm.installBuiltins() catch return .{ .kind = .fail_false_reject };
+    realm.installBuiltins() catch return fail_reject_or_ch;
     // test262 fixtures use `__collectGarbage` / `__clearKeptObjects`
     // / `__drainMicrotasks` for deterministic triggering — debug
     // host hooks `installBuiltins` deliberately doesn't install on
     // production realms.
-    realm.installTestGlobals() catch return .{ .kind = .fail_false_reject };
+    realm.installTestGlobals() catch return fail_reject_or_ch;
     // Cap each test at a generous opcode budget so an
     // infinite-loop fixture (`while(true){}`, recursive yield,
     // a `for(;;)` waiting on an awaitable that never settles)
@@ -2356,9 +2341,9 @@ fn classifyAndRun(
     // the globalThis object's properties, so `globalThis.$DONE`
     // sees the binding without a hand-mirror.
     {
-        const done_fn = realm.heap.allocateFunctionNative(test262Done, 1, "$DONE") catch return .{ .kind = .fail_false_reject };
+        const done_fn = realm.heap.allocateFunctionNative(test262Done, 1, "$DONE") catch return fail_reject_or_ch;
         const done_v = cynic.runtime.heap.taggedFunction(done_fn);
-        realm.globals.put(realm.allocator, "$DONE", done_v) catch return .{ .kind = .fail_false_reject };
+        realm.globals.put(realm.allocator, "$DONE", done_v) catch return fail_reject_or_ch;
     }
 
     // §INTERPRETING.md — `$262` is the test262 host hook
@@ -2366,7 +2351,7 @@ fn classifyAndRun(
     // `detachArrayBuffer`, etc. Tests gated on hooks Cynic
     // doesn't implement (`createRealm`, `agent.*`, `IsHTMLDDA`)
     // skip via the feature filter; the rest get a working shim.
-    install262(&realm) catch return .{ .kind = .fail_false_reject };
+    install262(&realm) catch return fail_reject_or_ch;
 
     // Install the module loader for both `is_module` tests AND
     // script tests that use dynamic `import()` (the `dynamic-import`
@@ -2401,13 +2386,13 @@ fn classifyAndRun(
     const eff_harness: ?harness_mod.HarnessSources = if (raw) null else harness_pair;
     if (eff_harness) |hp| {
         const r1 = cynic.runtime.evaluateScript(arena, &realm, hp.sta) catch {
-            return .{ .kind = .fail_false_reject };
+            return fail_reject_or_ch;
         };
-        if (r1 == .thrown) return .{ .kind = .fail_false_reject };
+        if (r1 == .thrown) return fail_reject_or_ch;
         const r2 = cynic.runtime.evaluateScript(arena, &realm, hp.assert_js) catch {
-            return .{ .kind = .fail_false_reject };
+            return fail_reject_or_ch;
         };
-        if (r2 == .thrown) return .{ .kind = .fail_false_reject };
+        if (r2 == .thrown) return fail_reject_or_ch;
 
         // Each `includes:` name resolves to a `vendor/test262/harness/<name>`
         // file, evaluated as another Script in the same realm.
@@ -2421,9 +2406,9 @@ fn classifyAndRun(
                 return .{ .kind = .skip, .skip_reason = .has_includes };
             };
             const r_inc = cynic.runtime.evaluateScript(arena, &realm, inc_source) catch {
-                return .{ .kind = .fail_false_reject };
+                return fail_reject_or_ch;
             };
-            if (r_inc == .thrown) return .{ .kind = .fail_false_reject };
+            if (r_inc == .thrown) return fail_reject_or_ch;
         }
     }
 
@@ -2542,7 +2527,7 @@ fn classifyAndRun(
     }
 
     if (expected_negative) |_| {
-        return .{ .kind = if (test_threw) .pass_negative else .fail_false_accept };
+        return if (test_threw) .{ .kind = .pass_negative } else fail_accept_or_ch;
     }
 
     // §INTERPRETING.md async-flagged tests pass iff `$DONE()`
@@ -2607,7 +2592,7 @@ fn classifyAndRun(
         // or genuine engine bugs surfaced by SES enforcement.
         //
         // Two-layer lookup: the message-based `classify` catches
-        // the bulk (~99.5 % of divergent fixtures); a smaller
+        // the bulk (~99.5 % of correctly_handled fixtures); a smaller
         // curated `classifyByPath` escape hatch covers fixtures
         // whose generic message (e.g. bare `Expected SameValue(
         // «false», «true») to be true` from non-propertyHelper
@@ -2617,11 +2602,17 @@ fn classifyAndRun(
             const cat = ses_divergent.classify(name_str, msg_str) orelse
                 ses_divergent.classifyByPath(rel);
             if (cat != null) {
-                // Skip the FAIL log line for the divergent
+                // Skip the FAIL log line for the correctly_handled
                 // case — it's not a real failure, and printing
                 // ~2500 of these per sweep is noise.
-                return .{ .kind = .fail_divergent };
+                return .{ .kind = .fail_correctly_handled };
             }
+        }
+
+        // A path/feature-based policy match also routes through
+        // `correctly_handled` and silences the FAIL log.
+        if (sticky_policy != null) {
+            return .{ .kind = .fail_correctly_handled };
         }
 
         // Real-failure FAIL log render.
@@ -2649,16 +2640,16 @@ fn classifyAndRun(
     // enforcement loses tests where the body is implicitly
     // synchronous and just relies on assert() inside it.
     if (fm.flags.async_flag) {
-        if (test_threw) return .{ .kind = .fail_false_reject };
+        if (test_threw) return fail_reject_or_ch;
         if (realm.async_done_called) {
-            if (!realm.async_done_error.isUndefined()) return .{ .kind = .fail_false_reject };
+            if (!realm.async_done_error.isUndefined()) return fail_reject_or_ch;
             return .{ .kind = .pass_positive };
         }
         // No $DONE called. Treat as pass — many fixtures rely on
         // implicit success.
         return .{ .kind = .pass_positive };
     }
-    return .{ .kind = if (test_threw) .fail_false_reject else .pass_positive };
+    return if (test_threw) fail_reject_or_ch else .{ .kind = .pass_positive };
 }
 
 /// True if any error-severity diagnostic in `items` has an
@@ -2907,7 +2898,7 @@ fn printVerbose(io: std.Io, rel: []const u8, r: RunResult) !void {
         .fail_false_reject => "FAIL(reject)",
         .fail_false_accept => "FAIL(accept)",
         .skip => "SKIP",
-        .fail_divergent => "DIVERGENT",
+        .fail_correctly_handled => "DIVERGENT",
     };
     const msg = try std.fmt.bufPrint(&buf, "{s} {s}\n", .{ tag, rel });
     try std.Io.File.stderr().writeStreamingAll(io, msg);
@@ -2916,15 +2907,14 @@ fn printVerbose(io: std.Io, rel: []const u8, r: RunResult) !void {
 fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
     var buf: [1024]u8 = undefined;
     const pass_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(stats.pass())) / @as(f64, @floatFromInt(stats.total));
-    // Layout A `spec%` for hardened mode: (pass + divergent) /
-    // total. Divergent counts as "engine behaved correctly"
-    // because SES is part of the spec Cynic ships in hardened
-    // mode. Equals `pass_pct` for non-hardened sweeps because
-    // `stats.divergent` stays zero.
-    const adj_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(stats.pass() + stats.divergent)) / @as(f64, @floatFromInt(stats.total));
+    // Headline `pass%`: (passing + correctly_handled) / total. A
+    // correctly-handled fixture is one Cynic refuses by design, so
+    // it counts toward the headline. Equals `pass_pct` when there
+    // are no correctly-handled fixtures.
+    const adj_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(stats.pass() + stats.correctly_handled)) / @as(f64, @floatFromInt(stats.total));
     // Suppress the `adj:` line when there's no divergence — keeps
     // the unhardened phase's tally clean.
-    if (stats.divergent == 0) {
+    if (stats.correctly_handled == 0) {
         const msg = try std.fmt.bufPrint(&buf,
             \\corpus:   {d}
             \\pass:     {d}   ({d:.2}% — pass / corpus)
@@ -2955,8 +2945,8 @@ fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
         const msg = try std.fmt.bufPrint(&buf,
             \\corpus:    {d}
             \\pass:      {d}   ({d:.2}% engine-true)
-            \\divergent: {d}
-            \\pass%:     {d:.2}% — (pass + divergent) / corpus under SES policy
+            \\corr-hand: {d}
+            \\pass%:     {d:.2}% — (pass + correctly-handled) / corpus
             \\fail:      {d}
             \\skip:      {d}
             \\oos:       {d}   (dropped from corpus — strict-only, Annex B, pre-Stage-4)
@@ -2968,7 +2958,7 @@ fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
             stats.total,
             stats.pass(),
             pass_pct,
-            stats.divergent,
+            stats.correctly_handled,
             adj_pct,
             stats.fail(),
             stats.skip,
@@ -3214,14 +3204,12 @@ const Row = struct {
     attempted: u32,
     spec_pct: f64,
     attempted_pct: f64,
-    /// SES-divergent fixture count for `.runtime_hardened` rows.
-    /// Zero for every other mode. Drives the Layout A score-row
-    /// math from `docs/handbook/ses-test262-policy.md`: hardened
-    /// headline `spec%` is `(pass + divergent) / total`, so the
-    /// raw `spec_pct` field is overridden with the adjusted
-    /// number at write time and the absolute count surfaces in
-    /// a new `divergent` column.
-    divergent: u32 = 0,
+    /// Correctly-handled fixture count for this row. Headline
+    /// `pass%` is `(passing + correctly_handled) / total`; the count
+    /// also surfaces as its own column. Hardened rows carry the
+    /// most (SES throws on top of the path-policy buckets);
+    /// unhardened rows carry the path-policy buckets only.
+    correctly_handled: u32 = 0,
     /// Wall-clock duration of the run that produced this row, in
     /// milliseconds. `null` on rows imported from history files
     /// that predate the `elapsed` column and on partial runs
@@ -3230,7 +3218,7 @@ const Row = struct {
     elapsed_ms: ?u64 = null,
     /// SES-witness side-channel counters (Phase 3 of
     /// `docs/handbook/ses-test262-policy.md`). Populated on
-    /// `.runtime_hardened` rows from the run that produced them.
+    /// `.hardened` rows from the run that produced them.
     /// Zero for parsed-from-history rows that predate the column,
     /// for other modes, and for runs that didn't touch any
     /// witness paths (`--filter` excluded them). Rendered as a
@@ -3244,20 +3232,20 @@ const Row = struct {
 /// Derive `attempted` from `pass` and `attempted_pct` for rows
 /// imported from history files that didn't carry the column.
 /// `attempted_pct = 100 * engine_pass / attempted` where
-/// `engine_pass = pass - divergent` (the spec-literal pass
+/// `engine_pass = pass - correctly_handled` (the spec-literal pass
 /// numerator). Solve for `attempted`. Falls back to `engine_pass`
 /// (≡ 100% attempted ≡ 0 fail) when the percent is zero or
 /// rounding would underflow.
 ///
-/// The `divergent` term is what makes this correct for hardened
-/// rows: their `pass` column includes the SES-divergent count,
+/// The `correctly_handled` term is what makes this correct for hardened
+/// rows: their `pass` column includes the SES-correctly_handled count,
 /// but `attempted_pct` was computed against the engine-true pass
-/// (excluding divergent). A naive solve without subtracting
-/// divergent inflates `attempted` by ~`divergent / engine%` —
-/// e.g. for hardened 37503 / 99.97, omitting divergent gave
+/// (excluding correctly_handled). A naive solve without subtracting
+/// correctly_handled inflates `attempted` by ~`correctly_handled / engine%` —
+/// e.g. for hardened 37503 / 99.97, omitting correctly_handled gave
 /// 37514 instead of the correct 34487.
-fn deriveAttempted(pass: u32, divergent: u32, attempted_pct: f64) u32 {
-    const engine_pass = if (pass >= divergent) pass - divergent else pass;
+fn deriveAttempted(pass: u32, correctly_handled: u32, attempted_pct: f64) u32 {
+    const engine_pass = if (pass >= correctly_handled) pass - correctly_handled else pass;
     if (attempted_pct <= 0.0 or engine_pass == 0) return engine_pass;
     const a = @as(f64, @floatFromInt(engine_pass)) * 100.0 / attempted_pct;
     const rounded: u32 = @intFromFloat(@round(a));
@@ -3354,9 +3342,9 @@ fn writeResults(
     // extracting its raw text so a parser refresh or unhardened-
     // only refresh doesn't wipe the per-bucket signal. The
     // scoreboard regen trigger in `writeFileBody` matches —
-    // `mode_just_run == .runtime_hardened` regenerates;
+    // `mode_just_run == .hardened` regenerates;
     // everything else falls back to `preserved_scoreboard`.
-    const preserved_scoreboard: ?[]const u8 = if (mode == .runtime_hardened)
+    const preserved_scoreboard: ?[]const u8 = if (mode == .hardened)
         null
     else
         extractScoreboardSection(existing);
@@ -3364,7 +3352,7 @@ fn writeResults(
     // dedicated phase sweeps, which run alongside the unhardened
     // path. Preserve verbatim unless the run that just finished
     // is the unhardened one (which feeds the per-feature stats).
-    const preserved_pre_stage4: ?[]const u8 = if (mode == .runtime)
+    const preserved_pre_stage4: ?[]const u8 = if (mode == .unhardened)
         null
     else
         extractPreStage4Section(existing);
@@ -3374,7 +3362,7 @@ fn writeResults(
     // that just finished is NOT hardened, preserve the previous
     // note verbatim so a parser- or unhardened-mode refresh
     // doesn't drop the line from the Current Scores section.
-    const preserved_witness_note: ?[]const u8 = if (mode == .runtime_hardened)
+    const preserved_witness_note: ?[]const u8 = if (mode == .hardened)
         null
     else
         extractWitnessNote(existing);
@@ -3382,7 +3370,7 @@ fn writeResults(
     // Detect the one-time pre→post Phase 5c transition (per-area
     // pass column shifting from unhardened to hardened source).
     // The biggest-movers callout in `writeFileBody` skips when
-    // the previous file's scoreboard had no `divergent` column.
+    // the previous file's scoreboard had no `correctly_handled` column.
     const prev_scoreboard_phase5c = prevScoreboardHasDivergent(existing);
 
     var buf: std.ArrayListUnmanaged(u8) = .empty;
@@ -3400,18 +3388,15 @@ fn makeRow(
     test262_sha: []const u8,
     elapsed_ms: ?u64,
 ) Row {
-    // Layout A from `docs/handbook/ses-test262-policy.md`: the
-    // headline `spec%` for `runtime_hardened` counts the
-    // divergent fixtures as passes (they're SES doing its job,
-    // not engine bugs), so the row is directly comparable to
-    // the unhardened `runtime` baseline. For every other mode
-    // `stats.divergent` is zero and the math collapses back to
-    // the original `pass / total`.
-    const headline_pass: u32 = stats.pass() + stats.divergent;
+    // Headline `pass%` counts correctly-handled fixtures as passes
+    // (Cynic's deliberate "no" is the right answer for the policy it
+    // ships), so all rows are directly comparable. With no
+    // correctly-handled fixtures the math is just `pass / total`.
+    const headline_pass: u32 = stats.pass() + stats.correctly_handled;
     const spec_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(headline_pass)) / @as(f64, @floatFromInt(stats.total));
     // `attempted%` deliberately keeps the raw-pass numerator —
     // it's the engine-quality gauge (what fraction of what we
-    // actually ran passed), and a divergent reclassification
+    // actually ran passed), and a correctly_handled reclassification
     // shouldn't move it. Drops on any real failure regardless
     // of SES policy.
     const attempted = stats.pass() + stats.fail();
@@ -3426,7 +3411,7 @@ fn makeRow(
         .attempted = attempted,
         .spec_pct = spec_pct,
         .attempted_pct = att_pct,
-        .divergent = stats.divergent,
+        .correctly_handled = stats.correctly_handled,
         .elapsed_ms = elapsed_ms,
         .witness_pass = stats.witness_pass,
         .witness_total = stats.witness_pass + stats.witness_fail,
@@ -3456,6 +3441,19 @@ fn currentShortSha(gpa: std.mem.Allocator, io: std.Io, dir: []const u8) ?[]u8 {
     return gpa.dupe(u8, trimmed) catch null;
 }
 
+/// Parse a Mode label from a history row's first cell, accepting
+/// both the current spellings (`unhardened` / `hardened` /
+/// `unhardened-allow-eval`) and the legacy ones (`runtime` /
+/// `runtime-hardened` / `runtime_hardened`) so a history file
+/// written before the rename re-renders into the new naming on
+/// the next write rather than dropping rows on the floor.
+fn parseModeLabel(s: []const u8) ?Mode {
+    if (std.mem.eql(u8, s, "runtime")) return .unhardened;
+    if (std.mem.eql(u8, s, "runtime-hardened")) return .hardened;
+    if (std.mem.eql(u8, s, "runtime_hardened")) return .hardened;
+    return std.meta.stringToEnum(Mode, s);
+}
+
 /// Read rows from the legacy linear table (`| date | mode |
 /// scope | cynic_sha | test262_sha | total | pass | fail | skip
 /// | spec% | attempted% |`). Only rows with `scope == cynic`
@@ -3477,7 +3475,7 @@ fn parseLinearRows(
         const date = std.mem.trim(u8, it.next() orelse continue, " ");
         const mode_s = std.mem.trim(u8, it.next() orelse continue, " ");
         const scope_s = std.mem.trim(u8, it.next() orelse continue, " ");
-        const mode = std.meta.stringToEnum(Mode, mode_s) orelse continue;
+        const mode = parseModeLabel(mode_s) orelse continue;
         if (!std.mem.eql(u8, scope_s, "cynic")) continue;
         const cynic_sha = std.mem.trim(u8, it.next() orelse continue, " ");
         const t262_sha = std.mem.trim(u8, it.next() orelse continue, " ");
@@ -3561,9 +3559,57 @@ fn parsePerDayRows(
             const scope_part = std.mem.trim(u8, label[comma + 1 ..], " ");
             if (!std.mem.eql(u8, scope_part, "cynic")) continue;
         }
-        const mode = std.meta.stringToEnum(Mode, mode_part) orelse continue;
+        const mode = parseModeLabel(mode_part) orelse continue;
 
-        const spec_cell = std.mem.trim(u8, it.next() orelse continue, " ");
+        // Peek the first data cell to decide between legacy schema
+        // (`pass% | engine% | pass / corpus | pass / engine-attempt
+        // | divergent | Δ pass | elapsed`) and the new Layout-B
+        // schema (`passing | failing | correctly handled | total |
+        // pass% | Δ pass | elapsed`). Legacy ends the first cell
+        // with `%`; the new schema's first cell is a plain integer.
+        const first_data_cell_raw = it.next() orelse continue;
+        const first_data_cell = std.mem.trim(u8, first_data_cell_raw, " ");
+        if (first_data_cell.len > 0 and first_data_cell[first_data_cell.len - 1] != '%') {
+            // New Layout-B schema. Parse as passing | failing |
+            // correctly_handled | total | pass% | Δ pass | elapsed.
+            const passing = std.fmt.parseInt(u32, first_data_cell, 10) catch continue;
+            const failing_cell = std.mem.trim(u8, it.next() orelse continue, " ");
+            const failing = std.fmt.parseInt(u32, failing_cell, 10) catch continue;
+            const ch_cell = std.mem.trim(u8, it.next() orelse continue, " ");
+            const ch = std.fmt.parseInt(u32, ch_cell, 10) catch continue;
+            const total_cell = std.mem.trim(u8, it.next() orelse continue, " ");
+            const total_b = std.fmt.parseInt(u32, total_cell, 10) catch continue;
+            const passpct_cell = std.mem.trim(u8, it.next() orelse continue, " ");
+            const spec_pct_b = std.fmt.parseFloat(f64, trimSuffix(passpct_cell, "%")) catch continue;
+            _ = it.next(); // Δ pass cell — recomputed at render time
+            const elapsed_cell_raw_b = it.next();
+            const elapsed_ms_b: ?u64 = blk: {
+                const cell_raw = elapsed_cell_raw_b orelse break :blk null;
+                const cell = std.mem.trim(u8, cell_raw, " ");
+                if (cell.len == 0) break :blk null;
+                break :blk parseElapsedCell(cell);
+            };
+            try rows.append(gpa, .{
+                .date = date,
+                .mode = mode,
+                .cynic_sha = cynic_sha,
+                .test262_sha = t262_sha,
+                .total = total_b,
+                .pass = passing + ch, // Row.pass = Layout-A-style headline
+                .attempted = passing + failing,
+                .spec_pct = spec_pct_b,
+                .attempted_pct = if (passing + failing == 0)
+                    0
+                else
+                    100.0 * @as(f64, @floatFromInt(passing)) / @as(f64, @floatFromInt(passing + failing)),
+                .correctly_handled = ch,
+                .elapsed_ms = elapsed_ms_b,
+            });
+            continue;
+        }
+
+        // Legacy schema continues here.
+        const spec_cell = first_data_cell;
         const att_cell = std.mem.trim(u8, it.next() orelse continue, " ");
         const pt_cell = std.mem.trim(u8, it.next() orelse continue, " ");
 
@@ -3586,17 +3632,16 @@ fn parsePerDayRows(
             const slash_pa = std.mem.indexOf(u8, cell, "/") orelse break :blk null;
             break :blk std.fmt.parseInt(u32, std.mem.trim(u8, cell[slash_pa + 1 ..], " "), 10) catch null;
         };
-        // `divergent` column (added 2026-05-26 as Layout A in
-        // `docs/handbook/ses-test262-policy.md`). Pre-Layout-A
-        // rows don't have it; the next cell is the Δ-pass cell
+        // The legacy schema's `divergent` column. Older rows don't
+        // have it; the next cell is then the Δ-pass cell
         // (which we always skip — it's computed fresh per
         // render). Distinguish by content: `—` or a plain
-        // integer is the divergent column; anything containing
+        // integer is the correctly_handled column; anything containing
         // `±`, `+`, or `-` (the Δ-pass sign) is the legacy
         // schema's Δ cell.
-        var divergent: u32 = 0;
+        var correctly_handled: u32 = 0;
         const next_cell_raw = it.next();
-        const seen_divergent_cell = blk: {
+        const seen_correctly_handled_cell = blk: {
             if (next_cell_raw) |raw| {
                 const cell = std.mem.trim(u8, raw, " ");
                 if (cell.len == 0) break :blk false;
@@ -3605,7 +3650,7 @@ fn parsePerDayRows(
                 // integer — it always has a sign prefix.
                 if (cell[0] == '+' or cell[0] == '-' or std.mem.startsWith(u8, cell, "±")) break :blk false;
                 if (std.mem.startsWith(u8, cell, "n/a")) break :blk false;
-                divergent = std.fmt.parseInt(u32, cell, 10) catch break :blk false;
+                correctly_handled = std.fmt.parseInt(u32, cell, 10) catch break :blk false;
                 break :blk true;
             }
             break :blk false;
@@ -3616,7 +3661,7 @@ fn parsePerDayRows(
         // and we already consumed the Δ-pass cell into
         // `next_cell_raw`, the elapsed cell is the next iter
         // token.
-        const elapsed_cell_raw = if (seen_divergent_cell) blk: {
+        const elapsed_cell_raw = if (seen_correctly_handled_cell) blk: {
             _ = it.next(); // discard Δ-pass cell
             break :blk it.next();
         } else it.next(); // legacy schema: Δ-pass cell already consumed into next_cell_raw, elapsed is next
@@ -3633,10 +3678,10 @@ fn parsePerDayRows(
             .test262_sha = t262_sha,
             .total = total,
             .pass = pass,
-            .attempted = pa_attempted_override orelse deriveAttempted(pass, divergent, att_pct),
+            .attempted = pa_attempted_override orelse deriveAttempted(pass, correctly_handled, att_pct),
             .spec_pct = spec_pct,
             .attempted_pct = att_pct,
-            .divergent = divergent,
+            .correctly_handled = correctly_handled,
             .elapsed_ms = elapsed_ms,
         });
     }
@@ -3692,7 +3737,7 @@ fn writeFileBody(
     prev_bucket_pass: *const std.StringHashMapUnmanaged(u32),
     mode_just_run: Mode,
     /// Verbatim text of the previous `## Where the runtime …`
-    /// section, used when `mode_just_run != .runtime` so a
+    /// section, used when `mode_just_run != .unhardened` so a
     /// parser refresh doesn't drop the scoreboard from the last
     /// runtime sweep. `null` when no scoreboard exists yet (the
     /// scoreboard appears for the first time only after a
@@ -3710,10 +3755,10 @@ fn writeFileBody(
     /// instead) or when no prior note exists in the file.
     preserved_witness_note: ?[]const u8,
     /// True if the existing file's per-area scoreboard already
-    /// has a `divergent` column (post-Phase-5c shape). Gates the
+    /// has a `correctly_handled` column (post-Phase-5c shape). Gates the
     /// biggest-movers callout: on the one-time pre→post-5c
     /// transition, every bucket's pass count legitimately drops
-    /// by its divergent count (source shifted from unhardened to
+    /// by its correctly_handled count (source shifted from unhardened to
     /// hardened), which would dominate the movers list with
     /// synthetic "regressions." Suppressing the callout once
     /// keeps the signal clean.
@@ -3726,71 +3771,57 @@ fn writeFileBody(
     );
     // TL;DR — derives the headline numbers from the latest
     // hardened-posture row so a casual reader hits the important
-    // breakdown first without parsing the table below. Lists all
-    // four outcome buckets explicitly because conflating
-    // engine-pass with policy-divergent in a single percentage
-    // hides where the work actually is.
-    if (latestRow(rows, .runtime_hardened)) |r| {
-        const engine_pass = r.pass - r.divergent;
-        const real_fails = r.attempted - engine_pass; // r.attempted is engine-true
-        const skip = r.total - r.pass - real_fails;
-        var tb: [2048]u8 = undefined;
+    // breakdown first without parsing the table below.
+    if (latestRow(rows, .hardened)) |r| {
+        const engine_pass = r.pass - r.correctly_handled;
+        const engine_fail = if (r.attempted >= engine_pass) r.attempted - engine_pass else 0;
+        var tb: [1536]u8 = undefined;
         const tldr = try std.fmt.bufPrint(
             &tb,
             "**Cynic passes {d:.2} % of its {d}-fixture test262 corpus** under the " ++
                 "default (hardened SES) posture (`cynic run`). The breakdown:\n\n" ++
-                "- **{d} pass** at the engine-true level (engine% = {d:.2} % — see Legend).\n" ++
-                "- **{d} SES-policy divergences** — Cynic's hardened posture throws by " ++
-                "design where test262 expects the spec-literal success (frozen primordials, " ++
-                "locked descriptors, override-mistake fix). Counted as engine-correct in " ++
-                "the headline `pass%` per Layout A; see `docs/handbook/ses-test262-policy.md`.\n" ++
-                "- **{d} real engine failures** — Cynic returns the wrong answer or " ++
-                "throws where the spec expects success. (libregexp Annex B / `/v` " ++
-                "carve-outs are documented in [AGENTS.md](../AGENTS.md).)\n" ++
-                "- **{d} skipped** — *in-corpus* skips that should eventually pass: " ++
-                "single-realm Cynic (`$262.createRealm()` cross-realm fixtures, which " ++
-                "need multi-realm support) plus a handful of eval-dependent fixtures " ++
-                "awaiting `--allow=eval`.\n" ++
-                "- **Out of scope, dropped before `corpus`:** sloppy-mode " ++
-                "(`flags: [noStrict]`) fixtures — Cynic is strict-only — the " ++
-                "Annex B / browser-era feature tags (`__proto__`, `legacy-regexp`, " ++
-                "`IsHTMLDDA`, …), the `annexB/` tree, `intl402/`, `staging/`, SES " ++
-                "carve-outs, and the feature tags for pre-Stage-4 proposals Cynic " ++
-                "hasn't implemented yet (decorators, import-defer, source-phase-imports, " ++
-                "import-bytes, immutable-arraybuffer, await-dictionary). The denominator " ++
-                "is pinned to the published ECMAScript edition; an unimplemented " ++
-                "proposal's fixtures re-enter `corpus` once it reaches Stage 4. " ++
-                "Implemented pre-Stage-4 proposals (joint-iteration, ShadowRealm) are " ++
-                "scored separately behind `--enable=`, not here.\n\n",
-            .{ r.spec_pct, r.total, engine_pass, r.attempted_pct, r.divergent, real_fails, skip },
+                "- **{d} passing** — Cynic produced the spec-expected result.\n" ++
+                "- **{d} correctly handled** — failures that hit a Cynic design policy " ++
+                "(Annex B not shipped, strict-only, no Intl, eval-off, SES throw) " ++
+                "rather than an engine bug. Counted as spec-correct in `pass%` because " ++
+                "Cynic's deliberate \"no\" is the right answer for the policy it ships.\n" ++
+                "- **{d} failing** — real engine failures with no policy bucket. Work to do.\n" ++
+                "- **Out of total**, dropped before `corpus`: the upstream `harness/` and " ++
+                "`staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, " ++
+                "source-phase-imports, import-bytes, immutable-arraybuffer, " ++
+                "await-dictionary, plus shipped joint-iteration / ShadowRealm — those get " ++
+                "their own dedicated scoreboard).\n\n",
+            .{ r.spec_pct, r.total, engine_pass, r.correctly_handled, engine_fail },
         );
         try out.appendSlice(gpa, tldr);
     }
     try out.appendSlice(gpa,
         \\## Current scores
         \\
-        \\| posture | pass% | engine% | passes / corpus | divergent |
-        \\|---|---:|---:|---:|---:|
+        \\| posture | passing | failing | correctly handled | total | pass% |
+        \\|---|---:|---:|---:|---:|---:|
         \\
     );
-    // Hardened row first (the default Cynic posture, `cynic run`),
-    // unhardened second (`--unhardened` opt-out / legacy
-    // ECMAScript baseline). Same engine path, different SES
-    // posture; the only meaningful delta is the `divergent`
-    // column.
-    inline for (.{ Mode.runtime_hardened, Mode.runtime }) |m| {
+    // Three rows in user-visible order: the `--allow=eval` opt-in
+    // first (currently a placeholder — `--allow=eval` hasn't shipped
+    // yet, see `docs/ses-alignment.md`, so the row reads `n/a` until
+    // the eval surface is wired into a phase sweep), then the
+    // unhardened baseline (`--unhardened` opt-out), then hardened
+    // (the default Cynic posture, `cynic run`). Same engine path,
+    // different policy mask: unhardened counts annex_b + no_strict +
+    // intl402 + eval as correctly handled; hardened adds SES on top.
+    try writeAllowEvalPlaceholderRow(gpa, out);
+    inline for (.{ Mode.unhardened, Mode.hardened }) |m| {
         if (latestRow(rows, m)) |r| try writeMiniRow(gpa, out, r);
     }
     try out.appendSlice(gpa,
         \\
-        \\> **pass%** is the headline — `pass / corpus` (a fixture
-        \\> Cynic doesn't ship counts as a `skip`, lowering this).
-        \\> **engine%** = `pass / (pass + fail)` — of fixtures the
-        \\> engine attempted, the fraction that passed at the
-        \\> spec-literal level (skips and SES divergences drop
-        \\> out). **The engine-quality gauge** — moves only when
-        \\> a real fixture flips engine pass/fail, independent of
-        \\> what's left unimplemented or how SES policy weighs in.
+        \\> **pass%** = `(passing + correctly handled) / total`. A
+        \\> fixture that fails because of a Cynic design policy
+        \\> (Annex B not shipped, strict-only, no Intl, eval-off, SES
+        \\> throw) counts as **correctly handled** rather than a
+        \\> real engine bug. Plain **failing** is what's left over —
+        \\> real engine work to do.
         \\
         \\
     );
@@ -3805,14 +3836,14 @@ fn writeFileBody(
     // hardened runs (parser / unhardened refreshes) preserve the
     // previous note verbatim via `preserved_witness_note` so the
     // line survives across writes.
-    if (mode_just_run == .runtime_hardened) {
-        if (latestRow(rows, .runtime_hardened)) |r| {
+    if (mode_just_run == .hardened) {
+        if (latestRow(rows, .hardened)) |r| {
             if (r.witness_total > 0) {
                 const pct: f64 = 100.0 * @as(f64, @floatFromInt(r.witness_pass)) / @as(f64, @floatFromInt(r.witness_total));
                 var wb: [256]u8 = undefined;
                 const wn = try std.fmt.bufPrint(
                     &wb,
-                    "*SES witness fidelity*: **{d} / {d}** witnesses classify as `divergent` ({d:.2} %). " ++
+                    "*SES witness fidelity*: **{d} / {d}** witnesses classify as SES-correctly-handled ({d:.2} %). " ++
                         "Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. " ++
                         "See `docs/handbook/ses-test262-policy.md`.\n\n",
                     .{ r.witness_pass, r.witness_total, pct },
@@ -3835,60 +3866,50 @@ fn writeFileBody(
         \\
         \\### Rows (postures)
         \\
-        \\Same engine path, different SES posture. Both numbers
+        \\Same engine path, different policy mask. All three rows
         \\refer to the same parse → compile → run sweep.
         \\
-        \\- **hardened** — the default posture (`cynic run`).
-        \\  Primordials frozen, override-mistake fix on, locked
-        \\  descriptors on every built-in `.name` / `.length`.
-        \\  Fixtures that check spec-mandated `configurable: true`
-        \\  on those slots reclassify as **divergent** (the engine
-        \\  throws correctly; the test's expectation is the part
-        \\  invalidated by SES).
-        \\- **unhardened** — `cynic --unhardened` opt-out. Same
-        \\  engine, but `realm.hardened = false` — primordials
-        \\  stay mutable, globalThis extensible, no
-        \\  override-mistake fix. The pre-SES ECMAScript baseline.
-        \\  No fixtures get divergent-reclassified here.
+        \\- **unhardened, `--allow=eval`** — unhardened plus the
+        \\  eval surface (`eval()`, `new Function(string)`, …) opted
+        \\  in. Placeholder today: `--allow=eval` isn't shipped (see
+        \\  `docs/ses-alignment.md`), so no sweep populates this row
+        \\  and every cell reads `n/a`. When the opt-in lands, eval
+        \\  fixtures move from "correctly handled" to plain passing.
+        \\- **unhardened** — `cynic --unhardened` opt-out. Eval off
+        \\  (so eval-dependent fixtures fail and classify as
+        \\  correctly handled), Annex B / Intl / noStrict failures
+        \\  also classify as correctly handled. SES posture off —
+        \\  no SES throws.
+        \\- **hardened** — the default posture (`cynic run`). All
+        \\  the unhardened policies plus SES — primordials frozen,
+        \\  override-mistake fix on, locked descriptors. Fixtures
+        \\  whose expectation conflicts with SES enforcement throw
+        \\  by design and classify as correctly handled.
         \\
         \\### Columns
         \\
-        \\- **`pass%`** — `pass / corpus`. Under **hardened**, the
-        \\  numerator is `(pass + divergent)` per Layout A: divergent
-        \\  fixtures fail by the strict ECMA-262 letter (SES rejects
-        \\  writes the spec allows) but Cynic's default posture
-        \\  ships the SES policy, so they count as engine-correct.
-        \\  **This is what an embedder running `cynic run` sees
-        \\  succeed.** Under **unhardened**, the numerator is plain
-        \\  `pass`.
-        \\- **`engine%`** — `pass / (pass + fail)`. Of fixtures the
-        \\  engine actually attempted, the fraction that passed at
-        \\  the spec-literal engine level (no SES weighting). The
-        \\  pass numerator excludes `divergent`, so a hardened
-        \\  regression that flips a real fixture from pass to fail
-        \\  moves this column even when the divergent count masks
-        \\  the headline `pass%`. **This is the actual engine-
-        \\  quality gauge** — today >99.9 % both rows.
-        \\- **`passes / corpus`** — raw counts for `pass%`. Under
-        \\  hardened, `passes` includes divergent.
-        \\- **`divergent`** (hardened-only) — fixtures whose
-        \\  test262-written assertion conflicts with SES enforcement
-        \\  (frozen primordials, locked descriptors, override-mistake
-        \\  fix). The engine throws on the offending operation; the
-        \\  fixture's "expected pass" is invalidated by Cynic's SES
-        \\  policy. **These are spec-failures by ECMA-262's letter**,
-        \\  accepted as policy-correct under the hardened posture.
-        \\  Counted separately from `fail`. See
-        \\  `docs/handbook/ses-test262-policy.md`.
+        \\- **`passing`** — engine-true successes. Cynic produced
+        \\  the spec-expected result.
+        \\- **`failing`** — engine-true failures that *don't* match
+        \\  any design policy. Real work to do.
+        \\- **`correctly handled`** — failures that hit a Cynic
+        \\  design policy: Annex B not shipped, strict-only,
+        \\  no Intl, eval-off, or SES throw. Counted with passes
+        \\  under `pass%` because Cynic's deliberate "no" is the
+        \\  spec-correct answer for the policy Cynic ships.
+        \\  First-match priority: annex_b > no_strict > intl402 >
+        \\  eval > SES.
+        \\- **`total`** — every fixture except pre-Stage-4
+        \\  proposals (Stage ≤ 3, shipped or not) and the upstream
+        \\  `staging/` / `harness/` paths.
+        \\- **`pass%`** — `(passing + correctly handled) / total`.
+        \\  The headline.
         \\- **SES witness fidelity** (the italic note above) —
-        \\  Phase 3 positive-coverage signal. The curated witness
-        \\  set in `tools/test262/ses_witnesses.zig` is a small
-        \\  list of paths that MUST classify as `divergent` under
-        \\  hardened runs. Drift either way (witness now passes —
-        \\  SES enforcement weakened; or witness fails for a
-        \\  non-divergence reason — pattern miss or engine
-        \\  regression in the SES throw path) is a hard signal.
-        \\  CI gates the floor at 100 %.
+        \\  positive-coverage signal. The curated witness set in
+        \\  `tools/test262/ses_witnesses.zig` is a small list of
+        \\  paths that MUST classify under the SES policy under
+        \\  hardened runs. Drift either way is a hard signal. CI
+        \\  gates the floor at 100 %.
         \\- **`Δ pass`** (history) — change in `pass` versus the
         \\  previous row of the same posture.
         \\- **`elapsed`** (history) — wall-clock time of the run
@@ -3909,56 +3930,34 @@ fn writeFileBody(
         \\a lower bound on spec coverage — a fixture not in
         \\`corpus` doesn't get a verdict either way.
         \\
-        \\### Scope (what's in `corpus`)
+        \\### Scope (what's in `total`)
         \\
-        \\Two-tier skiplist in
-        \\[`tools/test262/skip.zig`](../tools/test262/skip.zig)
-        \\(see the per-group comments there for the full list):
+        \\Every test262 fixture runs except:
         \\
-        \\- **Filtered out** (not in `corpus`): sloppy-mode
-        \\  fixtures (`flags: [noStrict]`) — Cynic is strict-only;
-        \\  Annex B language extensions + browser-era built-ins
-        \\  (both the `annexB/` tree and the `__proto__` /
-        \\  `legacy-regexp` / `IsHTMLDDA` feature tags);
-        \\  `intl402/`, `harness/`, `staging/`, SES carve-outs
-        \\  (`eval()` until `--allow=eval` ships, SharedArrayBuffer
-        \\  / Atomics); and the feature tags for pre-Stage-4
-        \\  proposals Cynic hasn't implemented yet (decorators,
+        \\- the upstream `harness/` and `staging/` paths (helpers
+        \\  and WIP grounds, not portable spec fixtures); and
+        \\- every Stage ≤ 3 proposal — both unshipped (decorators,
         \\  import-defer, source-phase-imports, import-bytes,
-        \\  immutable-arraybuffer, await-dictionary). The
-        \\  denominator is pinned to the published ECMAScript
-        \\  edition: an unimplemented proposal's fixtures stay out
-        \\  of `corpus` (reason `pre_stage4`) until it reaches
-        \\  Stage 4, so the headline only moves when Cynic does, not
-        \\  when TC39 lands new proposal fixtures upstream. Pre-
-        \\  Stage-4 proposals Cynic *has* implemented (joint-
-        \\  iteration, ShadowRealm) ship behind `--enable=<name>`
-        \\  and get their own phase sweep in `## Pre-Stage-4
-        \\  proposals shipped` below. The harness reports the
-        \\  frontmatter-driven trim (`noStrict` + Annex B +
-        \\  pre-Stage-4 feature tags) as `oos` in its per-run tally.
-        \\- **In `corpus` as `skip`** — *tech debt*, should
-        \\  eventually pass: cross-realm fixtures
-        \\  (`$262.createRealm()` — single-realm Cynic doesn't
-        \\  expose multi-realm to user JS yet) and eval-dependent
-        \\  fixtures awaiting `--allow=eval`. (A specced feature
-        \\  blocked on a vendored dependency would land here too;
-        \\  none today — Perlex covers the regex surface.) These
-        \\  count toward `corpus` so `pass%` reflects the actual
-        \\  work left instead of a trimmed-denominator headline.
+        \\  immutable-arraybuffer, await-dictionary) and shipped
+        \\  (joint-iteration, ShadowRealm). Shipped pre-Stage-4
+        \\  proposals get their own scoreboard in `## Pre-Stage-4
+        \\  proposals shipped` below.
         \\
-        \\Today: test262 ships ~52k fixtures; `corpus` is ~44k.
+        \\Annex B / `noStrict` / `intl402/` / the eval surface
+        \\are NOT skipped — they run and any failure classifies
+        \\as **correctly handled** under the matching policy.
+        \\
         \\
     );
 
     // Per-area scoreboard. Sourced from the **hardened (default)**
     // sweep so its numbers match what embedders see at `cynic
-    // run`, and so the `divergent` column carries actual SES-
-    // reclassification data — the unhardened path has no divergent
+    // run`, and so the `correctly_handled` column carries actual SES-
+    // reclassification data — the unhardened path has no correctly_handled
     // classifications by construction. For non-hardened writes
     // (unhardened-only refresh) re-emit the previous scoreboard
     // verbatim so the per-bucket signal survives.
-    if (mode_just_run == .runtime_hardened and buckets.map.count() > 0) {
+    if (mode_just_run == .hardened and buckets.map.count() > 0) {
         try writeScoreboard(gpa, out, buckets);
     } else if (preserved_scoreboard) |s| {
         try out.appendSlice(gpa, s);
@@ -3967,7 +3966,7 @@ fn writeFileBody(
     // Per-feature scoreboard for the pre-Stage-4 proposals Cynic
     // ships ahead of the published edition. Same preservation
     // contract as the per-area scoreboard.
-    if (mode_just_run == .runtime and (preStage4HasData(pre_stage4_hardened) or preStage4HasData(pre_stage4_unhardened))) {
+    if (mode_just_run == .unhardened and (preStage4HasData(pre_stage4_hardened) or preStage4HasData(pre_stage4_unhardened))) {
         try writePreStage4Scoreboard(gpa, out, pre_stage4_hardened, pre_stage4_unhardened);
     } else if (preserved_pre_stage4) |s| {
         try out.appendSlice(gpa, s);
@@ -4002,8 +4001,8 @@ fn writeFileBody(
         }
         try out.appendSlice(gpa, "\n\n");
         try out.appendSlice(gpa,
-            \\|         | pass% | engine% | pass / corpus | pass / engine-attempt | divergent | Δ pass | elapsed |
-            \\|---|---|---|---|---|---:|---:|---:|
+            \\|         | passing | failing | correctly handled | total | pass% | Δ pass | elapsed |
+            \\|---|---:|---:|---:|---:|---:|---:|---:|
             \\
         );
 
@@ -4021,11 +4020,11 @@ fn writeFileBody(
         // comparable to the stored hardened baseline (they count
         // parse-positive/negative only) so the deltas would be
         // misleading; unhardened-mode buckets have a slightly
-        // different `pass` total (no divergent reclassification)
+        // different `pass` total (no correctly_handled reclassification)
         // and would show synthetic moves on every alternation.
         // Parser / unhardened refreshes preserve the previous
         // scoreboard verbatim; the callout stays with it.
-        if (first_day and mode_just_run == .runtime_hardened and
+        if (first_day and mode_just_run == .hardened and
             prev_bucket_pass.count() > 0 and prev_scoreboard_phase5c)
         {
             try writeBiggestMovers(gpa, out, buckets, prev_bucket_pass);
@@ -4036,39 +4035,51 @@ fn writeFileBody(
     }
 }
 
-/// Posture label for the `## Current scores` table. Renders the
-/// `runtime` / `runtime_hardened` Mode in user-facing terms:
-/// "hardened (default)" vs "unhardened (`--unhardened`)" so a
-/// reader who doesn't know Cynic's mode naming sees what
-/// matters — which one ships, which one is the opt-out.
+/// Posture label for the `## Current scores` table. Renders each
+/// Mode in user-facing terms so a reader who doesn't know Cynic's
+/// mode naming sees what matters — which one ships, which is the
+/// opt-out, which is the placeholder waiting on `--allow=eval`.
 fn postureLabel(m: Mode) []const u8 {
     return switch (m) {
-        .runtime_hardened => "**hardened** (default — `cynic run`)",
-        .runtime => "**unhardened** (`cynic --unhardened`)",
+        .hardened => "**hardened** (default — `cynic run`)",
+        .unhardened => "**unhardened** (`cynic --unhardened`)",
+        .unhardened_allow_eval => "**unhardened, `--allow=eval`**",
     };
 }
 
+/// Emit the placeholder row for the `--allow=eval` posture. No
+/// sweep populates it yet — `--allow=eval` isn't shipped (see
+/// `docs/ses-alignment.md`) — so every cell renders as `n/a`. The
+/// row exists so the `## Current scores` layout stays stable
+/// when the eval surface lands and starts producing real numbers.
+fn writeAllowEvalPlaceholderRow(
+    gpa: std.mem.Allocator,
+    out: *std.ArrayListUnmanaged(u8),
+) !void {
+    var buf: [256]u8 = undefined;
+    const line = try std.fmt.bufPrint(&buf, "| {s} | n/a | n/a | n/a | n/a | n/a |\n", .{
+        postureLabel(.unhardened_allow_eval),
+    });
+    try out.appendSlice(gpa, line);
+}
+
+/// Column shape: passing | failing | correctly handled | total |
+/// pass%. `r.pass` is stored as `(passing + correctly_handled)`, so we
+/// recover `passing` via subtraction to emit the passing/failing split.
 fn writeMiniRow(
     gpa: std.mem.Allocator,
     out: *std.ArrayListUnmanaged(u8),
     r: Row,
 ) !void {
     var buf: [384]u8 = undefined;
-    // Divergent count is the only meaningful per-row delta
-    // between hardened and unhardened. Hardened renders the
-    // count; unhardened renders an em-dash (the SES posture
-    // off → no fixtures get reclassified).
-    if (r.divergent > 0) {
-        const line = try std.fmt.bufPrint(&buf, "| {s} | {d:.2} % | {d:.2} % | {d} / {d} | {d} |\n", .{
-            postureLabel(r.mode), r.spec_pct, r.attempted_pct, r.pass, r.total, r.divergent,
-        });
-        try out.appendSlice(gpa, line);
-    } else {
-        const line = try std.fmt.bufPrint(&buf, "| {s} | {d:.2} % | {d:.2} % | {d} / {d} | — |\n", .{
-            postureLabel(r.mode), r.spec_pct, r.attempted_pct, r.pass, r.total,
-        });
-        try out.appendSlice(gpa, line);
-    }
+    const engine_pass = r.pass - r.correctly_handled; // == passing
+    const engine_fail = if (r.attempted >= engine_pass) r.attempted - engine_pass else 0;
+    const line = try std.fmt.bufPrint(
+        &buf,
+        "| {s} | {d} | {d} | {d} | {d} | {d:.2} % |\n",
+        .{ postureLabel(r.mode), engine_pass, engine_fail, r.correctly_handled, r.total, r.spec_pct },
+    );
+    try out.appendSlice(gpa, line);
 }
 
 /// Render an elapsed-cell. Empty for rows imported from history
@@ -4096,34 +4107,22 @@ fn writeHistoryRow(
     var buf: [512]u8 = undefined;
     var elapsed_buf: [32]u8 = undefined;
     const elapsed_cell = try formatElapsedCell(&elapsed_buf, r.elapsed_ms);
-    // True-engine-pass numerator for the `pass / attempted`
-    // column — divergent reclassifications shouldn't inflate
-    // the engine-quality gauge.
-    const attempted_pass = r.pass - r.divergent;
-    var div_buf: [32]u8 = undefined;
-    const divergent_cell: []const u8 = if (r.divergent > 0)
-        try std.fmt.bufPrint(&div_buf, "{d}", .{r.divergent})
-    else
-        "—";
-    if (prev_pass) |p| {
+    const engine_pass = r.pass - r.correctly_handled; // == passing
+    const engine_fail = if (r.attempted >= engine_pass) r.attempted - engine_pass else 0;
+    const delta_cell: []const u8 = if (prev_pass) |p| blk: {
         const delta: i64 = @as(i64, r.pass) - @as(i64, p);
-        const sign: u8 = if (delta > 0) '+' else if (delta < 0) '-' else 0;
+        if (delta == 0) break :blk "±0";
+        var d_buf: [32]u8 = undefined;
+        const sign: u8 = if (delta > 0) '+' else '-';
         const mag: u64 = @abs(delta);
-        const line = if (sign == 0)
-            try std.fmt.bufPrint(&buf, "| **{s}** | {d:.2} % | {d:.2} % | {d} / {d} | {d} / {d} | {s} | ±0 | {s} |\n", .{
-                @tagName(r.mode), r.spec_pct, r.attempted_pct, r.pass, r.total, attempted_pass, r.attempted, divergent_cell, elapsed_cell,
-            })
-        else
-            try std.fmt.bufPrint(&buf, "| **{s}** | {d:.2} % | {d:.2} % | {d} / {d} | {d} / {d} | {s} | {c}{d} | {s} |\n", .{
-                @tagName(r.mode), r.spec_pct, r.attempted_pct, r.pass, r.total, attempted_pass, r.attempted, divergent_cell, sign, mag, elapsed_cell,
-            });
-        try out.appendSlice(gpa, line);
-    } else {
-        const line = try std.fmt.bufPrint(&buf, "| **{s}** | {d:.2} % | {d:.2} % | {d} / {d} | {d} / {d} | {s} | n/a | {s} |\n", .{
-            @tagName(r.mode), r.spec_pct, r.attempted_pct, r.pass, r.total, attempted_pass, r.attempted, divergent_cell, elapsed_cell,
-        });
-        try out.appendSlice(gpa, line);
-    }
+        break :blk try std.fmt.bufPrint(&d_buf, "{c}{d}", .{ sign, mag });
+    } else "n/a";
+    const line = try std.fmt.bufPrint(
+        &buf,
+        "| **{s}** | {d} | {d} | {d} | {d} | {d:.2} % | {s} | {s} |\n",
+        .{ @tagName(r.mode), engine_pass, engine_fail, r.correctly_handled, r.total, r.spec_pct, delta_cell, elapsed_cell },
+    );
+    try out.appendSlice(gpa, line);
 }
 
 /// Find the chronologically-previous row of the same mode for
@@ -4148,7 +4147,7 @@ fn writeScoreboard(
 
     try out.appendSlice(gpa,
         \\
-        \\## Where the engine fails (and where SES diverges), by area
+        \\## Where the engine fails, by area
         \\
         \\Per-bucket breakdown sourced from the **hardened (default)**
         \\sweep so the numbers match `cynic run`. Bucketed on the
@@ -4157,29 +4156,24 @@ fn writeScoreboard(
         \\
         \\**Reading guide:**
         \\
-        \\- The **top tier** (`1+ fails`) is the engine-work list.
-        \\  Today the only entry is `built-ins/RegExp` with 9
-        \\  libregexp Annex B / `/v` grammar gaps — fixtures that
-        \\  compile patterns the vendored libregexp matcher
-        \\  (QuickJS-NG) doesn't accept. All 9 are documented
-        \\  carve-outs in AGENTS.md ("Acknowledged exception —
-        \\  regex Annex B §B.1.4"). Closing them means patching
-        \\  vendored libregexp or switching matchers.
-        \\- The **0-fails tier** is sorted by `divergent ↓` so
-        \\  SES-hot buckets cluster at the top of the tail — that's
-        \\  where Cynic's frozen primordials / locked descriptors /
-        \\  override-mistake fix concentrate. `built-ins/Array`,
-        \\  `Object`, `TypedArray`, `String`, `Date`, `Math` are
-        \\  the heaviest — every primordial method's `.length` /
-        \\  `.name` slot SES locks down trips fixtures that read
-        \\  those descriptors back expecting `configurable: true`.
-        \\- ~~Strikethrough~~ rows are buckets we skip wholesale
-        \\  (out of scope per the Cynic-targeted skiplist — Annex B
-        \\  language extensions, `intl402`, `staging`,
-        \\  browser-era built-ins, …).
+        \\- The **`1+ fails` tiers** are the engine-work list — real
+        \\  failures with no policy bucket. Today the bulk is the
+        \\  SAB/Atomics surface (`built-ins/Atomics`,
+        \\  `built-ins/SharedArrayBuffer`, plus the `-sab.js`
+        \\  generated siblings under TypedArrayConstructors / DataView
+        \\  / TypedArray). Cynic doesn't ship shared memory, but
+        \\  could — so these are plain fails, not a policy bucket.
+        \\  The remainder (~13 fixtures) is the
+        \\  cross-realm cluster awaiting `--allow=eval` and multi-realm
+        \\  error attribution.
+        \\- The **0-fails tier** is sorted by `correctly handled ↓` so
+        \\  the heaviest policy buckets cluster first. `intl402/`
+        \\  trees dominate (no Intl), then the SES-hot built-ins
+        \\  (`Array`, `Object`, `TypedArray`, `String`, `Date`,
+        \\  `Math`), then the Annex B / eval / noStrict tails.
         \\
-        \\| area | pass | fail | skip | divergent | pass% | engine% |
-        \\|---|---:|---:|---:|---:|---:|---:|
+        \\| area | passing | failing | correctly handled | total | pass% |
+        \\|---|---:|---:|---:|---:|---:|
         \\
     );
 
@@ -4198,35 +4192,26 @@ fn writeScoreboard(
                 0 => "1000+ fails — engine-work tier",
                 1 => "100–999 fails — engine-work tier",
                 2 => "10–99 fails — engine-work tier",
-                3 => "1–9 fails — engine-work tier (libregexp Annex B carve-outs today)",
-                else => "0 fails — passing / wholly OOS (sorted by divergent ↓)",
+                3 => "1–9 fails — engine-work tier",
+                else => "0 fails — passing / all-policy (sorted by correctly handled ↓)",
             };
-            const hdr = try std.fmt.bufPrint(&buf, "| **_{s}_** | | | | | | |\n", .{label});
+            const hdr = try std.fmt.bufPrint(&buf, "| **_{s}_** | | | | | |\n", .{label});
             try out.appendSlice(gpa, hdr);
             prev_tier = tier;
         }
-        // Layout A: hardened spec% counts divergent as
-        // engine-correct because the throw is SES doing its job.
-        // Matches the `runtime_hardened` headline in `## Current
-        // scores`. The unhardened scoreboard would collapse this
-        // to plain `pass / total`, but we always source from the
-        // hardened sweep.
-        const headline_pass: u32 = b.pass + b.divergent;
+        // pass% = (passing + correctly_handled) / total, matching the
+        // hardened headline in `## Current scores` (this scoreboard is
+        // always sourced from the hardened sweep).
+        const headline_pass: u32 = b.pass + b.correctly_handled;
         const pct: f64 = if (b.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(headline_pass)) / @as(f64, @floatFromInt(b.total));
-        const attempted: u32 = b.pass + b.fail;
-        const att_pct: f64 = if (attempted == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(b.pass)) / @as(f64, @floatFromInt(attempted));
-        // Strikethrough buckets we skip wholesale (every test
-        // filtered out as out-of-scope per the Cynic-targeted
-        // skiplist). Now `pass + fail + divergent == 0` so they
-        // also show no SES enforcement signal.
-        const strike: bool = (b.pass == 0 and b.fail == 0 and b.divergent == 0);
+        const strike: bool = (b.pass == 0 and b.fail == 0 and b.correctly_handled == 0);
         const line = if (strike)
-            try std.fmt.bufPrint(&buf, "| ~~`{s}`~~ | ~~{d}~~ | ~~{d}~~ | ~~{d}~~ | ~~{d}~~ | ~~{d:.0} %~~ | ~~{d:.0} %~~ |\n", .{
-                b.name, b.pass, b.fail, b.skip, b.divergent, pct, att_pct,
+            try std.fmt.bufPrint(&buf, "| ~~`{s}`~~ | ~~{d}~~ | ~~{d}~~ | ~~{d}~~ | ~~{d}~~ | ~~{d:.0} %~~ |\n", .{
+                b.name, b.pass, b.fail, b.correctly_handled, b.total, pct,
             })
         else
-            try std.fmt.bufPrint(&buf, "| `{s}` | {d} | {d} | {d} | {d} | {d:.0} % | {d:.0} % |\n", .{
-                b.name, b.pass, b.fail, b.skip, b.divergent, pct, att_pct,
+            try std.fmt.bufPrint(&buf, "| `{s}` | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{
+                b.name, b.pass, b.fail, b.correctly_handled, b.total, pct,
             });
         try out.appendSlice(gpa, line);
     }
@@ -4258,22 +4243,15 @@ fn writePreStage4Scoreboard(
         \\
         \\Per-feature scores for the TC39 proposals Cynic ships at
         \\Stage 1–3, ahead of their inclusion in the published
-        \\edition. **Each proposal gets two rows** from dedicated
-        \\phase sweeps that run only the fixtures whose frontmatter
-        \\`features:` list names the proposal, in a realm where only
-        \\that proposal's flag is enabled: a **(hardened)** row — the
-        \\as-shipped SES posture (`--enable=<flag>`), SES-adjusted so
-        \\`pass` counts divergent fixtures the same way the headline
-        \\hardened row does — and an **(unhardened)** row against bare
-        \\ECMA-262, mirroring the main / unhardened split.
-        \\**These fixtures are excluded entirely from the top-line
-        \\`## Current scores` and the per-area scoreboard** — they
-        \\are not in the Cynic corpus and not in any bucket, so the
-        \\headline number tracks stable ECMA-262 conformance only.
-        \\When a proposal advances to Stage 4 the row stays here
-        \\until its features ship in mainline ECMA-262.
+        \\edition. Each proposal gets a **(hardened)** row — the
+        \\as-shipped SES posture under `--enable=<flag>`, with SES
+        \\throws counted as correctly handled — and an
+        \\**(unhardened)** row against bare ECMA-262. Same column
+        \\shape as the main `## Current scores` table:
+        \\`passing | failing | correctly handled | total | pass%`.
+        \\These fixtures are excluded from the top-line score.
         \\
-        \\| feature | pass | fail | skip | pass% | engine% |
+        \\| feature | passing | failing | correctly handled | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
@@ -4283,17 +4261,17 @@ fn writePreStage4Scoreboard(
         const name = tracked_pre_stage4_features[i];
         const h = pre_stage4_hardened.slots[i];
         if (h.total != 0) {
-            const pct: f64 = 100.0 * @as(f64, @floatFromInt(h.pass)) / @as(f64, @floatFromInt(h.total));
-            const att: u32 = h.pass + h.fail;
-            const att_pct: f64 = if (att == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(h.pass)) / @as(f64, @floatFromInt(att));
-            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (hardened) | {d} | {d} | {d} | {d:.0} % | {d:.0} % |\n", .{ name, h.pass, h.fail, h.skip, pct, att_pct }));
+            // PreStage4Stats today uses `skip` for the policy-CH
+            // count under hardened sweeps (no separate ch field);
+            // shipped pre-Stage-4 proposals have fail=0, so the
+            // proxy holds. Same columns as the main scoreboard.
+            const pct: f64 = 100.0 * @as(f64, @floatFromInt(h.pass + h.skip)) / @as(f64, @floatFromInt(h.total));
+            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (hardened) | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ name, h.pass, h.fail, h.skip, h.total, pct }));
         }
         const u = pre_stage4_unhardened.slots[i];
         if (u.total != 0) {
             const pct: f64 = 100.0 * @as(f64, @floatFromInt(u.pass)) / @as(f64, @floatFromInt(u.total));
-            const att: u32 = u.pass + u.fail;
-            const att_pct: f64 = if (att == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(u.pass)) / @as(f64, @floatFromInt(att));
-            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (unhardened) | {d} | {d} | {d} | {d:.0} % | {d:.0} % |\n", .{ name, u.pass, u.fail, u.skip, pct, att_pct }));
+            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (unhardened) | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ name, u.pass, u.fail, u.skip, u.total, pct }));
         }
     }
     try out.appendSlice(gpa, "\n");
@@ -4386,13 +4364,13 @@ fn extractWitnessNote(existing: []const u8) ?[]const u8 {
 }
 
 /// True if the existing file's per-area scoreboard already
-/// carries a `divergent` column (i.e. post-Phase-5c shape).
+/// carries a `correctly_handled` column (i.e. post-Phase-5c shape).
 /// Used by `writeFileBody` to gate the "Biggest movers"
 /// callout: on the one-time transition from pre-5c (pass
 /// column sourced from unhardened) to post-5c (pass column
 /// sourced from hardened, slightly lower per-bucket), every
 /// row's `pass` legitimately drops by the per-bucket
-/// divergent count, which would dominate the movers list
+/// correctly_handled count, which would dominate the movers list
 /// with synthetic "regressions." Suppressing the callout on
 /// that single sweep keeps the signal clean.
 /// Locate the per-area scoreboard section by trying both the
@@ -4400,6 +4378,13 @@ fn extractWitnessNote(existing: []const u8) ?[]const u8 {
 /// by area` heading from earlier file generations. Returns the
 /// byte offset of the heading line on success, null otherwise.
 fn findScoreboardHeading(existing: []const u8) ?struct { offset: usize, length: usize } {
+    // Most recent heading first. Each prior render lives in
+    // historical results.md files; the legacy fallbacks below let
+    // a pre-Layout-B file extract its scoreboard section cleanly.
+    const layout_b = "## Where the engine fails, by area";
+    if (std.mem.indexOf(u8, existing, layout_b)) |off| {
+        return .{ .offset = off, .length = layout_b.len };
+    }
     const headings = [_][]const u8{
         "## Where the engine fails (and where SES diverges), by area",
         "## Where the runtime stands, by area",
@@ -4416,7 +4401,7 @@ fn prevScoreboardHasDivergent(existing: []const u8) bool {
     const found = findScoreboardHeading(existing) orelse return false;
     const start = found.offset;
     // Find the column-header line (starts with `| area |`). The
-    // divergent column adds a `| divergent |` cell; pre-5c
+    // correctly_handled column adds a `| correctly_handled |` cell; pre-5c
     // tables didn't have it.
     var cursor = start;
     const cap = @min(existing.len, start + 4096);
@@ -4424,7 +4409,7 @@ fn prevScoreboardHasDivergent(existing: []const u8) bool {
         const eol = std.mem.indexOfScalarPos(u8, existing, cursor, '\n') orelse cap;
         const line = existing[cursor..eol];
         if (std.mem.startsWith(u8, line, "| area |")) {
-            return std.mem.indexOf(u8, line, "| divergent |") != null;
+            return std.mem.indexOf(u8, line, "| correctly_handled |") != null;
         }
         cursor = eol + 1;
     }

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -663,12 +663,12 @@ const Stats = struct {
     skip: u32 = 0,
     pos_attempted: u32 = 0,
     neg_attempted: u32 = 0,
-    /// Correctly-handled fixtures — failures Cynic produces by design
-    /// (SES throw, Annex B not shipped, strict-only, no Intl, eval
-    /// off). SES is matched against the thrown-error pattern in
-    /// `tools/test262/ses_divergent.zig`; the rest via
-    /// `skip_rules.pathPolicyKind`. Counted in `total` but neither
-    /// `pass()` nor `fail()`; feeds the headline
+    /// Failures Cynic produces by design (SES throw, Annex B not
+    /// shipped, strict-only, no Intl, eval off) — rendered as the
+    /// **`expected fails`** column. SES is matched against the
+    /// thrown-error pattern in `tools/test262/ses_divergent.zig`; the
+    /// rest via `skip_rules.pathPolicyKind`. Counted in `total` but
+    /// neither `pass()` nor `fail()`; feeds the headline
     /// `(passing + correctly_handled) / total`.
     correctly_handled: u32 = 0,
     /// SES-witness fixture counters — curated subset of paths
@@ -1391,7 +1391,7 @@ fn runSweep(
             // (handled in `classifyAndRun` via the `out_of_phase` /
             // `pre_stage4` skip reasons). Annex B, intl402, eval,
             // noStrict, SES carve-outs all RUN — their failures
-            // classify as **correctly handled** via the policy
+            // classify as an **expected fail** via the policy
             // classifier, so the corpus shape reflects the full
             // ECMA-262 surface Cynic targets and the headline
             // credits Cynic for the policies it ships.
@@ -1871,7 +1871,7 @@ fn recordOutcome(
     }
     // Bump the per-area bucket (`pass` / `fail` / `skip` /
     // `correctly_handled`) so the scoreboard reflects this fixture's
-    // outcome. The headline correctly-handled count sits in
+    // outcome. The headline expected-fails count sits in
     // `Stats.correctly_handled` for the score-row math.
     if (bucket_kind) |bk| try buckets.bump(bucketName(rel), bk);
     if (outcome.kind == .pass_positive or outcome.kind == .fail_false_reject) {
@@ -2088,7 +2088,7 @@ fn mergeBuckets(dst: *BucketMap, src: *const BucketMap) !void {
 /// hardened phase is running (the headline `.main` sweep or a
 /// hardened per-feature sweep) and the path is in the curated
 /// `ses_divergent.divergent_paths` list, return `.fail_correctly_handled`
-/// so the fixture lands in the correctly-handled bucket instead of
+/// so the fixture lands in the expected-fails bucket instead of
 /// being scored as a real engine bug. Unhardened phases skip this —
 /// with the freeze pass off, the fixture passes outright.
 ///
@@ -2177,7 +2177,7 @@ fn classifyAndRun(
     }
 
     // `flags: [noStrict]` fixtures run; a failure classifies as
-    // `correctly handled` under the no_strict policy via the sticky
+    // an expected fail under the no_strict policy via the sticky
     // policy lookup below.
     // §test262 `flags: [raw]` — the harness MUST NOT prepend any
     // preamble (sta.js + assert.js + includes). The fixture either
@@ -2207,7 +2207,7 @@ fn classifyAndRun(
     // the corpus does the parser handle" gauge instead of a
     // heuristic-skipped underestimate.
     // Annex B / SES carve-out feature-tagged fixtures run; a failure
-    // classifies as `correctly handled` under the matching policy via
+    // classifies as an expected fail under the matching policy via
     // the sticky policy lookup below.
     //
     // Pre-Stage-4 (Stage ≤ 3) proposals stay dropped: shipped ones
@@ -2908,9 +2908,9 @@ fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
     var buf: [1024]u8 = undefined;
     const pass_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(stats.pass())) / @as(f64, @floatFromInt(stats.total));
     // Headline `pass%`: (passing + correctly_handled) / total. A
-    // correctly-handled fixture is one Cynic refuses by design, so
+    // an expected fail is one Cynic refuses by design, so
     // it counts toward the headline. Equals `pass_pct` when there
-    // are no correctly-handled fixtures.
+    // are no expected fails.
     const adj_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(stats.pass() + stats.correctly_handled)) / @as(f64, @floatFromInt(stats.total));
     // Suppress the `adj:` line when there's no divergence — keeps
     // the unhardened phase's tally clean.
@@ -2945,8 +2945,8 @@ fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
         const msg = try std.fmt.bufPrint(&buf,
             \\corpus:    {d}
             \\passing:   {d}   ({d:.2}% engine-true)
-            \\corr-hand: {d}   (correctly handled fails)
-            \\pass%:     {d:.2}% — (passing + correctly-handled fails) / corpus
+            \\corr-hand: {d}   (expected fails)
+            \\pass%:     {d:.2}% — (passing + expected fails) / corpus
             \\failing:   {d}
             \\skip:      {d}
             \\oos:       {d}   (dropped from corpus — pre-Stage-4)
@@ -3204,10 +3204,10 @@ const Row = struct {
     attempted: u32,
     spec_pct: f64,
     attempted_pct: f64,
-    /// Correctly-handled fixture count for this row. Headline
-    /// `pass%` is `(passing + correctly_handled) / total`; the count
-    /// also surfaces as its own column. Hardened rows carry the
-    /// most (SES throws on top of the path-policy buckets);
+    /// Expected-fails count for this row (the `expected fails`
+    /// column). Headline `pass%` is
+    /// `(passing + correctly_handled) / total`. Hardened rows carry
+    /// the most (SES throws on top of the path-policy buckets);
     /// unhardened rows carry the path-policy buckets only.
     correctly_handled: u32 = 0,
     /// Wall-clock duration of the run that produced this row, in
@@ -3388,10 +3388,10 @@ fn makeRow(
     test262_sha: []const u8,
     elapsed_ms: ?u64,
 ) Row {
-    // Headline `pass%` counts correctly-handled fixtures as passes
+    // Headline `pass%` counts expected fails as passes
     // (Cynic's deliberate "no" is the right answer for the policy it
     // ships), so all rows are directly comparable. With no
-    // correctly-handled fixtures the math is just `pass / total`.
+    // expected fails the math is just `pass / total`.
     const headline_pass: u32 = stats.pass() + stats.correctly_handled;
     const spec_pct: f64 = if (stats.total == 0) 0.0 else 100.0 * @as(f64, @floatFromInt(headline_pass)) / @as(f64, @floatFromInt(stats.total));
     // `attempted%` deliberately keeps the raw-pass numerator —
@@ -3564,8 +3564,8 @@ fn parsePerDayRows(
         // Peek the first data cell to decide between the legacy
         // schema (`pass% | engine% | pass / corpus | pass /
         // engine-attempt | divergent | Δ pass | elapsed`) and the
-        // current schema (`passing | failing | correctly handled
-        // fails | total | pass% | Δ pass | elapsed`). Legacy ends the
+        // current schema (`passing | failing | expected fails |
+        // total | pass% | Δ pass | elapsed`). Legacy ends the
         // first cell with `%`; the current schema's first cell is a
         // plain integer.
         const first_data_cell_raw = it.next() orelse continue;
@@ -3780,7 +3780,7 @@ fn writeFileBody(
             "**Cynic passes {d:.2} % of its {d}-fixture test262 corpus** under the " ++
                 "default (hardened SES) posture (`cynic run`). The breakdown:\n\n" ++
                 "- **{d} passing** — Cynic produced the spec-expected result.\n" ++
-                "- **{d} correctly handled fails** — failures that hit a Cynic design " ++
+                "- **{d} expected fails** — failures that hit a Cynic design " ++
                 "policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) " ++
                 "rather than an engine bug. Counted as spec-correct in `pass%` because " ++
                 "Cynic's deliberate \"no\" is the right answer for the policy it ships.\n" ++
@@ -3797,7 +3797,7 @@ fn writeFileBody(
     try out.appendSlice(gpa,
         \\## Current scores
         \\
-        \\| posture | passing | failing | correctly handled fails | total | pass% |
+        \\| posture | passing | failing | expected fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
@@ -3807,7 +3807,7 @@ fn writeFileBody(
     // ships), then the unhardened baseline (`--unhardened` opt-out),
     // then hardened (the default Cynic posture, `cynic run`). Same
     // engine path, different policy mask: unhardened counts annex_b +
-    // no_strict + intl402 + eval as correctly handled fails; hardened
+    // no_strict + intl402 + eval as expected fails; hardened
     // adds SES on top.
     try writeAllowEvalPlaceholderRow(gpa, out);
     inline for (.{ Mode.unhardened, Mode.hardened }) |m| {
@@ -3815,10 +3815,10 @@ fn writeFileBody(
     }
     try out.appendSlice(gpa,
         \\
-        \\> **pass%** = `(passing + correctly handled fails) / total`.
+        \\> **pass%** = `(passing + expected fails) / total`.
         \\> A fixture that fails because of a Cynic design policy
         \\> (Annex B not shipped, strict-only, no Intl, eval-off, SES
-        \\> throw) is a **correctly handled fail** rather than a real
+        \\> throw) is a **expected fail** rather than a real
         \\> engine bug. Plain **failing** is what's left over — real
         \\> engine work to do. The `--allow=eval` row is always `n/a`
         \\> until that opt-in ships.
@@ -3843,7 +3843,7 @@ fn writeFileBody(
                 var wb: [256]u8 = undefined;
                 const wn = try std.fmt.bufPrint(
                     &wb,
-                    "*SES witness fidelity*: **{d} / {d}** witnesses classify as SES-correctly-handled ({d:.2} %). " ++
+                    "*SES witness fidelity*: **{d} / {d}** witnesses are SES expected fails ({d:.2} %). " ++
                         "Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. " ++
                         "See `docs/handbook/ses-test262-policy.md`.\n\n",
                     .{ r.witness_pass, r.witness_total, pct },
@@ -3883,7 +3883,7 @@ fn writeFileBody(
         \\  the unhardened policies plus SES — primordials frozen,
         \\  override-mistake fix on, locked descriptors. Fixtures
         \\  whose expectation conflicts with SES enforcement throw
-        \\  by design and count as correctly handled fails.
+        \\  by design and count as expected fails.
         \\
         \\### Columns
         \\
@@ -3891,7 +3891,7 @@ fn writeFileBody(
         \\  the spec-expected result.
         \\- **`failing`** — engine-true failures that *don't* match
         \\  any design policy. Real work to do.
-        \\- **`correctly handled fails`** — failures that hit a Cynic
+        \\- **`expected fails`** — failures that hit a Cynic
         \\  design policy: Annex B not shipped, strict-only,
         \\  no Intl, eval-off, or SES throw. Counted with passes
         \\  under `pass%` because Cynic's deliberate "no" is the
@@ -3901,7 +3901,7 @@ fn writeFileBody(
         \\- **`total`** — every fixture except pre-Stage-4
         \\  proposals (Stage ≤ 3, shipped or not) and the upstream
         \\  `staging/` / `harness/` paths.
-        \\- **`pass%`** — `(passing + correctly handled fails) / total`.
+        \\- **`pass%`** — `(passing + expected fails) / total`.
         \\  The headline.
         \\- **SES witness fidelity** (the italic note above) —
         \\  positive-coverage signal. The curated witness set in
@@ -3944,7 +3944,7 @@ fn writeFileBody(
         \\
         \\Annex B / `noStrict` / `intl402/` / the eval surface
         \\are NOT skipped — they run and any failure classifies
-        \\as **correctly handled** under the matching policy.
+        \\as an **expected fail** under the matching policy.
         \\
         \\
     );
@@ -4000,7 +4000,7 @@ fn writeFileBody(
         }
         try out.appendSlice(gpa, "\n\n");
         try out.appendSlice(gpa,
-            \\|         | passing | failing | correctly handled fails | total | pass% | Δ pass | elapsed |
+            \\|         | passing | failing | expected fails | total | pass% | Δ pass | elapsed |
             \\|---|---:|---:|---:|---:|---:|---:|---:|
             \\
         );
@@ -4063,7 +4063,7 @@ fn writeAllowEvalPlaceholderRow(
     try out.appendSlice(gpa, line);
 }
 
-/// Column shape: passing | failing | correctly handled | total |
+/// Column shape: passing | failing | expected fails | total |
 /// pass%. `r.pass` is stored as `(passing + correctly_handled)`, so we
 /// recover `passing` via subtraction to emit the passing/failing split.
 fn writeMiniRow(
@@ -4166,13 +4166,13 @@ fn writeScoreboard(
         \\  The remainder (~13 fixtures) is the
         \\  cross-realm cluster awaiting `--allow=eval` and multi-realm
         \\  error attribution.
-        \\- The **0-fails tier** is sorted by `correctly handled fails ↓` so
+        \\- The **0-fails tier** is sorted by `expected fails ↓` so
         \\  the heaviest policy buckets cluster first. `intl402/`
         \\  trees dominate (no Intl), then the SES-hot built-ins
         \\  (`Array`, `Object`, `TypedArray`, `String`, `Date`,
         \\  `Math`), then the Annex B / eval / noStrict tails.
         \\
-        \\| area | passing | failing | correctly handled fails | total | pass% |
+        \\| area | passing | failing | expected fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
@@ -4193,7 +4193,7 @@ fn writeScoreboard(
                 1 => "100–999 fails — engine-work tier",
                 2 => "10–99 fails — engine-work tier",
                 3 => "1–9 fails — engine-work tier",
-                else => "0 fails — passing / all-policy (sorted by correctly handled fails ↓)",
+                else => "0 fails — passing / all-policy (sorted by expected fails ↓)",
             };
             const hdr = try std.fmt.bufPrint(&buf, "| **_{s}_** | | | | | |\n", .{label});
             try out.appendSlice(gpa, hdr);
@@ -4245,13 +4245,13 @@ fn writePreStage4Scoreboard(
         \\Stage 1–3, ahead of their inclusion in the published
         \\edition. Each proposal gets a **(hardened)** row — the
         \\as-shipped SES posture under `--enable=<flag>`, with SES
-        \\throws counted as correctly handled fails — and an
+        \\throws counted as expected fails — and an
         \\**(unhardened)** row against bare ECMA-262. Same column
         \\shape as the main `## Current scores` table:
-        \\`passing | failing | correctly handled fails | total | pass%`.
+        \\`passing | failing | expected fails | total | pass%`.
         \\These fixtures are excluded from the top-line score.
         \\
-        \\| feature | passing | failing | correctly handled fails | total | pass% |
+        \\| feature | passing | failing | expected fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -2944,12 +2944,12 @@ fn printTally(io: std.Io, stats: *const Stats, elapsed_ms: i64) !void {
     } else {
         const msg = try std.fmt.bufPrint(&buf,
             \\corpus:    {d}
-            \\pass:      {d}   ({d:.2}% engine-true)
-            \\corr-hand: {d}
-            \\pass%:     {d:.2}% — (pass + correctly-handled) / corpus
-            \\fail:      {d}
+            \\passing:   {d}   ({d:.2}% engine-true)
+            \\corr-hand: {d}   (correctly handled fails)
+            \\pass%:     {d:.2}% — (passing + correctly-handled fails) / corpus
+            \\failing:   {d}
             \\skip:      {d}
-            \\oos:       {d}   (dropped from corpus — strict-only, Annex B, pre-Stage-4)
+            \\oos:       {d}   (dropped from corpus — pre-Stage-4)
             \\  parse-positive: {d} attempted, {d} pass, {d} fail (false-reject)
             \\  parse-negative: {d} attempted, {d} pass, {d} fail (false-accept)
             \\elapsed:   {d}ms
@@ -3561,16 +3561,17 @@ fn parsePerDayRows(
         }
         const mode = parseModeLabel(mode_part) orelse continue;
 
-        // Peek the first data cell to decide between legacy schema
-        // (`pass% | engine% | pass / corpus | pass / engine-attempt
-        // | divergent | Δ pass | elapsed`) and the new Layout-B
-        // schema (`passing | failing | correctly handled | total |
-        // pass% | Δ pass | elapsed`). Legacy ends the first cell
-        // with `%`; the new schema's first cell is a plain integer.
+        // Peek the first data cell to decide between the legacy
+        // schema (`pass% | engine% | pass / corpus | pass /
+        // engine-attempt | divergent | Δ pass | elapsed`) and the
+        // current schema (`passing | failing | correctly handled
+        // fails | total | pass% | Δ pass | elapsed`). Legacy ends the
+        // first cell with `%`; the current schema's first cell is a
+        // plain integer.
         const first_data_cell_raw = it.next() orelse continue;
         const first_data_cell = std.mem.trim(u8, first_data_cell_raw, " ");
         if (first_data_cell.len > 0 and first_data_cell[first_data_cell.len - 1] != '%') {
-            // New Layout-B schema. Parse as passing | failing |
+            // Current schema. Parse as passing | failing |
             // correctly_handled | total | pass% | Δ pass | elapsed.
             const passing = std.fmt.parseInt(u32, first_data_cell, 10) catch continue;
             const failing_cell = std.mem.trim(u8, it.next() orelse continue, " ");
@@ -3595,7 +3596,7 @@ fn parsePerDayRows(
                 .cynic_sha = cynic_sha,
                 .test262_sha = t262_sha,
                 .total = total_b,
-                .pass = passing + ch, // Row.pass = Layout-A-style headline
+                .pass = passing + ch, // Row.pass stores (passing + ch)
                 .attempted = passing + failing,
                 .spec_pct = spec_pct_b,
                 .attempted_pct = if (passing + failing == 0)
@@ -3621,11 +3622,9 @@ fn parsePerDayRows(
         // Parse the raw `pass / attempted` cell — earlier code
         // derived attempted from `att_pct` via the inverse
         // formula, but the 2-decimal % is lossy: hardened rows
-        // round-tripped 34487 → 34488 (off-by-one), which
-        // propagated into the TL;DR's "real engine failures"
-        // count. Reading the raw integer fixes this for any row
-        // post-Layout-A; pre-Layout-A rows hit the deriveAttempted
-        // fallback below when the cell shape doesn't match.
+        // round-tripped 34487 → 34488 (off-by-one). Reading the raw
+        // integer fixes this; rows old enough to lack the cell hit
+        // the deriveAttempted fallback below.
         const pa_attempted_override: ?u32 = blk: {
             const cell_raw = it.next() orelse break :blk null;
             const cell = std.mem.trim(u8, cell_raw, " ");
@@ -3781,8 +3780,8 @@ fn writeFileBody(
             "**Cynic passes {d:.2} % of its {d}-fixture test262 corpus** under the " ++
                 "default (hardened SES) posture (`cynic run`). The breakdown:\n\n" ++
                 "- **{d} passing** — Cynic produced the spec-expected result.\n" ++
-                "- **{d} correctly handled** — failures that hit a Cynic design policy " ++
-                "(Annex B not shipped, strict-only, no Intl, eval-off, SES throw) " ++
+                "- **{d} correctly handled fails** — failures that hit a Cynic design " ++
+                "policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) " ++
                 "rather than an engine bug. Counted as spec-correct in `pass%` because " ++
                 "Cynic's deliberate \"no\" is the right answer for the policy it ships.\n" ++
                 "- **{d} failing** — real engine failures with no policy bucket. Work to do.\n" ++
@@ -3798,30 +3797,31 @@ fn writeFileBody(
     try out.appendSlice(gpa,
         \\## Current scores
         \\
-        \\| posture | passing | failing | correctly handled | total | pass% |
+        \\| posture | passing | failing | correctly handled fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
     // Three rows in user-visible order: the `--allow=eval` opt-in
-    // first (currently a placeholder — `--allow=eval` hasn't shipped
-    // yet, see `docs/ses-alignment.md`, so the row reads `n/a` until
-    // the eval surface is wired into a phase sweep), then the
-    // unhardened baseline (`--unhardened` opt-out), then hardened
-    // (the default Cynic posture, `cynic run`). Same engine path,
-    // different policy mask: unhardened counts annex_b + no_strict +
-    // intl402 + eval as correctly handled; hardened adds SES on top.
+    // first (always `n/a` — `--allow=eval` doesn't exist as a runtime
+    // flag yet; the row is reserved so the layout is stable when it
+    // ships), then the unhardened baseline (`--unhardened` opt-out),
+    // then hardened (the default Cynic posture, `cynic run`). Same
+    // engine path, different policy mask: unhardened counts annex_b +
+    // no_strict + intl402 + eval as correctly handled fails; hardened
+    // adds SES on top.
     try writeAllowEvalPlaceholderRow(gpa, out);
     inline for (.{ Mode.unhardened, Mode.hardened }) |m| {
         if (latestRow(rows, m)) |r| try writeMiniRow(gpa, out, r);
     }
     try out.appendSlice(gpa,
         \\
-        \\> **pass%** = `(passing + correctly handled) / total`. A
-        \\> fixture that fails because of a Cynic design policy
+        \\> **pass%** = `(passing + correctly handled fails) / total`.
+        \\> A fixture that fails because of a Cynic design policy
         \\> (Annex B not shipped, strict-only, no Intl, eval-off, SES
-        \\> throw) counts as **correctly handled** rather than a
-        \\> real engine bug. Plain **failing** is what's left over —
-        \\> real engine work to do.
+        \\> throw) is a **correctly handled fail** rather than a real
+        \\> engine bug. Plain **failing** is what's left over — real
+        \\> engine work to do. The `--allow=eval` row is always `n/a`
+        \\> until that opt-in ships.
         \\
         \\
     );
@@ -3871,20 +3871,19 @@ fn writeFileBody(
         \\
         \\- **unhardened, `--allow=eval`** — unhardened plus the
         \\  eval surface (`eval()`, `new Function(string)`, …) opted
-        \\  in. Placeholder today: `--allow=eval` isn't shipped (see
-        \\  `docs/ses-alignment.md`), so no sweep populates this row
-        \\  and every cell reads `n/a`. When the opt-in lands, eval
-        \\  fixtures move from "correctly handled" to plain passing.
+        \\  in. **Always `n/a`**: `--allow=eval` isn't shipped (see
+        \\  `docs/ses-alignment.md`), so no sweep populates this row.
+        \\  The row is reserved so the layout stays stable when the
+        \\  opt-in lands (eval fails would then become passes).
         \\- **unhardened** — `cynic --unhardened` opt-out. Eval off
-        \\  (so eval-dependent fixtures fail and classify as
-        \\  correctly handled), Annex B / Intl / noStrict failures
-        \\  also classify as correctly handled. SES posture off —
-        \\  no SES throws.
+        \\  (so eval-dependent fixtures fail and count as correctly
+        \\  handled fails), Annex B / Intl / noStrict failures too.
+        \\  SES posture off — no SES throws.
         \\- **hardened** — the default posture (`cynic run`). All
         \\  the unhardened policies plus SES — primordials frozen,
         \\  override-mistake fix on, locked descriptors. Fixtures
         \\  whose expectation conflicts with SES enforcement throw
-        \\  by design and classify as correctly handled.
+        \\  by design and count as correctly handled fails.
         \\
         \\### Columns
         \\
@@ -3892,7 +3891,7 @@ fn writeFileBody(
         \\  the spec-expected result.
         \\- **`failing`** — engine-true failures that *don't* match
         \\  any design policy. Real work to do.
-        \\- **`correctly handled`** — failures that hit a Cynic
+        \\- **`correctly handled fails`** — failures that hit a Cynic
         \\  design policy: Annex B not shipped, strict-only,
         \\  no Intl, eval-off, or SES throw. Counted with passes
         \\  under `pass%` because Cynic's deliberate "no" is the
@@ -3902,7 +3901,7 @@ fn writeFileBody(
         \\- **`total`** — every fixture except pre-Stage-4
         \\  proposals (Stage ≤ 3, shipped or not) and the upstream
         \\  `staging/` / `harness/` paths.
-        \\- **`pass%`** — `(passing + correctly handled) / total`.
+        \\- **`pass%`** — `(passing + correctly handled fails) / total`.
         \\  The headline.
         \\- **SES witness fidelity** (the italic note above) —
         \\  positive-coverage signal. The curated witness set in
@@ -4001,7 +4000,7 @@ fn writeFileBody(
         }
         try out.appendSlice(gpa, "\n\n");
         try out.appendSlice(gpa,
-            \\|         | passing | failing | correctly handled | total | pass% | Δ pass | elapsed |
+            \\|         | passing | failing | correctly handled fails | total | pass% | Δ pass | elapsed |
             \\|---|---:|---:|---:|---:|---:|---:|---:|
             \\
         );
@@ -4047,11 +4046,12 @@ fn postureLabel(m: Mode) []const u8 {
     };
 }
 
-/// Emit the placeholder row for the `--allow=eval` posture. No
-/// sweep populates it yet — `--allow=eval` isn't shipped (see
-/// `docs/ses-alignment.md`) — so every cell renders as `n/a`. The
-/// row exists so the `## Current scores` layout stays stable
-/// when the eval surface lands and starts producing real numbers.
+/// Emit the `--allow=eval` posture row. This row is **always** all
+/// `n/a`: `--allow=eval` isn't a shipped runtime flag (see
+/// `docs/ses-alignment.md`), so no sweep ever populates it. The row
+/// exists only to keep the `## Current scores` layout stable for when
+/// the opt-in lands. No `Mode.unhardened_allow_eval` history row is
+/// ever written, so there's nothing to read back — it's hardcoded here.
 fn writeAllowEvalPlaceholderRow(
     gpa: std.mem.Allocator,
     out: *std.ArrayListUnmanaged(u8),
@@ -4166,13 +4166,13 @@ fn writeScoreboard(
         \\  The remainder (~13 fixtures) is the
         \\  cross-realm cluster awaiting `--allow=eval` and multi-realm
         \\  error attribution.
-        \\- The **0-fails tier** is sorted by `correctly handled ↓` so
+        \\- The **0-fails tier** is sorted by `correctly handled fails ↓` so
         \\  the heaviest policy buckets cluster first. `intl402/`
         \\  trees dominate (no Intl), then the SES-hot built-ins
         \\  (`Array`, `Object`, `TypedArray`, `String`, `Date`,
         \\  `Math`), then the Annex B / eval / noStrict tails.
         \\
-        \\| area | passing | failing | correctly handled | total | pass% |
+        \\| area | passing | failing | correctly handled fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
@@ -4193,7 +4193,7 @@ fn writeScoreboard(
                 1 => "100–999 fails — engine-work tier",
                 2 => "10–99 fails — engine-work tier",
                 3 => "1–9 fails — engine-work tier",
-                else => "0 fails — passing / all-policy (sorted by correctly handled ↓)",
+                else => "0 fails — passing / all-policy (sorted by correctly handled fails ↓)",
             };
             const hdr = try std.fmt.bufPrint(&buf, "| **_{s}_** | | | | | |\n", .{label});
             try out.appendSlice(gpa, hdr);
@@ -4245,13 +4245,13 @@ fn writePreStage4Scoreboard(
         \\Stage 1–3, ahead of their inclusion in the published
         \\edition. Each proposal gets a **(hardened)** row — the
         \\as-shipped SES posture under `--enable=<flag>`, with SES
-        \\throws counted as correctly handled — and an
+        \\throws counted as correctly handled fails — and an
         \\**(unhardened)** row against bare ECMA-262. Same column
         \\shape as the main `## Current scores` table:
-        \\`passing | failing | correctly handled | total | pass%`.
+        \\`passing | failing | correctly handled fails | total | pass%`.
         \\These fixtures are excluded from the top-line score.
         \\
-        \\| feature | passing | failing | correctly handled | total | pass% |
+        \\| feature | passing | failing | correctly handled fails | total | pass% |
         \\|---|---:|---:|---:|---:|---:|
         \\
     );
@@ -4378,12 +4378,11 @@ fn extractWitnessNote(existing: []const u8) ?[]const u8 {
 /// by area` heading from earlier file generations. Returns the
 /// byte offset of the heading line on success, null otherwise.
 fn findScoreboardHeading(existing: []const u8) ?struct { offset: usize, length: usize } {
-    // Most recent heading first. Each prior render lives in
-    // historical results.md files; the legacy fallbacks below let
-    // a pre-Layout-B file extract its scoreboard section cleanly.
-    const layout_b = "## Where the engine fails, by area";
-    if (std.mem.indexOf(u8, existing, layout_b)) |off| {
-        return .{ .offset = off, .length = layout_b.len };
+    // Current heading first; the legacy fallbacks below let an older
+    // results.md file extract its scoreboard section cleanly.
+    const current = "## Where the engine fails, by area";
+    if (std.mem.indexOf(u8, existing, current)) |off| {
+        return .{ .offset = off, .length = current.len };
     }
     const headings = [_][]const u8{
         "## Where the engine fails (and where SES diverges), by area",

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -1,63 +1,47 @@
 //! Skip rules for the test262 harness — the single source of truth for
-//! which fixtures Cynic does not run, and *why*. The structure mirrors
-//! the one question that decides a fixture's fate:
+//! which fixtures Cynic does not run, and how a failure is classified.
 //!
-//!     Could this fixture pass in the `main` phase — i.e. under Cynic's
-//!     default production posture (strict-only, SES-hardened, eval-off,
-//!     edge-host), scored against the published ECMA-262 edition?
+//! The harness runs (almost) every fixture and sorts each into one of:
+//! `passing`, `failing`, or `correctly handled` (a failure Cynic
+//! produces *by design* — see `pathPolicyKind`). Only two narrow
+//! categories never run at all. So this file has exactly four jobs,
+//! each a `pub fn` the harness calls:
 //!
-//! That question routes every non-(pass/fail) fixture to exactly one of
-//! three accounting outcomes. The deciding axis is NOT "permanent vs.
-//! recoverable" — it is "out of `main`'s denominator vs. counted in it":
+//!   1. `pathIsSkipped` — corpus-walk exclusions. `harness/` (preamble
+//!      helpers, not fixtures) and `staging/` (upstream WIP). Filtered
+//!      before frontmatter parsing; never enter `total`.
 //!
-//!   A. WALK-EXCLUDED — not engine surface at all (harness helpers,
-//!      staging grounds, the Intl-only `intl402/` tree). Filtered before
-//!      frontmatter parsing; never enters the corpus.
-//!      → `corpus_excluded_prefixes`.
+//!   2. `featureIsUnimplementedProposal` — pre-Stage-4 proposals Cynic
+//!      hasn't implemented (decorators, import-defer, …). Dropped from
+//!      `total` so the headline can't decay as TC39 lands proposal
+//!      fixtures upstream. (Proposals Cynic *has* shipped —
+//!      joint-iteration, ShadowRealm — are kept out of the main rows
+//!      by the harness's per-phase feature-tag gate, not by this file,
+//!      and get their own dedicated `feature:<name>` scoreboard.)
 //!
-//!   B. OUT OF SCOPE — can never pass in `main`, for a *structural*
-//!      reason rather than unfinished engineering. Dropped from the
-//!      `corpus` denominator entirely, so `pass%` is not penalised.
-//!      Three structural reasons:
-//!        • never-ship policy — Annex B, the strict-only carve-out, the
-//!          SES surface (`eval` / `Function(string)` / `SharedArrayBuffer`
-//!          / `Atomics`). Only a policy reversal moves these. The eval
-//!          surface is matched both in bulk (`ses_path_prefixes` /
-//!          `ses_substrings` — fixtures that test the eval feature itself)
-//!          and as individual exact paths (`eval_dependent_exact_paths` —
-//!          fixtures that test some *other* feature but reach the
-//!          assertion through `eval`, so they can't be bulk-matched).
-//!          → `pathIsPermanentlyOutOfScope`, `featureIsOutOfScope`.
-//!        • not in the published edition — a pre-Stage-4 proposal. Pinned
-//!          out so the headline can't decay as TC39 lands proposal
-//!          fixtures upstream. Recoverable: at Stage 4 it becomes a
-//!          counted skip (outcome C); when Cynic ships it, it moves to its
-//!          own `feature:<name>` phase. → `featureIsUnimplementedProposal`.
-//!        • scored in a different phase — a feature Cynic ships behind a
-//!          `--enable` flag (`joint-iteration`, `ShadowRealm`). `main`
-//!          runs the default posture, so these are scored in a dedicated
-//!          `feature:<name>` phase, reached via the harness's feature-tag
-//!          mechanism — NOT a skip.zig path list, so they don't appear in
-//!          the predicates below at all.
+//!   3. `pathIsCurrentlySkipped` — tech-debt skips: in-scope fixtures
+//!      Cynic *should* pass but doesn't yet (cross-realm attribution,
+//!      a vendored-matcher gap). Counted in `total`, lowering `pass%`
+//!      — the live "work left" signal.
 //!
-//!   C. COUNTED SKIP — *in* `main`'s scope and would pass once Cynic
-//!      finishes the engineering it owes: a published-edition feature
-//!      blocked on a vendor/infra gap, or a cross-realm fixture that
-//!      lands when multi-realm support does. Stays in the denominator and
-//!      lowers `pass%` — this is the live "work left" signal.
-//!      → `pathIsCurrentlySkipped`, `featureIsCurrentlySkipped`.
+//!   4. `pathPolicyKind` — the policy classifier. For a fixture that
+//!      ran and FAILED, decide whether the failure is one Cynic makes
+//!      *on purpose* (Annex B not shipped, strict-only, no Intl,
+//!      eval surface off) and therefore counts as "correctly handled"
+//!      rather than a real bug. First match wins, in priority order
+//!      annex_b > no_strict > intl402 > eval. (The fifth policy, SES,
+//!      is matched separately by the harness against the runtime error
+//!      pattern — see `tools/test262/ses_divergent.zig` — because it's
+//!      only knowable after the fixture throws.)
 //!
-//! "Permanent" in the predicate names is shorthand for "permanently
-//! absent from `main`'s denominator" (outcome B), NOT a claim about any
-//! future opt-in: even if `--allow=eval` ships one day, `main` still runs
-//! eval-off, so the eval surface stays dropped here regardless. The
-//! honest wart: `single_realm_exact_paths` sits in B today but is outcome
-//! C in spirit (cross-realm core semantics, no flag needed); it moves to
-//! a counted skip — or straight to passing — when the in-progress
-//! multi-realm work lands.
+//! SharedArrayBuffer / Atomics fixtures are deliberately NOT a policy:
+//! Cynic could ship shared memory, so their failures stay plain
+//! `failing` until it does.
 //!
-//! Lookup is `mem.startsWith`, `mem.indexOf`, `mem.endsWith`, or
-//! `mem.eql` over comptime-iterable lists.
+//! The bulk of this file is the data the four functions read — comptime
+//! string lists, matched via `mem.startsWith` / `mem.indexOf` /
+//! `mem.endsWith` / `mem.eql`. The `ses_*`-prefixed eval lists keep
+//! their historical names; they feed the `eval` policy now.
 
 const std = @import("std");
 
@@ -72,9 +56,18 @@ const std = @import("std");
 // these gate the corpus walk itself.
 
 pub const corpus_excluded_prefixes = [_][]const u8{
+    // Harness helpers (sta.js / assert.js) — preamble files, not test
+    // fixtures. Always filtered before frontmatter parsing.
     "harness/",
+    // Staging ground — upstream-WIP fixtures that aren't required to
+    // be portable; not part of any published edition. Filtered for the
+    // same reason pre-Stage-4 proposals are: scoring stable ECMA-262
+    // shouldn't be dragged by upstream WIP.
     "staging/",
-    "intl402/",
+    // NOTE: `intl402/` used to be filtered here. It now runs, and any
+    // failure classifies as the `intl402` policy in `pathPolicyKind` —
+    // Cynic doesn't ship Intl, so those failures are "correctly
+    // handled" rather than engine bugs.
 };
 
 // Compatibility alias for callers that still reach for the old name.
@@ -198,41 +191,27 @@ pub const annex_b_regex_exact_paths = [_][]const u8{
     "built-ins/String/prototype/split/separator-regexp.js",
 };
 
-// ── SES surface ─────────────────────────────────────────────────────
+// ── eval surface (eval policy) ──────────────────────────────────────
 //
-// No `eval` / `new Function(string)` (runtime code construction
-// breaks SES isolation and is a major optimisation fence). No
-// shared memory (`SharedArrayBuffer` / `Atomics`) — Cynic's
-// edge-runtime hosts are single-agent-per-isolate. Permanent
-// decisions per AGENTS.md "SES-aligned by default".
+// `eval` / `new Function(string)` and friends. Cynic ships no runtime
+// code construction by default (breaks SES isolation, major
+// optimisation fence — AGENTS.md "eval and runtime code construction").
+// A fixture that fails because it reaches its assertion through the
+// eval surface classifies as `correctly handled` under the `eval`
+// policy. (SharedArrayBuffer / Atomics are NOT here — Cynic could ship
+// shared memory, so those failures stay plain `failing`.)
 
-pub const ses_path_prefixes = [_][]const u8{
+/// Whole sub-trees that exist only to test the eval surface.
+pub const eval_path_prefixes = [_][]const u8{
     "language/eval-code/",
     "built-ins/eval/",
-    "built-ins/Atomics/",
-    "built-ins/SharedArrayBuffer/",
-};
-
-/// Basename-suffix skips for fixtures that *exercise* SAB / Atomics
-/// indirectly from another bucket. test262 generates an `-sab.js`
-/// sibling alongside each `-buffer-arg` / `set/` / `DataView/` /
-/// internals fixture (same body, `SharedArrayBuffer` swapped for
-/// `ArrayBuffer`). The non-`-sab` sibling stays attempted and tests
-/// the same behaviour against `ArrayBuffer` — skipping `-sab.js`
-/// removes duplicate coverage of a permanently-OOS host primitive
-/// without losing signal. ~96 fixtures across `built-ins/DataView`,
-/// `built-ins/TypedArray/prototype/set`, and
-/// `built-ins/TypedArrayConstructors/{ctors,ctors-bigint,internals}`.
-pub const ses_path_suffixes = [_][]const u8{
-    "-sab.js",
 };
 
 /// `built-ins/Function/` is a *mixed* bucket — the prototype
-/// methods (`apply`, `call`, `bind`, …) are in scope, but every
-/// test under §15.3.2 / §15.3.5 exercises `Function(string)` /
-/// `new Function(string)` which is a permanent SES carve-out.
-/// Match by basename substring so the prototype-method fixtures
-/// stay attempted.
+/// methods (`apply`, `call`, `bind`, …) are real engine surface, but
+/// every test under §15.3.2 / §15.3.5 exercises `Function(string)` /
+/// `new Function(string)`, the eval surface. Match by basename
+/// substring so the prototype-method fixtures stay attempted.
 pub const ses_substrings = [_][]const u8{
     "built-ins/Function/15.3.2",
     "built-ins/Function/S15.3.2",
@@ -974,18 +953,6 @@ pub const ses_substring_pairs = [_][2][]const u8{
     .{ "built-ins/Promise/", "ctx-non-ctor.js" },
 };
 
-pub const ses_features = [_][]const u8{
-    // SES carve-outs (eval, SharedArrayBuffer, Atomics) skip by
-    // PATH (the `ses_path_prefixes` / `ses_path_suffixes` /
-    // `ses_substrings` rules above), NOT by feature tag.
-    // Feature-tag skipping hides cross-bucket fixtures that only
-    // *use* the surface name (e.g. an `ArrayBuffer` fixture tagged
-    // `[SharedArrayBuffer]` but exercising legitimate non-SAB
-    // ArrayBuffer behaviour). Path/suffix rules are surgical;
-    // feature-tag rules over-fire. See the `runtime-only gaps are
-    // NOT hidden` test below for the asserted policy.
-};
-
 // ── Single-realm host ───────────────────────────────────────────────
 //
 // `$262.createRealm()` IS exposed to the test262 harness (a real
@@ -1194,22 +1161,16 @@ pub const deferred_path_prefixes = [_][]const u8{
     // scope` test guards against a subtree regressing back to here.
 };
 
-// ── eval-dependent — SES surface, individual-fixture form ───────────
+// ── eval-dependent — eval surface, individual-fixture form ──────────
 //
-// Single fixtures that exercise `eval` / `new Function(string)` and so
-// can't pass under the default eval-off posture. The SES surface
-// (header outcome B, "never-ship policy") — same bucket as the bulk
-// eval `ses_path_prefixes` / `ses_substrings` above, just matched as
-// exact paths because these fixtures don't *test the eval feature*;
-// they test some other feature and merely reach the assertion through
-// `eval` (e.g. wrap a parse-error check in `eval("…")`), so no path or
-// substring rule catches them.
-//
-// Consumed by `pathIsPermanentlyOutOfScope` → dropped from the `corpus`
-// denominator, exactly like the bulk eval surface. NOT a counted skip:
-// `main` runs eval-off, and it stays eval-off even if `--allow=eval`
-// ships as an opt-in later (see [docs/ses-alignment.md] §Phase 4), so
-// the eval surface stays permanently out of `main` regardless.
+// Single fixtures that reach their assertion through `eval` /
+// `new Function(string)` but don't *test the eval feature* — they test
+// some other feature and merely wrap it in `eval("…")`, so no prefix
+// or substring rule catches them. Consumed by `pathPolicyKind` as part
+// of the `eval` policy: a failure here classifies as `correctly
+// handled` (eval surface off) rather than a real bug. When
+// `--allow=eval` ships, these would move from correctly-handled to
+// plain passing.
 
 pub const eval_dependent_exact_paths = [_][]const u8{
     // `built-ins/Function/prototype/S15.3.5.2_A1_T2.js` — uses
@@ -1287,80 +1248,19 @@ pub fn pathIsSkipped(rel_path: []const u8) bool {
     return false;
 }
 
-/// Header **outcome B** by path, "never-ship policy" reason: fixtures
-/// that can never pass in the `main` phase because passing would require
-/// a surface Cynic refuses to ship — Annex B, the strict-only carve-out,
-/// the SES surface (`eval` / `Function(string)` / `SharedArrayBuffer` /
-/// `Atomics`). Deliberate `AGENTS.md` decisions; only a policy reversal
-/// moves them. The caller drops them from the `corpus` denominator at
-/// walk-time (no false-reject noise in `test262-results.md`).
-///
-/// The eval surface is matched two ways: in bulk (`ses_path_prefixes` /
-/// `ses_substrings`, fixtures that test eval itself) and as
-/// `eval_dependent_exact_paths` (fixtures that test another feature but
-/// reach the assertion through `eval`). Both are equally permanent here:
-/// `main` runs eval-off and stays eval-off even if `--allow=eval` ships
-/// as an opt-in later. (The other two outcome-B reasons aren't path-
-/// based: pre-Stage-4 → `featureIsUnimplementedProposal`; the
-/// `--enable`-gated proposals → the harness feature-tag mechanism.)
-///
-/// "Permanently" is "permanently absent from `main`", not "never run".
-/// Known wart: `single_realm_exact_paths` is filed here but is really
-/// outcome C (it needs no flag — just the in-progress multi-realm work);
-/// it relocates to `pathIsCurrentlySkipped`, or to passing, when that
-/// lands.
-pub fn pathIsPermanentlyOutOfScope(rel_path: []const u8) bool {
-    inline for (.{ annex_b_path_prefixes, ses_path_prefixes }) |group| {
-        for (group) |prefix| {
-            if (std.mem.startsWith(u8, rel_path, prefix)) return true;
-        }
-    }
-    for (ses_substrings) |needle| {
-        if (std.mem.indexOf(u8, rel_path, needle) != null) return true;
-    }
-    for (ses_substring_pairs) |pair| {
-        if (std.mem.indexOf(u8, rel_path, pair[0]) != null and
-            std.mem.indexOf(u8, rel_path, pair[1]) != null) return true;
-    }
-    for (ses_path_suffixes) |suffix| {
-        if (std.mem.endsWith(u8, rel_path, suffix)) return true;
-    }
-    inline for (.{
-        strict_only_exact_paths,
-        annex_b_regex_exact_paths,
-        ses_exact_paths,
-        single_realm_exact_paths,
-        // eval-dependent fixtures: the SES eval surface in individual-
-        // fixture form. `main` runs eval-off (and stays so even if
-        // `--allow=eval` ships later), so they're permanently dropped
-        // here, same as the bulk eval paths/substrings above.
-        eval_dependent_exact_paths,
-    }) |group| {
-        for (group) |exact| {
-            if (std.mem.eql(u8, rel_path, exact)) return true;
-        }
-    }
-    return false;
-}
-
-/// Header **outcome C** by path: fixtures *in* `main`'s scope that
-/// Cynic skips **today** but would pass once it finishes the
-/// engineering it owes — a published-edition feature blocked on a
-/// vendor/infra gap, or a cross-realm fixture that lands with multi-
-/// realm support. The caller keeps these **in** the `corpus`
-/// denominator and counts them as `skip` (reason `.by_path`), so they
-/// lower `pass%` — the live "work left" signal, kept distinct from
-/// `pathIsPermanentlyOutOfScope`'s "out of `main`" set.
+/// Tech-debt skips by path: fixtures *in* scope that Cynic skips
+/// **today** but should eventually pass once it finishes the
+/// engineering it owes — a cross-realm fixture awaiting multi-realm
+/// error attribution, or a published-edition feature blocked on a
+/// vendor/infra gap. The caller keeps these **in** `total` and counts
+/// them as `skip`, so they lower `pass%` — the live "work left"
+/// signal. (A fixture that simply *fails* a policy Cynic ships by
+/// design is not here — it runs and classifies as `correctly handled`
+/// via `pathPolicyKind`. Pre-Stage-4 proposals aren't here either —
+/// they're recognised by feature tag in `featureIsUnimplementedProposal`.)
 ///
 /// Nearly empty right now: every source array below is empty except
-/// `single_realm_path_contains` (the one `-realm-function-ctor.`
-/// needle). Two non-members worth calling out:
-///   • eval-dependent fixtures are NOT here — they need `--allow=eval`
-///     (a non-default flag), so they're outcome B in
-///     `pathIsPermanentlyOutOfScope`, not work owed against `main`.
-///   • pre-Stage-4 proposals are NOT here — they're recognised by
-///     feature tag and dropped as `.pre_stage4` (see
-///     `featureIsUnimplementedProposal`); their path groups stay empty.
+/// `single_realm_path_contains` (the one `-realm-function-ctor.` needle).
 pub fn pathIsCurrentlySkipped(rel_path: []const u8) bool {
     inline for (.{ stage_maturity_path_prefixes, deferred_path_prefixes }) |group| {
         for (group) |prefix| {
@@ -1379,52 +1279,17 @@ pub fn pathIsCurrentlySkipped(rel_path: []const u8) bool {
     return false;
 }
 
-/// Compatibility wrapper used by the test262 harness at corpus
-/// walk-time. The harness doesn't currently distinguish the two
-/// reasons — both must be filtered out so the rolled-up score
-/// reflects what Cynic actually attempts. Future tooling (e.g.
-/// a "what's the maximum reachable score if we land all the
-/// planned work?" report) can call the two predicates
-/// independently.
-pub fn pathIsCynicOutOfScope(rel_path: []const u8) bool {
-    return pathIsPermanentlyOutOfScope(rel_path) or pathIsCurrentlySkipped(rel_path);
-}
-
-/// Feature tags that put a fixture **permanently out of scope**:
-/// Annex B browser constructs (§B) and the SES carve-outs. A
-/// strict-only, SES-hardened, non-browser engine will never ship
-/// these, so the fixtures can't pass under any plausible Cynic
-/// posture — exactly like the `annexB/` path tree. The harness drops
-/// them from the `corpus` denominator entirely rather than counting
-/// them as in-corpus skips (see `recordOutcome` in `test262.zig`).
-pub fn featureIsOutOfScope(feature: []const u8) bool {
-    inline for (.{ annex_b_features, ses_features }) |group| {
-        for (group) |f| {
-            if (std.mem.eql(u8, feature, f)) return true;
-        }
-    }
-    return false;
-}
-
 /// Feature tags for pre-Stage-4 proposals Cynic hasn't implemented
-/// (decorators, import-defer, source-phase-imports, …). These are
-/// **out of scope**: they aren't part of any published ECMA-262
-/// edition, so the harness drops them from the `corpus` denominator
-/// (reason `.pre_stage4`), just like the permanent carve-outs.
-///
-/// The difference from `featureIsOutOfScope` is that these are
-/// *recoverable*, via two distinct gates back into scope:
-///   - the proposal reaches **Stage 4** → it's specced, so it must
-///     leave `stage_maturity_features` and become an in-scope counted
-///     skip (we're on the hook for it in the headline whether or not
-///     Cynic ships it yet); or
+/// (decorators, import-defer, source-phase-imports, …). Dropped from
+/// `total` (reason `.pre_stage4`): they aren't in any published
+/// ECMA-262 edition, so the headline shouldn't move when TC39 lands
+/// their fixtures upstream. Recoverable two ways:
+///   - the proposal reaches **Stage 4** → it's specced, so it leaves
+///     `stage_maturity_features` and re-enters `total`; or
 ///   - Cynic **implements** it → it graduates to a dedicated
-///     `feature:<name>` phase (a `FeatureFlag`, scored with the flag
-///     on — `joint-iteration`, `ShadowRealm`), excluded from `main`.
-///
-/// Pinning the denominator to the published-edition boundary keeps the
-/// headline from silently decaying as TC39 lands new proposal fixtures
-/// in test262 — score only moves when Cynic does.
+///     `feature:<name>` phase (a `FeatureFlag` — `joint-iteration`,
+///     `ShadowRealm`), kept out of the main rows by the harness's
+///     per-phase feature-tag gate.
 pub fn featureIsUnimplementedProposal(feature: []const u8) bool {
     for (stage_maturity_features) |f| {
         if (std.mem.eql(u8, feature, f)) return true;
@@ -1432,27 +1297,100 @@ pub fn featureIsUnimplementedProposal(feature: []const u8) bool {
     return false;
 }
 
-/// Feature tags Cynic skips **today** but still counts in the corpus:
-/// a specced (published-edition) feature blocked on a vendor/infra gap
-/// — the vendored libregexp matcher or unshipped Unicode-property
-/// data. The spec mandates these, so they stay **in** the denominator
-/// as `skip` and `pass%` reflects the work owed. (Currently empty —
-/// Perlex plus the shipped Unicode tables cover today's surface; the
-/// hook stays for the next libregexp/Unicode gap.)
-pub fn featureIsCurrentlySkipped(feature: []const u8) bool {
-    for (vendor_features) |f| {
-        if (std.mem.eql(u8, feature, f)) return true;
-    }
-    return false;
-}
+// ════════════════════════════════════════════════════════════════════
+//   Policy classification
+// ════════════════════════════════════════════════════════════════════
+//
+// For a fixture that ran and FAILED, decide whether the failure is one
+// Cynic produces *by design* — and therefore counts as "correctly
+// handled" rather than a real bug. Four path/frontmatter-derived
+// policies live here; the fifth (`ses`) is matched by the harness
+// against the runtime error pattern (`tools/test262/ses_divergent.zig`)
+// because it's only knowable after the throw.
+//
+//   annex_b   — Annex B language / built-ins / regex grammar; Cynic is
+//               a strict-only edge target, no Annex B.
+//   no_strict — `flags: [noStrict]` or a strict-only carve-out path.
+//   intl402   — `intl402/` tree or an `Intl`-prefixed feature tag;
+//               Cynic doesn't ship Intl.
+//   eval      — the eval surface (`eval` / `new Function(string)` /
+//               `GeneratorFunction(string)` / …); off unless `--allow=eval`.
+//
+// First match wins, in priority order annex_b > no_strict > intl402 >
+// eval. SharedArrayBuffer / Atomics are NOT a policy — Cynic could ship
+// shared memory, so those failures stay plain `failing`.
 
-/// Union of all three — any feature tag the engine doesn't currently
-/// run, whether permanently out of scope, an unimplemented pre-Stage-4
-/// proposal, or a vendor-blocked specced feature.
-pub fn featureIsUnsupported(feature: []const u8) bool {
-    return featureIsOutOfScope(feature) or
-        featureIsUnimplementedProposal(feature) or
-        featureIsCurrentlySkipped(feature);
+pub const PolicyKind = enum {
+    annex_b,
+    no_strict,
+    intl402,
+    eval,
+    ses,
+};
+
+/// Map a fixture failure to its policy bucket, if any. SES classification
+/// is *not* handled here — the harness runs the SES divergence matcher
+/// against the thrown error after the fixture executes. This returns
+/// the first matching path/frontmatter-derived policy in priority order.
+///
+/// `features` is the fixture's frontmatter `features:` list (may be
+/// empty). `no_strict` is the parsed `flags: [noStrict]` bit.
+pub fn pathPolicyKind(
+    rel_path: []const u8,
+    features: []const []const u8,
+    no_strict: bool,
+) ?PolicyKind {
+    // Priority 1 — annex_b. Path tree first, then exact paths under the
+    // main tree that need Annex B leniency, then feature tags.
+    for (annex_b_path_prefixes) |prefix| {
+        if (std.mem.startsWith(u8, rel_path, prefix)) return .annex_b;
+    }
+    for (annex_b_regex_exact_paths) |exact| {
+        if (std.mem.eql(u8, rel_path, exact)) return .annex_b;
+    }
+    for (annex_b_features) |feat| {
+        for (features) |f| if (std.mem.eql(u8, f, feat)) return .annex_b;
+    }
+
+    // Priority 2 — no_strict.
+    if (no_strict) return .no_strict;
+
+    // Priority 3 — intl402.
+    if (std.mem.startsWith(u8, rel_path, "intl402/")) return .intl402;
+    // Frontmatter feature tags for Intl — `Intl.*`, `Intl-enumeration`,
+    // `IntlPluralRules` historical names. Cheap prefix check covers all
+    // forms in the corpus.
+    for (features) |f| if (std.mem.startsWith(u8, f, "Intl")) return .intl402;
+
+    // Priority 4 — eval surface. Eval prefixes + substrings + exact
+    // paths + eval-dependent exact paths. SAB/Atomics deliberately
+    // excluded (plain fail).
+    for (eval_path_prefixes) |prefix| {
+        if (std.mem.startsWith(u8, rel_path, prefix)) return .eval;
+    }
+    for (ses_substrings) |needle| {
+        if (std.mem.indexOf(u8, rel_path, needle) != null) return .eval;
+    }
+    for (ses_substring_pairs) |pair| {
+        if (std.mem.indexOf(u8, rel_path, pair[0]) != null and
+            std.mem.indexOf(u8, rel_path, pair[1]) != null) return .eval;
+    }
+    inline for (.{ ses_exact_paths, eval_dependent_exact_paths }) |group| {
+        for (group) |exact| {
+            if (std.mem.eql(u8, rel_path, exact)) return .eval;
+        }
+    }
+    // Strict-only carve-out paths — `with` in a strict-only engine and
+    // the four indirect-eval Sputnik fixtures. The latter genuinely
+    // need sloppy mode (per `strict_only_exact_paths`'s comment) so they
+    // classify as no_strict; the hashbang/ShadowRealm strict-mode ones
+    // are also strict-only carve-outs. Conservatively bucket as
+    // `no_strict` since that's the structural reason.
+    for (strict_only_exact_paths) |exact| {
+        if (std.mem.eql(u8, rel_path, exact)) return .no_strict;
+    }
+
+    return null;
 }
 
 // ════════════════════════════════════════════════════════════════════
@@ -1461,368 +1399,126 @@ pub fn featureIsUnsupported(feature: []const u8) bool {
 
 const testing = std.testing;
 
-test "skip: known path prefixes" {
+
+test "skip: corpus-walk exclusions" {
+    // Only `harness/` and `staging/` are walk-excluded now. intl402
+    // RUNS under the new model (failures classify as the intl402
+    // policy), so it must NOT be path-skipped.
     try testing.expect(pathIsSkipped("harness/sta.js"));
-    try testing.expect(pathIsSkipped("intl402/Locale/extensions.js"));
     try testing.expect(pathIsSkipped("staging/explicit-resource-management/foo.js"));
+    try testing.expect(!pathIsSkipped("intl402/Locale/extensions.js"));
     try testing.expect(!pathIsSkipped("language/expressions/optional-chaining/foo.js"));
-    try testing.expect(!pathIsSkipped("built-ins/Array/prototype/at/length.js"));
     try testing.expect(!pathIsSkipped("annexB/B.1.1/legacy-octal.js"));
 }
 
-test "skip: Annex B out of scope" {
-    try testing.expect(pathIsCynicOutOfScope("annexB/built-ins/escape/empty-string.js"));
-    try testing.expect(pathIsCynicOutOfScope("annexB/built-ins/String/prototype/blink/B.2.3.4.js"));
-    try testing.expect(pathIsCynicOutOfScope("annexB/built-ins/Date/prototype/setYear/year-nan.js"));
-    try testing.expect(pathIsCynicOutOfScope("annexB/language/comments/single-line-html-open.js"));
-    try testing.expect(pathIsCynicOutOfScope("annexB/built-ins/String/prototype/substr/length-undef.js"));
-    // Main-tree fixture that depends on Annex B regex-grammar leniency
-    // (`/\X/`, `/\XA0/`, `/\k<x>/` with no group) — strict-rejected per
-    // AGENTS.md "Regex Annex B", so permanently out of scope.
-    try testing.expect(pathIsCynicOutOfScope("built-ins/String/prototype/split/separator-regexp.js"));
-    try testing.expect(pathIsPermanentlyOutOfScope("built-ins/String/prototype/split/separator-regexp.js"));
+test "policy: annex_b" {
+    // The whole annexB/ tree.
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("annexB/built-ins/escape/empty-string.js", &.{}, false).?);
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("annexB/language/comments/single-line-html-open.js", &.{}, false).?);
+    // Main-tree fixture needing Annex B regex-grammar leniency.
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("built-ins/String/prototype/split/separator-regexp.js", &.{}, false).?);
+    // Annex B feature tags (§B.2.2 accessors, legacy regexp, IsHTMLDDA).
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("x.js", &.{"__proto__"}, false).?);
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("x.js", &.{"IsHTMLDDA"}, false).?);
 }
 
-test "skip: SES out of scope" {
-    try testing.expect(pathIsCynicOutOfScope("language/eval-code/direct/var.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/eval/length.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Atomics/load/length.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/SharedArrayBuffer/length.js"));
-    // §15.3.2 Function-constructor fixtures (always `Function(string)`).
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Function/S15.3.2.1_A1_T1.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Function/15.3.2.1-11-9-s.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Function/S15.3.5_A2_T2.js"));
-    // …prototype methods stay in scope.
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Function/prototype/apply/length.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Function/prototype/call/length.js"));
-    // SAB-suffix generator siblings — duplicate coverage of a
-    // permanently-OOS host primitive; the `-buffer-arg/byteoffset…`
-    // ArrayBuffer sibling stays attempted.
-    try testing.expect(pathIsCynicOutOfScope(
+test "policy: no_strict" {
+    // `flags: [noStrict]` bit.
+    try testing.expectEqual(PolicyKind.no_strict, pathPolicyKind("language/statements/for-in/x.js", &.{}, true).?);
+    // Strict-only carve-out paths (the `with`-hashbang fixture, the
+    // four indirect-eval Sputnik fixtures, the ShadowRealm sloppy one).
+    try testing.expectEqual(PolicyKind.no_strict, pathPolicyKind("language/comments/hashbang/use-strict.js", &.{}, false).?);
+    try testing.expectEqual(PolicyKind.no_strict, pathPolicyKind("language/statements/variable/12.2.1-9-s.js", &.{}, false).?);
+}
+
+test "policy: intl402" {
+    try testing.expectEqual(PolicyKind.intl402, pathPolicyKind("intl402/NumberFormat/x.js", &.{}, false).?);
+    // Intl-prefixed feature tag on a non-intl402 path.
+    try testing.expectEqual(PolicyKind.intl402, pathPolicyKind("built-ins/x.js", &.{"Intl.Segmenter"}, false).?);
+}
+
+test "policy: eval surface" {
+    // Whole eval sub-trees.
+    try testing.expectEqual(PolicyKind.eval, pathPolicyKind("language/eval-code/direct/var.js", &.{}, false).?);
+    try testing.expectEqual(PolicyKind.eval, pathPolicyKind("built-ins/eval/length.js", &.{}, false).?);
+    // Function(string) substring family.
+    try testing.expectEqual(PolicyKind.eval, pathPolicyKind("built-ins/Function/S15.3.2.1_A1_T1.js", &.{}, false).?);
+    // eval-dependent exact path (tests another feature via eval).
+    try testing.expectEqual(PolicyKind.eval, pathPolicyKind("language/types/string/S8.4_A7.1.js", &.{}, false).?);
+    // Function.prototype methods stay real engine surface (no policy).
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("built-ins/Function/prototype/apply/length.js", &.{}, false));
+}
+
+test "policy: SAB / Atomics are NOT a policy (plain fail)" {
+    // Cynic could ship shared memory, so a SAB/Atomics failure stays
+    // `failing`, not `correctly handled`.
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("built-ins/Atomics/load/length.js", &.{}, false));
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("built-ins/SharedArrayBuffer/length.js", &.{}, false));
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind(
         "built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-is-negative-throws-sab.js",
-    ));
-    try testing.expect(pathIsCynicOutOfScope(
-        "built-ins/DataView/prototype/getInt32/index-is-out-of-range-sab.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/TypedArrayConstructors/ctors/buffer-arg/byteoffset-is-negative-throws.js",
-    ));
-    // Class field initializer fixtures whose assertion depends on
-    // eval (cluster narrowed via the `class/elements/ + -eval-` pair).
-    try testing.expect(pathIsCynicOutOfScope("language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall.js"));
-    try testing.expect(pathIsCynicOutOfScope("language/statements/class/elements/arrow-body-direct-eval-err-contains-arguments.js"));
-    // Non-eval class/elements fixtures stay in scope.
-    try testing.expect(!pathIsCynicOutOfScope("language/expressions/class/elements/evaluation-error/computed-name-toprimitive-returns-nonobject.js"));
-    try testing.expect(!pathIsCynicOutOfScope("language/statements/class/elements/private-class-field-initialization-is-visible-to-proxy.js"));
-    // `language/function-code/10.4.3-1-{13,…,65}-s.js` and `gs.js`
-    // — strict-mode `this`-binding via Function(string) / eval(string).
-    try testing.expect(pathIsCynicOutOfScope("language/function-code/10.4.3-1-13-s.js"));
-    try testing.expect(pathIsCynicOutOfScope("language/function-code/10.4.3-1-19-s.js"));
-    try testing.expect(pathIsCynicOutOfScope("language/function-code/10.4.3-1-65gs.js"));
-    // Non-Function/eval siblings in the same bucket stay attempted.
-    try testing.expect(!pathIsCynicOutOfScope("language/function-code/10.4.3-1-103.js"));
-    try testing.expect(!pathIsCynicOutOfScope("language/function-code/10.4.3-1-106.js"));
-    try testing.expect(!pathIsCynicOutOfScope("language/function-code/S10.2.1_A5.2_T1.js"));
-    try testing.expect(!pathIsCynicOutOfScope("language/function-code/block-decl-onlystrict.js"));
-    // `Promise.<m>.call(eval)` ctx-non-ctor cluster — all SES.
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/resolve/ctx-non-ctor.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/all/ctx-non-ctor.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/any/ctx-non-ctor.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/race/ctx-non-ctor.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/try/ctx-non-ctor.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Promise/withResolvers/ctx-non-ctor.js"));
-    // Constructor-arg `ctx-*` siblings stay attempted.
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Promise/try/ctx-ctor.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Promise/try/ctx-ctor-throws.js"));
-    // Iterator.zip/zipKeyed result-is-iterator.js resolve
-    // %IteratorHelperPrototype% via wellKnownIntrinsicObjects.js
-    // (`new Function("return …")`) — SES carve-out. The
-    // iterator-helpers siblings obtain it directly and stay in.
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Iterator/zip/result-is-iterator.js"));
-    try testing.expect(pathIsCynicOutOfScope("built-ins/Iterator/zipKeyed/result-is-iterator.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Iterator/prototype/map/result-is-iterator.js"));
-}
-
-test "skip: main-spec paths not OOS" {
-    try testing.expect(!pathIsCynicOutOfScope("language/expressions/addition/order-of-evaluation.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/String/prototype/substr/length-undef.js"));
-}
-
-test "skip: Temporal fully in scope" {
-    // The whole Temporal namespace now ships — nothing under
-    // `built-ins/Temporal/` is path-skipped. Assert representative
-    // fixtures across every member run, so this test catches a future
-    // regression that re-defers any subtree (as PlainDateTime once did).
-    // `Temporal.Now` (§2) was the last member to land; its clock reads
-    // the host realtime clock and its system time zone is always UTC.
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/Now/extensible.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/getOwnPropertyNames.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/PlainDateTime/prototype/add/branding.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/PlainYearMonth/prototype/with/branding.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/PlainMonthDay/prototype/with/branding.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/Temporal/ZonedDateTime/prototype/add/branding.js"));
-}
-
-test "skip: ShadowRealm is not path-skipped (feature-gated)" {
-    // ShadowRealm isn't out-of-scope at the path level — it ships
-    // behind `--enable=ShadowRealm` (Stage 2.7), so the harness's
-    // feature-tag mechanism (not skip.zig) keeps its fixtures out of
-    // the main row and scores them in the feature phase.
-    // pathIsCynicOutOfScope therefore stays false across the tree.
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/ShadowRealm/constructor.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/ShadowRealm/extensibility.js"));
-    try testing.expect(!pathIsCynicOutOfScope("built-ins/ShadowRealm/prototype/evaluate/not-constructor.js"));
-    // One carve-out remains: the sloppy-mode `evaluate` fixture is
-    // permanently OOS under the strict-only policy — it asserts the
-    // child Script runs non-strict, which Cynic never does.
-    try testing.expect(pathIsCynicOutOfScope("built-ins/ShadowRealm/prototype/evaluate/no-conditional-strict-mode.js"));
-}
-
-test "skip: eval-dependent fixtures are out of `main`, not counted skips" {
-    // Header outcome B ("never-ship policy", SES surface): the
-    // `eval_dependent_exact_paths` need `eval`, so they can never pass in
-    // the eval-off `main` phase. They must be dropped from the
-    // denominator (permanent predicate, walk-time `continue`), NOT
-    // counted as `.by_path` skips that penalise `pass%`. This locks the
-    // design decision: the eval surface is permanently out of `main`,
-    // same bucket as the bulk eval fixtures — `built-ins/eval/`,
-    // `built-ins/Function/15.3.2`, etc. — and stays so even if
-    // `--allow=eval` ships as an opt-in later.
-    const eval_dependent = [_][]const u8{
-        "built-ins/Function/prototype/S15.3.5.2_A1_T2.js",
-        "language/types/string/S8.4_A7.1.js",
-        "built-ins/AsyncFunction/proto-from-ctor-realm.js",
-        "built-ins/GeneratorFunction/proto-from-ctor-realm-prototype.js",
-    };
-    for (eval_dependent) |path| {
-        try testing.expect(pathIsPermanentlyOutOfScope(path)); // dropped
-        try testing.expect(!pathIsCurrentlySkipped(path)); // not counted
-        try testing.expect(pathIsCynicOutOfScope(path)); // union holds
-    }
-    // The four indirect-eval fixtures fail even WITH `--allow=eval`
-    // (strict-only parses the eval'd source strict), so they're a
-    // never-ship strict-only carve-out — also permanent, also not a
-    // counted skip, but for a different structural reason.
-    try testing.expect(pathIsPermanentlyOutOfScope("language/statements/variable/12.2.1-9-s.js"));
-    try testing.expect(!pathIsCurrentlySkipped("language/statements/variable/12.2.1-9-s.js"));
-}
-
-test "skip: /v unicodeSets generated — Perlex handles code-point set ops" {
-    // The code-point half of the grammar now compiles natively, so the
-    // char-only set-op fixtures are back in scope (Perlex renders the
-    // verdict). Set-difference (`--`):
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-class-difference-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-character-property-escape.js",
-    ));
-    // Nested character class as operand (`[[…]op…]` / `[…op[…]]`):
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-class-union-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-class-intersection-character-property-escape.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-property-escape-union-character-class.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-class-escape-intersection-character-class.js",
-    ));
-    // Flat union / intersection between supported operands stays in scope.
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-union-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-class-escape-union-character.js",
-    ));
-
-    // String-literal escape (`\q{…}`) is now in scope — Perlex lowers a
-    // may-contain-strings class to an alternation (§22.2.2.7):
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/string-literal-intersection-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-union-string-literal.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/string-literal-difference-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/string-literal-union-string-literal.js",
-    ));
-
-    // Property-of-strings escapes (`\p{RGI_Emoji}`,
-    // `\p{Emoji_Keycap_Sequence}`) are now in scope — the
-    // emoji-sequence tables and the resolver's string members shipped,
-    // so Perlex lowers them to an alternation like any `\q{…}` set:
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-character.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-union-property-of-strings-escape.js",
-    ));
-    // `\p{RGI_Emoji}` matched against the emoji-16.0 data, set-difference
-    // against a property-of-strings operand, and a `\q{…}` unioned with a
-    // property-of-strings escape all resolve through the shipped
-    // emoji-sequence tables — every fixture attempts and passes (verified
-    // against the harness), so none is deferred to libregexp any longer:
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/rgi-emoji-16.0.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/character-property-escape-difference-property-of-strings-escape.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/string-literal-union-property-of-strings-escape.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/unicodeSets/generated/property-of-strings-escape-union-string-literal.js",
+        &.{},
+        false,
     ));
 }
 
-test "skip: Proxy revocable tco-fn-realm now in scope" {
-    // §10.5.12 [[Call]] on a revoked Proxy throws TypeError. The
-    // tco-fn-realm fixture asserts the TypeError comes from the
-    // running execution context's realm — the "other" realm whose
-    // function is on the stack when ValidateNonRevokedProxy fails,
-    // not the parent dispatch loop's active realm. Cynic now tracks
-    // the running-context realm per CallFrame (`running_realm`,
-    // copied from the callee `JSFunction.realm` at frame entry) and
-    // threads it into `callValue` for the revoked-proxy throw, so
-    // the fixture is attempted, not path-skipped.
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/Proxy/revocable/tco-fn-realm.js",
-    ));
-    // Same-bucket fixtures without `-realm` stay in scope.
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/Proxy/revocable/revocation-function-extensible.js",
-    ));
+test "policy: in-scope fixtures have no policy" {
+    // A normal passing fixture isn't policy-classified.
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("built-ins/Array/prototype/at/length.js", &.{}, false));
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("language/expressions/addition/order-of-evaluation.js", &.{}, false));
+    // Temporal ships — in scope, no policy.
+    try testing.expectEqual(@as(?PolicyKind, null), pathPolicyKind("built-ins/Temporal/PlainDateTime/prototype/add/branding.js", &.{}, false));
 }
 
-test "skip: planned vendor gaps" {
-    // `Script_Extensions=Unknown` (alias `scx=Zzzz`) is no longer a
-    // vendor gap: Perlex resolves `\p{…}` Script / Script_Extensions
-    // escapes through Cynic's own Unicode tables
-    // (`unicode/perlex_props.zig`) at parse and runtime, so the value
-    // never reaches libregexp (whose tables omit the "Unknown" special
-    // value). The fixture is attempted, not path-skipped.
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/property-escapes/special-property-value-Script_Extensions-Unknown.js",
-    ));
-    // The string-property positive form and `-negative-*` siblings
-    // stay in scope — libregexp handles `\p{…}` for property-of-
-    // strings, and Cynic's parse-time validator (§22.2.1.5) rejects
-    // the spec-illegal `\P{StringProperty}` and `[^\p{StringProperty}]`
-    // forms under `/v`.
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/property-escapes/generated/strings/RGI_Emoji.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/property-escapes/generated/strings/RGI_Emoji-negative-u.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/property-escapes/generated/strings/RGI_Emoji-negative-P.js",
-    ));
-    try testing.expect(!pathIsCynicOutOfScope(
-        "built-ins/RegExp/property-escapes/generated/strings/RGI_Emoji-negative-CharacterClass.js",
-    ));
+test "policy: priority — annex_b before eval" {
+    // A path that is both Annex B and reaches through eval resolves to
+    // annex_b (higher priority).
+    try testing.expectEqual(PolicyKind.annex_b, pathPolicyKind("annexB/built-ins/escape/eval.js", &.{}, false).?);
 }
 
-test "skip: unsupported features — stage maturity + planned" {
-    // Stage 3 syntax — parser would choke.
-    try testing.expect(featureIsUnsupported("decorators"));
-    try testing.expect(featureIsUnsupported("import-defer"));
-    try testing.expect(featureIsUnsupported("source-phase-imports"));
-    // regexp-modifiers is supported (Perlex compiles `(?ims-ims:…)`);
-    // it must NOT be flagged unsupported.
-    try testing.expect(!featureIsUnsupported("regexp-modifiers"));
-    // explicit-resource-management is supported (full surface
-    // shipped); it must NOT be flagged unsupported.
-    try testing.expect(!featureIsUnsupported("explicit-resource-management"));
-}
-
-test "skip: Annex B feature flags are hidden via feature filter" {
-    // Object.prototype.__proto__ accessor (§B.2.2.1), the four
-    // accessor methods (§B.2.2.{2,3,4,5}), the RegExp legacy
-    // statics (§B.2.{4,5}), and the IsHTMLDDA host primitive
-    // (§B.2.7) all live in annex_b_features. Cynic doesn't
-    // ship them per "Annex B in its entirety — out"; their
-    // fixtures would otherwise show as honest runtime fails for
-    // a permanent carve-out.
-    try testing.expect(featureIsUnsupported("__proto__"));
-    try testing.expect(featureIsUnsupported("__getter__"));
-    try testing.expect(featureIsUnsupported("__setter__"));
-    try testing.expect(featureIsUnsupported("legacy-regexp"));
-    try testing.expect(featureIsUnsupported("IsHTMLDDA"));
-}
-
-test "skip: OOS feature tags — permanent vs pre-Stage-4 vs vendor-blocked" {
-    // Permanent OOS: Annex B + SES carve-outs. A strict-only,
-    // non-browser, hardened engine never ships these, so the harness
-    // drops them from the corpus denominator (reason `.annex_b`). They
-    // classify via `featureIsOutOfScope` and nothing else.
-    try testing.expect(featureIsOutOfScope("__proto__"));
-    try testing.expect(featureIsOutOfScope("__getter__"));
-    try testing.expect(featureIsOutOfScope("__setter__"));
-    try testing.expect(featureIsOutOfScope("legacy-regexp"));
-    try testing.expect(featureIsOutOfScope("IsHTMLDDA"));
-    try testing.expect(!featureIsUnimplementedProposal("__proto__"));
-    try testing.expect(!featureIsCurrentlySkipped("__proto__"));
-
-    // Pre-Stage-4 proposals Cynic hasn't implemented are ALSO dropped
-    // from the corpus (reason `.pre_stage4`) — they aren't in any
-    // published edition, so they're out of scope until they reach
-    // Stage 4 (then in-scope, counted) or Cynic ships them (then a
-    // dedicated `feature:` phase). They classify via
-    // `featureIsUnimplementedProposal`, never as permanent OOS or as a
-    // counted in-corpus skip.
+test "skip: pre-Stage-4 proposals dropped from total" {
+    // Unshipped Stage <= 3 proposals — dropped via feature tag.
     try testing.expect(featureIsUnimplementedProposal("decorators"));
     try testing.expect(featureIsUnimplementedProposal("import-defer"));
     try testing.expect(featureIsUnimplementedProposal("source-phase-imports"));
     try testing.expect(featureIsUnimplementedProposal("await-dictionary"));
     try testing.expect(featureIsUnimplementedProposal("immutable-arraybuffer"));
-    try testing.expect(!featureIsOutOfScope("decorators"));
-    try testing.expect(!featureIsCurrentlySkipped("decorators"));
-
-    // `featureIsCurrentlySkipped` is the in-corpus bucket: a specced
-    // feature blocked on a vendor/infra gap. It's empty today (Perlex
-    // covers the regex surface), so no positive case — but it stays
-    // distinct from the two OOS predicates above.
-
-    // The union recognises all three buckets.
-    try testing.expect(featureIsUnsupported("__proto__"));
-    try testing.expect(featureIsUnsupported("decorators"));
-
-    // A shipped / specced feature is in none of the buckets — runnable.
-    try testing.expect(!featureIsOutOfScope("class"));
+    // Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) are
+    // NOT here — the harness keeps them out of the main rows via the
+    // per-phase feature-tag gate, and scores them in dedicated phases.
+    try testing.expect(!featureIsUnimplementedProposal("ShadowRealm"));
+    try testing.expect(!featureIsUnimplementedProposal("joint-iteration"));
+    // Shipped, specced features are runnable.
     try testing.expect(!featureIsUnimplementedProposal("class"));
-    try testing.expect(!featureIsCurrentlySkipped("class"));
+    try testing.expect(!featureIsUnimplementedProposal("regexp-modifiers"));
+    try testing.expect(!featureIsUnimplementedProposal("explicit-resource-management"));
 }
 
-test "skip: runtime-only gaps are NOT hidden" {
-    // SES-policy and Stage 3+ runtime features all parse fine;
-    // their fixtures show as honest runtime fails. Path-skipped
-    // OOS surfaces (eval, SharedArrayBuffer, Atomics) match by
-    // path, not by feature tag — the feature tag stays runnable
-    // so non-OOS callers don't get over-filtered.
-    try testing.expect(!featureIsUnsupported("Reflect.parse"));
-    try testing.expect(!featureIsUnsupported("ShadowRealm"));
-    try testing.expect(!featureIsUnsupported("SharedArrayBuffer"));
-    try testing.expect(!featureIsUnsupported("Atomics"));
-    try testing.expect(!featureIsUnsupported("eval"));
-    try testing.expect(!featureIsUnsupported("Array.fromAsync"));
-    try testing.expect(!featureIsUnsupported("Math.sumPrecise"));
-    try testing.expect(!featureIsUnsupported("async-iterator-helpers"));
+test "skip: tech-debt path skips (counted in total, lower pass%)" {
+    // Cross-realm fixtures awaiting multi-realm error attribution.
+    try testing.expect(pathIsCurrentlySkipped(
+        "language/expressions/class/elements/private-method-multiple-evaluations-of-class-realm-function-ctor.js",
+    ));
+    // Temporal fully ships — not a tech-debt skip.
+    try testing.expect(!pathIsCurrentlySkipped("built-ins/Temporal/Now/extensible.js"));
+    try testing.expect(!pathIsCurrentlySkipped("built-ins/Temporal/PlainDateTime/prototype/add/branding.js"));
+    // RegExp /v and property-escape surfaces ship via Perlex — not skipped.
+    try testing.expect(!pathIsCurrentlySkipped(
+        "built-ins/RegExp/property-escapes/special-property-value-Script_Extensions-Unknown.js",
+    ));
+    try testing.expect(!pathIsCurrentlySkipped(
+        "built-ins/RegExp/unicodeSets/generated/character-class-difference-character.js",
+    ));
 }
 
-test "skip: shipping features not flagged unsupported" {
-    try testing.expect(!featureIsUnsupported("regexp-v-flag")); // libregexp partial; positive forms ship
-    try testing.expect(!featureIsUnsupported("regexp-named-groups"));
-    try testing.expect(!featureIsUnsupported("regexp-duplicate-named-groups")); // native Perlex engine
-
-    try testing.expect(!featureIsUnsupported("class"));
-    try testing.expect(!featureIsUnsupported("optional-chaining"));
-    try testing.expect(!featureIsUnsupported("async-functions"));
+test "skip: ShadowRealm is not path-skipped (feature-gated)" {
+    // ShadowRealm ships behind `--enable=ShadowRealm`; the harness's
+    // per-phase feature-tag gate keeps it out of the main rows, not a
+    // skip.zig path list. So neither walk-skip nor tech-debt-skip fires.
+    try testing.expect(!pathIsSkipped("built-ins/ShadowRealm/constructor.js"));
+    try testing.expect(!pathIsCurrentlySkipped("built-ins/ShadowRealm/constructor.js"));
+    // The sloppy-mode `evaluate` fixture classifies as no_strict policy.
+    try testing.expectEqual(
+        PolicyKind.no_strict,
+        pathPolicyKind("built-ins/ShadowRealm/prototype/evaluate/no-conditional-strict-mode.js", &.{}, false).?,
+    );
 }

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -1399,7 +1399,6 @@ pub fn pathPolicyKind(
 
 const testing = std.testing;
 
-
 test "skip: corpus-walk exclusions" {
     // Only `harness/` and `staging/` are walk-excluded now. intl402
     // RUNS under the new model (failures classify as the intl402


### PR DESCRIPTION
## What

Reworks the test262 scoring model. Previously the harness walked out Annex B / `intl402/` / `noStrict` / the eval surface before scoring, and the SES posture's intentional throws were tracked as a one-off `divergent` column. Now **every fixture runs** except `harness/`, `staging/`, and Stage ≤ 3 proposals — and each failure is sorted into:

- **passing** — engine produced the spec-expected result
- **failing** — a real engine bug, no policy bucket. The work-left signal.
- **correctly handled** — a failure Cynic produces *by design*: Annex B not shipped, strict-only, no Intl, eval-off, or SES throw.

Headline `pass% = (passing + correctly handled) / total`.

## Score rows

`## Current scores` grows to three postures (the order requested):

| posture | passing | failing | correctly handled | total | pass% |
|---|---:|---:|---:|---:|---:|
| **unhardened, `--allow=eval`** | n/a | n/a | n/a | n/a | n/a |
| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % |
| **hardened** (`cynic run`) | 40178 | 593 | 10120 | 50894 | 98.83 % |

The `--allow=eval` row is a placeholder until the eval opt-in ships (it has no runtime today); the layout is reserved so it picks up the eval fixtures cleanly when it lands.

The same `passing | failing | correctly handled | total | pass%` columns flow through the per-area scoreboard, the per-feature (pre-Stage-4) table, and per-day history. Old history rows are migrated in place; the parser accepts both schemas.

## The 593 hardened fails

Not regressions — all "Cynic doesn't ship X yet":

- **486** are the shared-memory surface (Atomics 270, SharedArrayBuffer 104, `-sab.js` view siblings ~112). SAB/Atomics are deliberately **not** a policy bucket (Cynic could ship them), so they stay plain `failing`.
- **~13** cross-realm fixtures awaiting `--allow=eval` / multi-realm error attribution.
- **0** "engine got the answer wrong" bugs.

## skip.zig cleanup

Replaced the obsolete A/B/C "outcome" taxonomy (9 predicates) with the 4 functions the model actually uses — `pathIsSkipped`, `pathIsCurrentlySkipped`, `featureIsUnimplementedProposal`, `pathPolicyKind` — and deleted ~480 lines of dead predicates + data arrays. Test block rewritten to the new API (11 tests, all green).

## Verification

- `zig build` ✓ · `zig build test262` builds ✓ · `skip.zig` units 11/11 ✓
- Full sweep clean; `test262-results.md` regenerated (included — PRs review against it).
- Changes are confined to `tools/` + docs; `src/` untouched.

## Docs

AGENTS.md, README, `docs/handbook/ses-test262-policy.md`, `docs/ses-alignment.md`, `docs/ROADMAP.md` updated to the new column/row model.
