### PR TITLE
proxy: enforce [[Call]] callability gate and [[GetOwnProperty]] compatibility

### DIFF
--- a/src/runtime/builtins/object.zig
+++ b/src/runtime/builtins/object.zig
@@ -2185,6 +2185,32 @@ pub fn objectGetOwnPropertyDescriptor(realm: *Realm, this_value: Value, args: []
                     if (!target_had and !proxy_target.extensible) {
                         return throwTypeError(realm, "'getOwnPropertyDescriptor' on proxy returned a descriptor for an absent property of a non-extensible target");
                     }
+                    // §10.5.5 steps 16-18 — IsCompatiblePropertyDescriptor
+                    // (extensibleTarget, resultDesc, targetDesc). When the
+                    // target owns the property, the trap's descriptor must be
+                    // compatible with the target's current one. Reuse the
+                    // shared §10.1.6.3 ValidateAndApplyPropertyDescriptor
+                    // guard `isCompatibleRedefine`: against a non-configurable
+                    // target property it rejects a trap that claims
+                    // `configurable: true`, toggles `enumerable`, flips
+                    // data<->accessor, or mutates a non-writable data slot's
+                    // value/writable. (The configurable→non-configurable and
+                    // writable specials below are §10.5.5 steps 19-21, which
+                    // that guard does not cover.)
+                    if (target_had) {
+                        const t_flags = proxy_target.flagsFor(key);
+                        const t_is_acc = proxy_target.hasAccessor(key);
+                        const t_value = proxy_target.lookupOwn(key) orelse Value.undefined_;
+                        var t_getter: ?*JSFunction = null;
+                        var t_setter: ?*JSFunction = null;
+                        if (proxy_target.getAccessor(key)) |acc| {
+                            t_getter = acc.getter;
+                            t_setter = acc.setter;
+                        }
+                        if (!isCompatibleRedefine(t_is_acc, t_flags, t_value, t_getter, t_setter, parsed_inv)) {
+                            return throwTypeError(realm, "'getOwnPropertyDescriptor' on proxy returned a descriptor incompatible with the non-configurable target property");
+                        }
+                    }
                     if (parsed_inv.has_configurable and !parsed_inv.configurable) {
                         if (!target_had) {
                             return throwTypeError(realm, "'getOwnPropertyDescriptor' on proxy reported non-configurable for an absent target property");

--- a/src/runtime/lantern/call.zig
+++ b/src/runtime/lantern/call.zig
@@ -188,10 +188,23 @@ pub fn callValue(
     this_value: Value,
     args: []const Value,
 ) RunError!RunResult {
-    // Proxy of fn — dispatch through `apply` trap if present;
-    // otherwise unwrap to the target function.
+    // §10.5.12 Proxy [[Call]] — a proxy exposes a [[Call]] internal
+    // method ONLY when its target was callable at creation: §10.5.1
+    // ProxyCreate step 3 gates installing [[Call]] on
+    // IsCallable(target). `proxy_callable` records that gate (set in
+    // proxyConstructor for function / callable-proxy targets, and
+    // preserved across revocation). Enter this block only for an
+    // object that is BOTH a proxy (a live target slot, or revoked)
+    // AND callable. The callability clause excludes a proxy over a
+    // non-callable target — `new Proxy({}, { apply() {} })` has no
+    // [[Call]], so invoking it must fall through to the ordinary
+    // "not a function" TypeError with the `apply` trap never firing.
+    // The proxy-identity clause is equally load-bearing:
+    // %Function.prototype% also carries `proxy_callable` (its
+    // callability marker, so `typeof` reports "function") yet is not
+    // a proxy, and must reach the identity check below — not here.
     if (heap_mod.valueAsPlainObject(callee_v)) |po| {
-        if (po.proxy_target_fn != null or po.proxy_target != null or po.proxy_revoked) {
+        if ((po.proxy_target_fn != null or po.proxy_target != null or po.proxy_revoked) and po.proxy_callable) {
             if (po.proxy_revoked) {
                 // §10.5.12 step 1 ValidateNonRevokedProxy throws in
                 // the running execution context's realm — `running_realm`,

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -7974,6 +7974,69 @@ test "Object.prototype.toString: callable Proxy reports [object Function]" {
     , "[object Function]");
 }
 
+test "Proxy [[Call]]: non-callable-target proxy throws on call (§10.5.12)" {
+    // §10.5.1 ProxyCreate step 3 installs a [[Call]] internal method
+    // only when IsCallable(target) is true. A proxy over a plain
+    // object therefore has no [[Call]]: invoking it throws TypeError,
+    // and the installed `apply` trap must NOT fire.
+    try expectScriptThrowsWithBuiltins(
+        \\const p = new Proxy({}, { apply() { return "called"; } });
+        \\p();
+    );
+}
+
+test "Proxy [[Call]]: non-callable-target proxy has typeof object" {
+    // A non-callable proxy is not a function — §14 typeof reports
+    // "object", confirming the absence of [[Call]].
+    try expectScriptStringWithBuiltins(
+        \\typeof new Proxy({}, { apply() {} });
+    , "object");
+}
+
+test "Proxy [[Call]]: callable-target proxy still dispatches apply trap" {
+    // The fix must not disturb the genuine callable path — a proxy
+    // over a function keeps its [[Call]] and fires the apply trap.
+    try expectScriptStringWithBuiltins(
+        \\const p = new Proxy(function () {}, { apply() { return "ok"; } });
+        \\p();
+    , "ok");
+}
+
+test "Proxy [[Call]]: non-callable proxy rejected via Reflect.apply" {
+    // Reflective callers route through the same callValue chokepoint.
+    try expectScriptThrowsWithBuiltins(
+        \\Reflect.apply(new Proxy({}, { apply() { return 1; } }), undefined, []);
+    );
+}
+
+test "Proxy [[GetOwnProperty]]: trap can't report non-configurable target as configurable (§10.5.5)" {
+    // §10.5.5 steps 16-18 IsCompatiblePropertyDescriptor — a
+    // getOwnPropertyDescriptor trap that claims configurable:true for
+    // a non-configurable target property is an invariant violation.
+    try expectScriptThrowsWithBuiltins(
+        \\const t = {};
+        \\Object.defineProperty(t, "x", { value: 1, configurable: false, writable: true });
+        \\const p = new Proxy(t, {
+        \\  getOwnPropertyDescriptor() {
+        \\    return { value: 1, configurable: true, writable: true, enumerable: true };
+        \\  }
+        \\});
+        \\Object.getOwnPropertyDescriptor(p, "x");
+    );
+}
+
+test "Proxy [[GetOwnProperty]]: compatible descriptor passes through" {
+    // A configurable target property whose trap descriptor agrees is
+    // returned unchanged — the new invariant check must not over-reject.
+    try expectScriptStringWithBuiltins(
+        \\const t = { x: 1 };
+        \\const p = new Proxy(t, {
+        \\  getOwnPropertyDescriptor(tt, k) { return Object.getOwnPropertyDescriptor(tt, k); }
+        \\});
+        \\String(Object.getOwnPropertyDescriptor(p, "x").value);
+    , "1");
+}
+
 test "Object.prototype.toString: @@toStringTag getter throw propagates" {
     // §20.1.3.6 step 15 — Get(O, @@toStringTag) can throw.
     try expectScriptThrowsWithBuiltins(


### PR DESCRIPTION
Fixes #7. Fixes #8.

Two §10.5 Proxy internal-method invariants were missing. Both are mode-independent (unrelated to strict/sloppy).

## #7 — `[[Call]]` over a non-callable target (§10.5.12)
`callValue` routed any proxy with a target slot to the `apply` trap, so `new Proxy({}, { apply() {} })()` ran the trap and returned a value instead of throwing. ProxyCreate (§10.5.1 step 3) installs `[[Call]]` only when the target is callable, so such a proxy has no `[[Call]]` — invoking it must throw `TypeError`, with the trap never firing.

**Fix:** gate the proxy-call dispatch on `proxy_callable` alongside the proxy-identity check. The identity clause stays load-bearing because `%Function.prototype%` also carries `proxy_callable` (its `typeof === "function"` marker) yet is not a proxy, and must reach the identity fast-path rather than the trap.

## #8 — `[[GetOwnProperty]]` incompatible descriptor (§10.5.5 steps 16-18)
The `getOwnPropertyDescriptor` trap path skipped `IsCompatiblePropertyDescriptor`, so a trap could report `configurable: true` for a non-configurable target property.

**Fix:** run the existing §10.1.6.3 `ValidateAndApplyPropertyDescriptor` guard (`isCompatibleRedefine`) against the target's current descriptor.

## Tests & verification
- 6 regression unit tests (4 for `[[Call]]`, 2 for `[[GetOwnProperty]]`), including guards that the callable-proxy and compatible-descriptor paths still work.
- `zig build test`: green.
- test262: `built-ins/Proxy` **0 fail** (288/294), `built-ins/Function/prototype` **0 fail** (217/243), `language/expressions/call` **0 fail** (75/75).
- Leak check (`--top-rss` on `built-ins/Proxy`): no fixture over the 8 MB RSS-delta threshold.

> Branched from `main` HEAD; the `tests.zig` hunk will need a trivial rebase against the in-flight runtime work before merge.
