### PR TITLE
refactor: route built-in accessors through makeNativeFunction (§17 [[Construct]] fix)

### DIFF
--- a/src/runtime/builtins/array.zig
+++ b/src/runtime/builtins/array.zig
@@ -145,9 +145,7 @@ pub fn install(realm: *Realm) !void {
         // §10.2.9 SetFunctionName step 7 — a getter's name is
         // prefixed with `"get "`. `Object.getOwnPropertyDescriptor
         // (Array, Symbol.species).get.name === "get [Symbol.species]"`.
-        const species_getter = try realm.heap.allocateFunctionNative(arraySpeciesGetter, 0, "get [Symbol.species]");
-        species_getter.proto = realm.intrinsics.function_prototype;
-        species_getter.realm = realm;
+        const species_getter = try intrinsics.makeNativeFunction(realm, arraySpeciesGetter, 0, "get [Symbol.species]");
         const entry = try arr_ctor.accessors.getOrPut(realm.allocator, "@@species");
         entry.value_ptr.* = .{ .getter = species_getter };
         try arr_ctor.property_flags.put(realm.allocator, "@@species", .{

--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -56,8 +56,7 @@ fn installSpeciesGetter(realm: *Realm, ctor: *@import("../function.zig").JSFunct
     // `"get [Symbol.species]"` per §15.7.4 (well-known-symbol
     // accessor formatting). Matches what `Symbol.species/symbol-
     // species-name.js` reads via `Object.getOwnPropertyDescriptor`.
-    const getter = try realm.heap.allocateFunctionNative(speciesReturnsThis, 0, "get [Symbol.species]");
-    getter.proto = realm.intrinsics.function_prototype;
+    const getter = try intrinsics.makeNativeFunction(realm, speciesReturnsThis, 0, "get [Symbol.species]");
     const entry = try ctor.accessors.getOrPut(realm.allocator, "@@species");
     entry.value_ptr.* = .{ .getter = getter };
     try ctor.property_flags.put(realm.allocator, "@@species", .{

--- a/src/runtime/builtins/iterator.zig
+++ b/src/runtime/builtins/iterator.zig
@@ -156,12 +156,8 @@ pub fn install(realm: *Realm) !void {
 /// "constructor", v). Matches `built-ins/Iterator/prototype/
 /// constructor/{prop-desc,weird-setter}.js`.
 fn installIteratorPrototypeConstructorAccessor(realm: *Realm, proto: *JSObject) !void {
-    const getter = try realm.heap.allocateFunctionNative(iteratorPrototypeConstructorGet, 0, "get constructor");
-    getter.proto = realm.intrinsics.function_prototype;
-    getter.realm = realm;
-    const setter = try realm.heap.allocateFunctionNative(iteratorPrototypeConstructorSet, 1, "set constructor");
-    setter.proto = realm.intrinsics.function_prototype;
-    setter.realm = realm;
+    const getter = try intrinsics.makeNativeFunction(realm, iteratorPrototypeConstructorGet, 0, "get constructor");
+    const setter = try intrinsics.makeNativeFunction(realm, iteratorPrototypeConstructorSet, 1, "set constructor");
     // §17 — built-in accessor properties: { enumerable: false,
     // configurable: true }.
     const entry = try proto.getOrPutAccessor(realm.allocator, "constructor");
@@ -188,12 +184,8 @@ fn installIteratorPrototypeConstructorAccessor(realm: *Realm, proto: *JSObject) 
 /// SetterThatIgnoresPrototypeProperties(%Iterator.prototype%,
 /// @@toStringTag, v).
 fn installIteratorPrototypeToStringTagAccessor(realm: *Realm, proto: *JSObject) !void {
-    const getter = try realm.heap.allocateFunctionNative(iteratorPrototypeToStringTagGet, 0, "get [Symbol.toStringTag]");
-    getter.proto = realm.intrinsics.function_prototype;
-    getter.realm = realm;
-    const setter = try realm.heap.allocateFunctionNative(iteratorPrototypeToStringTagSet, 1, "set [Symbol.toStringTag]");
-    setter.proto = realm.intrinsics.function_prototype;
-    setter.realm = realm;
+    const getter = try intrinsics.makeNativeFunction(realm, iteratorPrototypeToStringTagGet, 0, "get [Symbol.toStringTag]");
+    const setter = try intrinsics.makeNativeFunction(realm, iteratorPrototypeToStringTagSet, 1, "set [Symbol.toStringTag]");
     const entry = try proto.getOrPutAccessor(realm.allocator, "@@toStringTag");
     entry.value_ptr.* = .{ .getter = getter, .setter = setter };
     try proto.property_flags.put(realm.allocator, "@@toStringTag", .{

--- a/src/runtime/builtins/promise.zig
+++ b/src/runtime/builtins/promise.zig
@@ -97,10 +97,7 @@ pub fn install(realm: *Realm) !void {
     // §27.2.4.6 — the getter's `name` property is
     // `"get [Symbol.species]"`; the `get ` prefix is required by
     // §10.2.10 SetFunctionName for accessor functions.
-    const species_getter = try realm.heap.allocateFunctionNative(promiseSpeciesGetter, 0, "get [Symbol.species]");
-    species_getter.proto = realm.intrinsics.function_prototype;
-    species_getter.has_construct = false;
-    species_getter.realm = realm;
+    const species_getter = try intrinsics.makeNativeFunction(realm, promiseSpeciesGetter, 0, "get [Symbol.species]");
     const sp_entry = try fn_obj.accessors.getOrPut(realm.allocator, "@@species");
     sp_entry.value_ptr.* = .{ .getter = species_getter };
     try fn_obj.property_flags.put(realm.allocator, "@@species", .{

--- a/src/runtime/builtins/regexp.zig
+++ b/src/runtime/builtins/regexp.zig
@@ -114,8 +114,7 @@ pub fn install(realm: *Realm) !void {
     // built-in name is `"get [Symbol.species]"` (§22.2.4.2),
     // descriptor `{ get, set: undefined, enumerable: false,
     // configurable: true }`.
-    const species_getter = try realm.heap.allocateFunctionNative(regexpSpeciesGetter, 0, "get [Symbol.species]");
-    species_getter.proto = realm.intrinsics.function_prototype;
+    const species_getter = try intrinsics.makeNativeFunction(realm, regexpSpeciesGetter, 0, "get [Symbol.species]");
     const species_entry = try fn_obj.accessors.getOrPut(realm.allocator, "@@species");
     species_entry.value_ptr.* = .{ .getter = species_getter };
     try fn_obj.property_flags.put(realm.allocator, "@@species", .{

--- a/src/runtime/builtins/typed_array.zig
+++ b/src/runtime/builtins/typed_array.zig
@@ -98,9 +98,7 @@ pub fn install(realm: *Realm) !void {
         // overridden). `Symbol.species` is the hook every
         // ArrayBuffer.prototype.slice fixture pokes at.
         {
-            const species_getter = try realm.heap.allocateFunctionNative(arrayBufferSpeciesGetter, 0, "get [Symbol.species]");
-            species_getter.proto = realm.intrinsics.function_prototype;
-            species_getter.realm = realm;
+            const species_getter = try intrinsics.makeNativeFunction(realm, arrayBufferSpeciesGetter, 0, "get [Symbol.species]");
             const entry = try ctor.accessors.getOrPut(realm.allocator, "@@species");
             entry.value_ptr.* = .{ .getter = species_getter };
             try ctor.property_flags.put(realm.allocator, "@@species", .{
@@ -272,9 +270,7 @@ pub fn install(realm: *Realm) !void {
     // inherited getter and resolve to the subclass.
     {
         // §10.2.9 step 7 — getter names carry the `"get "` prefix.
-        const species_getter = try realm.heap.allocateFunctionNative(typedArraySpeciesGetter, 0, "get [Symbol.species]");
-        species_getter.proto = realm.intrinsics.function_prototype;
-        species_getter.realm = realm;
+        const species_getter = try intrinsics.makeNativeFunction(realm, typedArraySpeciesGetter, 0, "get [Symbol.species]");
         const entry = try ta_ctor.accessors.getOrPut(realm.allocator, "@@species");
         entry.value_ptr.* = .{ .getter = species_getter };
         try ta_ctor.property_flags.put(realm.allocator, "@@species", .{

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -1067,10 +1067,10 @@ pub fn installNativeGetter(realm: *Realm, proto: *JSObject, name: []const u8, ge
         std.fmt.allocPrint(realm.classAllocator(), "get [Symbol.{s}]", .{name[2..]}) catch return error.OutOfMemory
     else
         std.fmt.allocPrint(realm.classAllocator(), "get {s}", .{name}) catch return error.OutOfMemory;
-    const getter = try realm.heap.allocateFunctionNative(getter_fn, 0, getter_name);
-    getter.proto = realm.intrinsics.function_prototype;
-    // §10.2.5 — accessor closures carry their installing realm.
-    getter.realm = realm;
+    // §17 — an accessor getter is not a constructor; `makeNativeFunction`
+    // clears `[[Construct]]` and sets `[[Prototype]]` = %Function.prototype%
+    // (§20.2.3) and `[[Realm]]` (§10.2.5).
+    const getter = try makeNativeFunction(realm, getter_fn, 0, getter_name);
     const entry = try proto.getOrPutAccessor(realm.allocator, name);
     entry.value_ptr.* = .{ .getter = getter };
     // §17 — built-in accessor properties are { enumerable: false,

--- a/src/runtime/surface_audit_test.zig
+++ b/src/runtime/surface_audit_test.zig
@@ -32,6 +32,7 @@ const testing = std.testing;
 
 const Realm = @import("realm.zig").Realm;
 const JSObject = @import("object.zig").JSObject;
+const Accessor = @import("object.zig").Accessor;
 
 /// Collect every own property name on `obj` (data + accessor),
 /// returning a duplicated, sorted slice. Caller frees with
@@ -433,4 +434,87 @@ test "method-registration shape: Set.prototype values/keys/@@iterator are the sa
     const iter = set_proto.lookupOwn("@@iterator").?;
     try testing.expect(heap_mod.valueAsFunction(values).? == heap_mod.valueAsFunction(keys).?);
     try testing.expect(heap_mod.valueAsFunction(values).? == heap_mod.valueAsFunction(iter).?);
+}
+
+/// Assert a built-in accessor function carries the §17 / §10.2.5
+/// shape: it is NOT a constructor (`[[Construct]]` absent —
+/// accessor functions never construct), its `[[Prototype]]` is
+/// `%Function.prototype%`, its `[[Realm]]` is the installing
+/// realm, and its `.name` is the `"get "` / `"set "`-prefixed
+/// form per §10.2.9 SetFunctionName.
+fn expectCanonicalAccessorFn(
+    realm: *Realm,
+    fn_obj_opt: ?*@import("function.zig").JSFunction,
+    expected_name: []const u8,
+) !void {
+    const fn_obj = fn_obj_opt orelse {
+        std.debug.print("[accessor-shape] missing accessor fn \"{s}\"\n", .{expected_name});
+        return error.MissingAccessorFn;
+    };
+    try testing.expect(!fn_obj.has_construct);
+    try testing.expect(fn_obj.proto == realm.intrinsics.function_prototype);
+    try testing.expect(fn_obj.realm == realm);
+    try testing.expect(fn_obj.name != null);
+    try testing.expectEqualStrings(expected_name, fn_obj.name.?);
+}
+
+test "accessor-registration shape: @@species getters aren't constructors and carry [[Realm]]" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    // §22.1.2.5 / §24.1.2.2 / §27.2.4.10 etc. — `get C[@@species]`
+    // is an accessor; its getter is a non-constructor built-in.
+    const cases = [_][]const u8{ "Array", "Map", "Set", "Promise", "RegExp" };
+    for (cases) |name| {
+        const ctor_v = realm.globals.get(name) orelse {
+            std.debug.print("[accessor-shape] no global {s}\n", .{name});
+            return error.NoCtor;
+        };
+        const ctor = heap_mod.valueAsFunction(ctor_v) orelse return error.CtorNotFn;
+        const acc: Accessor = ctor.accessors.get("@@species") orelse {
+            std.debug.print("[accessor-shape] {s} missing @@species accessor\n", .{name});
+            return error.NoSpeciesAccessor;
+        };
+        try expectCanonicalAccessorFn(&realm, acc.getter, "get [Symbol.species]");
+    }
+}
+
+test "accessor-registration shape: Iterator.prototype accessor pairs aren't constructors" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    const iter_v = realm.globals.get("Iterator") orelse return error.NoIterator;
+    const iter_ctor = heap_mod.valueAsFunction(iter_v) orelse return error.IteratorNotFn;
+    const proto = iter_ctor.prototype orelse return error.NoIteratorProto;
+    const proto_ext = proto.extension orelse return error.NoIteratorProtoExt;
+
+    // §27.1.4.5 / §27.1.4.6 — `constructor` and `@@toStringTag` are
+    // accessor pairs; neither the getter nor the setter constructs.
+    const ctor_acc: Accessor = proto_ext.accessors.get("constructor") orelse return error.NoCtorAccessor;
+    try expectCanonicalAccessorFn(&realm, ctor_acc.getter, "get constructor");
+    try expectCanonicalAccessorFn(&realm, ctor_acc.setter, "set constructor");
+
+    const tag_acc: Accessor = proto_ext.accessors.get("@@toStringTag") orelse return error.NoTagAccessor;
+    try expectCanonicalAccessorFn(&realm, tag_acc.getter, "get [Symbol.toStringTag]");
+    try expectCanonicalAccessorFn(&realm, tag_acc.setter, "set [Symbol.toStringTag]");
+}
+
+test "accessor-registration shape: simple installNativeGetter getters aren't constructors" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    // §25.1.6 get ArrayBuffer.prototype.byteLength — a plain
+    // `installNativeGetter` accessor; the getter is a non-constructor.
+    const ab_v = realm.globals.get("ArrayBuffer") orelse return error.NoArrayBuffer;
+    const ab_ctor = heap_mod.valueAsFunction(ab_v) orelse return error.ABNotFn;
+    const ab_proto = ab_ctor.prototype orelse return error.NoABProto;
+    const ab_ext = ab_proto.extension orelse return error.NoABProtoExt;
+    const acc: Accessor = ab_ext.accessors.get("byteLength") orelse return error.NoByteLengthAccessor;
+    try expectCanonicalAccessorFn(&realm, acc.getter, "get byteLength");
 }


### PR DESCRIPTION
## Summary

Built-in getters/setters were wrongly **constructable**: `JSFunction.has_construct` defaults to `true` and the accessor install sites never cleared it — a §17 violation (accessor functions are not constructors). This routes them all through `makeNativeFunction` (introduced in #9), which clears `has_construct` and sets `[[Prototype]] = %Function.prototype%` (§20.2.3) and `[[Realm]]` (§10.2.5).

### Sites fixed
- **`installNativeGetter` (central)** — repairs *every* simple getter: `byteLength`, `size`, `description`, all Temporal fields, etc.
- **`@@species` getters** — `array`, `typed_array` (×2), `promise`, `regexp`, `collections`. `collections` also gains the previously-missing `[[Realm]]`; `promise` drops a now-redundant manual `has_construct = false`.
- **Iterator.prototype accessor pairs** — `constructor` and `@@toStringTag` get/set (all 4 functions).

### Tests
+84 lines in `surface_audit_test.zig` pinning the accessor shape (non-constructor, `%Function.prototype%`, `[[Realm]]`, `"get "`/`"set "` name). These went **red on the bug**, green after the fix.

## Verification
- `zig build test` → exit 0 (3 new tests red→green)
- Full test262 sweep → **0 fail** (91.03% engine-true)
- `Symbol.species` bucket → **0 fail**

Net: +98 / −33 across 8 files. Stacks conceptually on #9 (same `makeNativeFunction` consolidation).