### PR TITLE
refactor: set native function [[Realm]] at allocation time (§10.2.5)

### DIFF
--- a/src/runtime/builtins/array.zig
+++ b/src/runtime/builtins/array.zig
@@ -3891,7 +3891,7 @@ fn makeBoundCb(
     state: *JSObject,
     sc: *heap_mod.HandleScope,
 ) NativeError!*JSFunction {
-    const impl_fn = realm.heap.allocateFunctionNative(impl, 1, "") catch return error.OutOfMemory;
+    const impl_fn = realm.heap.allocateFunctionNative(realm, impl, 1, "") catch return error.OutOfMemory;
     impl_fn.proto = realm.intrinsics.function_prototype;
     impl_fn.has_construct = false;
     // Root `impl_fn` across the `bound` allocation below — otherwise
@@ -3900,7 +3900,7 @@ fn makeBoundCb(
     // dangling pointer that surfaces as "value is not callable" when
     // the trampoline later dereferences `bound_target`.
     sc.push(heap_mod.taggedFunction(impl_fn)) catch return error.OutOfMemory;
-    const bound = realm.heap.allocateFunctionNative(promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
+    const bound = realm.heap.allocateFunctionNative(realm, promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
     bound.proto = realm.intrinsics.function_prototype;
     bound.has_construct = false;
     realm.heap.setBoundTarget(bound, impl_fn);

--- a/src/runtime/builtins/async_disposable_stack.zig
+++ b/src/runtime/builtins/async_disposable_stack.zig
@@ -190,7 +190,7 @@ fn asyncDisposableStackAdopt(realm: *Realm, this_value: Value, args: []const Val
 
     // §27.4.3.2 step 5-6 — build the wrapper closure as a bound
     // function. `bound_this = undefined`, prefix args `[value]`.
-    const wrapper = realm.heap.allocateFunctionNative(boundAdoptTrampoline, 0, "") catch return error.OutOfMemory;
+    const wrapper = realm.heap.allocateFunctionNative(realm, boundAdoptTrampoline, 0, "") catch return error.OutOfMemory;
     wrapper.proto = realm.intrinsics.function_prototype;
     wrapper.has_construct = false;
     realm.heap.setBoundTarget(wrapper, on_dispose);
@@ -525,10 +525,10 @@ fn allocateStepBound(
     impl: NativeFn,
     name: []const u8,
 ) NativeError!*JSFunction {
-    const inner = realm.heap.allocateFunctionNative(impl, 1, name) catch return error.OutOfMemory;
+    const inner = realm.heap.allocateFunctionNative(realm, impl, 1, name) catch return error.OutOfMemory;
     inner.proto = realm.intrinsics.function_prototype;
     inner.has_construct = false;
-    const outer = realm.heap.allocateFunctionNative(boundAdoptTrampoline, 1, name) catch return error.OutOfMemory;
+    const outer = realm.heap.allocateFunctionNative(realm, boundAdoptTrampoline, 1, name) catch return error.OutOfMemory;
     outer.proto = realm.intrinsics.function_prototype;
     outer.has_construct = false;
     realm.heap.setBoundTarget(outer, inner);

--- a/src/runtime/builtins/async_iterator.zig
+++ b/src/runtime/builtins/async_iterator.zig
@@ -300,9 +300,9 @@ fn wrapAsyncGenResultWithClose(
             // rejection reaction calls IteratorClose before
             // rejecting the outer Promise (§27.6.1.6 step 13).
             const outer = intrinsics_mod.allocatePromiseFor(realm, null, .pending, Value.undefined_) catch return error.OutOfMemory;
-            const fulfill_fn = realm.heap.allocateFunctionNative(if (done) iterResultDoneTrue else iterResultDoneFalse, 1, "asyncGenYield") catch return error.OutOfMemory;
+            const fulfill_fn = realm.heap.allocateFunctionNative(realm, if (done) iterResultDoneTrue else iterResultDoneFalse, 1, "asyncGenYield") catch return error.OutOfMemory;
             fulfill_fn.has_construct = false;
-            const reject_fn = realm.heap.allocateFunctionNative(closeIteratorOnReject, 1, "closeIterator") catch return error.OutOfMemory;
+            const reject_fn = realm.heap.allocateFunctionNative(realm, closeIteratorOnReject, 1, "closeIterator") catch return error.OutOfMemory;
             reject_fn.has_construct = false;
             reject_fn.properties.put(realm.allocator, "__cynic_sync_iter__", sync_iter_v) catch return error.OutOfMemory;
             const p_reactions = p.promiseReactionsPtr(realm.allocator) catch return error.OutOfMemory;

--- a/src/runtime/builtins/date.zig
+++ b/src/runtime/builtins/date.zig
@@ -126,7 +126,7 @@ pub fn install(realm: *Realm) !void {
     // from the `installNativeMethodOnProto` default of writable: true.
     // The function's own `.name` is `"[Symbol.toPrimitive]"`, not
     // the raw `@@toPrimitive` slot key.
-    const tp_fn = try realm.heap.allocateFunctionNative(dateToPrimitive, 1, "[Symbol.toPrimitive]");
+    const tp_fn = try realm.heap.allocateFunctionNative(realm, dateToPrimitive, 1, "[Symbol.toPrimitive]");
     tp_fn.has_construct = false;
     try proto.setWithFlags(realm.allocator, "@@toPrimitive", heap_mod.taggedFunction(tp_fn), .{
         .writable = false,

--- a/src/runtime/builtins/disposable_stack.zig
+++ b/src/runtime/builtins/disposable_stack.zig
@@ -177,7 +177,7 @@ fn disposableStackAdopt(realm: *Realm, this_value: Value, args: []const Value) N
 
     // §27.3.3.2 step 5-6 — build the wrapper closure as a bound
     // function. `bound_this = undefined`, prefix args `[value]`.
-    const wrapper = realm.heap.allocateFunctionNative(boundAdoptTrampoline, 0, "") catch return error.OutOfMemory;
+    const wrapper = realm.heap.allocateFunctionNative(realm, boundAdoptTrampoline, 0, "") catch return error.OutOfMemory;
     wrapper.proto = realm.intrinsics.function_prototype;
     wrapper.has_construct = false;
     realm.heap.setBoundTarget(wrapper, on_dispose);

--- a/src/runtime/builtins/error.zig
+++ b/src/runtime/builtins/error.zig
@@ -369,11 +369,8 @@ pub fn installError(
     parent_proto: *JSObject,
     arity: u8,
 ) !*JSFunction {
-    const fn_obj = try realm.heap.allocateFunctionNative(native, arity, name);
-    // §10.2.5 — built-in constructors carry their installing realm
-    // so cross-realm identity checks can tell when a constructor's
-    // realm differs from the caller's.
-    fn_obj.realm = realm;
+    // §10.2.5 [[Realm]] is wired inside allocateFunctionNative.
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, native, arity, name);
     // The auto-allocated prototype was given.constructor by
     // allocateFunctionNative-equivalent paths in non-native
     // allocateFunction; native fns don't get a prototype unless

--- a/src/runtime/builtins/function.zig
+++ b/src/runtime/builtins/function.zig
@@ -96,7 +96,7 @@ pub fn installPrototypeMethods(realm: *Realm) !void {
     // §20.2.3.6 — Function.prototype[@@hasInstance].
     // Descriptor: `{w:false, e:false, c:false}` (per §17).
     // Function's own `name` is "[Symbol.hasInstance]", `length` is 1.
-    const hi_fn = try realm.heap.allocateFunctionNative(functionHasInstance, 1, "[Symbol.hasInstance]");
+    const hi_fn = try realm.heap.allocateFunctionNative(realm, functionHasInstance, 1, "[Symbol.hasInstance]");
     hi_fn.proto = fn_proto;
     hi_fn.has_construct = false;
     try fn_proto.setWithFlags(realm.allocator, "@@hasInstance", heap_mod.taggedFunction(hi_fn), .{
@@ -150,7 +150,7 @@ fn functionConstructor(realm: *Realm, this_value: Value, args: []const Value) Na
     // returns undefined regardless of arguments — matches the
     // spec semantics of `Function()` (a function whose body is
     // the empty string).
-    const empty = realm.heap.allocateFunctionNative(emptyFunctionBody, 0, "anonymous") catch return error.OutOfMemory;
+    const empty = realm.heap.allocateFunctionNative(realm, emptyFunctionBody, 0, "anonymous") catch return error.OutOfMemory;
     empty.realm = ctor_realm;
     // §10.2.2 base-kind [[Construct]] — this is an ordinary function
     // (its body is the empty string), so a nulled `prototype` falls
@@ -509,7 +509,7 @@ fn functionBind(realm: *Realm, this_value: Value, args: []const Value) NativeErr
 
     // The bound function carries no chunk; call sites detect
     // `bound_target` and route through that.
-    const bound = realm.heap.allocateFunctionNative(boundFunctionTrampoline, 0, "bound") catch return error.OutOfMemory;
+    const bound = realm.heap.allocateFunctionNative(realm, boundFunctionTrampoline, 0, "bound") catch return error.OutOfMemory;
     bound.proto = realm.intrinsics.function_prototype;
     realm.heap.setBoundTarget(bound, target);
     realm.heap.setBoundThis(bound, bound_this);
@@ -628,7 +628,7 @@ pub fn wireVariantInstancePrototypes(realm: *Realm) !void {
 }
 
 fn installVariantCtor(realm: *Realm, name: []const u8) !*JSObject {
-    const fn_obj = try realm.heap.allocateFunctionNative(variantCtorThrows, 1, name);
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, variantCtorThrows, 1, name);
     fn_obj.proto = realm.intrinsics.function_prototype;
     // §27.3.1 / §27.4.1 / §27.7.1 — GeneratorFunction /
     // AsyncGeneratorFunction / AsyncFunction are subclasses of

--- a/src/runtime/builtins/harden.zig
+++ b/src/runtime/builtins/harden.zig
@@ -71,7 +71,7 @@ pub fn freezeLazyIntrinsic(realm: *Realm, obj: *@import("../object.zig").JSObjec
 }
 
 pub fn install(realm: *Realm) !void {
-    const harden_fn = try realm.heap.allocateFunctionNative(hardenNative, 1, "harden");
+    const harden_fn = try realm.heap.allocateFunctionNative(realm, hardenNative, 1, "harden");
     try realm.globals.put(realm.allocator, "harden", heap_mod.taggedFunction(harden_fn));
 }
 

--- a/src/runtime/builtins/promise.zig
+++ b/src/runtime/builtins/promise.zig
@@ -215,11 +215,11 @@ pub fn newPromiseCapability(realm: *Realm, ctor: *JSFunction) NativeError!Promis
     // §27.2.1.5.1 GetCapabilitiesExecutor Functions — anonymous,
     // length 2, non-constructor. Observable when a subclass /
     // poisoned constructor inspects the executor it received.
-    const executor_impl = realm.heap.allocateFunctionNative(capabilityExecutorImpl, 2, "") catch return error.OutOfMemory;
+    const executor_impl = realm.heap.allocateFunctionNative(realm, capabilityExecutorImpl, 2, "") catch return error.OutOfMemory;
     executor_impl.proto = realm.intrinsics.function_prototype;
     executor_impl.has_construct = false;
     cap_sc.push(heap_mod.taggedFunction(executor_impl)) catch return error.OutOfMemory;
-    const executor = realm.heap.allocateFunctionNative(boundResolveTrampoline, 2, "") catch return error.OutOfMemory;
+    const executor = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 2, "") catch return error.OutOfMemory;
     executor.proto = realm.intrinsics.function_prototype;
     executor.has_construct = false;
     cap_sc.push(heap_mod.taggedFunction(executor)) catch return error.OutOfMemory;
@@ -384,19 +384,19 @@ fn promiseConstructor(realm: *Realm, this_value: Value, args: []const Value) Nat
     // anonymous (`name: ""`) and not constructors (`hasOwn-
     // Property(resolveFn, "prototype") === false`,
     // `new resolveFn()` throws).
-    const resolve_impl = realm.heap.allocateFunctionNative(promiseResolveImpl, 1, "") catch return error.OutOfMemory;
+    const resolve_impl = realm.heap.allocateFunctionNative(realm, promiseResolveImpl, 1, "") catch return error.OutOfMemory;
     resolve_impl.proto = realm.intrinsics.function_prototype;
     resolve_impl.has_construct = false;
-    const resolve_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const resolve_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     resolve_fn.proto = realm.intrinsics.function_prototype;
     resolve_fn.has_construct = false;
     realm.heap.setBoundTarget(resolve_fn, resolve_impl);
     realm.heap.setBoundThis(resolve_fn, inst_v);
 
-    const reject_impl = realm.heap.allocateFunctionNative(promiseRejectImpl, 1, "") catch return error.OutOfMemory;
+    const reject_impl = realm.heap.allocateFunctionNative(realm, promiseRejectImpl, 1, "") catch return error.OutOfMemory;
     reject_impl.proto = realm.intrinsics.function_prototype;
     reject_impl.has_construct = false;
-    const reject_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const reject_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     reject_fn.proto = realm.intrinsics.function_prototype;
     reject_fn.has_construct = false;
     realm.heap.setBoundTarget(reject_fn, reject_impl);
@@ -735,13 +735,13 @@ fn promiseFinally(realm: *Realm, this_value: Value, args: []const Value) NativeE
         realm.heap.setFinallyCallback(ctx, on_finally_fn);
         realm.heap.setFinallyConstructor(ctx, C);
 
-        const then_fn = realm.heap.allocateFunctionNative(finallyThenReaction, 1, "") catch return error.OutOfMemory;
+        const then_fn = realm.heap.allocateFunctionNative(realm, finallyThenReaction, 1, "") catch return error.OutOfMemory;
         then_fn.proto = realm.intrinsics.function_prototype;
         then_fn.is_arrow = true;
         fin_sc.push(heap_mod.taggedFunction(then_fn)) catch return error.OutOfMemory;
         realm.heap.setCapturedThis(then_fn, heap_mod.taggedObject(ctx));
 
-        const catch_fn = realm.heap.allocateFunctionNative(finallyCatchReaction, 1, "") catch return error.OutOfMemory;
+        const catch_fn = realm.heap.allocateFunctionNative(realm, finallyCatchReaction, 1, "") catch return error.OutOfMemory;
         catch_fn.proto = realm.intrinsics.function_prototype;
         catch_fn.is_arrow = true;
         fin_sc.push(heap_mod.taggedFunction(catch_fn)) catch return error.OutOfMemory;
@@ -921,6 +921,7 @@ fn chainFinallyResult(realm: *Realm, result: Value, carry: Value, is_throw: bool
     realm.heap.setObjectPrototype(thunk_ctx, realm.intrinsics.object_prototype);
     realm.heap.setFinallyValue(thunk_ctx, carry);
     const thunk_fn = realm.heap.allocateFunctionNative(
+        realm,
         if (is_throw) finallyThrowThunk else finallyReturnThunk,
         0,
         "",
@@ -1376,19 +1377,19 @@ fn resolveInputAsPromise(realm: *Realm, ctor: *JSFunction, v: Value) NativeError
             const target_v = allocatePromiseFor(realm, ctor, .pending, Value.undefined_) catch return error.OutOfMemory;
 
             // §27.2.1.3 Resolve/Reject Functions — anonymous, non-ctor.
-            const resolve_impl = realm.heap.allocateFunctionNative(promiseResolveImpl, 1, "") catch return error.OutOfMemory;
+            const resolve_impl = realm.heap.allocateFunctionNative(realm, promiseResolveImpl, 1, "") catch return error.OutOfMemory;
             resolve_impl.proto = realm.intrinsics.function_prototype;
             resolve_impl.has_construct = false;
-            const resolve_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+            const resolve_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
             resolve_fn.proto = realm.intrinsics.function_prototype;
             resolve_fn.has_construct = false;
             realm.heap.setBoundTarget(resolve_fn, resolve_impl);
             realm.heap.setBoundThis(resolve_fn, target_v);
 
-            const reject_impl = realm.heap.allocateFunctionNative(promiseRejectImpl, 1, "") catch return error.OutOfMemory;
+            const reject_impl = realm.heap.allocateFunctionNative(realm, promiseRejectImpl, 1, "") catch return error.OutOfMemory;
             reject_impl.proto = realm.intrinsics.function_prototype;
             reject_impl.has_construct = false;
-            const reject_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+            const reject_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
             reject_fn.proto = realm.intrinsics.function_prototype;
             reject_fn.has_construct = false;
             realm.heap.setBoundTarget(reject_fn, reject_impl);
@@ -1471,22 +1472,22 @@ fn allocElementClosures(realm: *Realm, sc: *heap_mod.HandleScope, state: *JSObje
 
     // §27.2.4.1.{Resolve,Reject} Element Functions — anonymous,
     // length 1, non-constructor.
-    const resolve_impl = realm.heap.allocateFunctionNative(aggResolveElement, 1, "") catch return error.OutOfMemory;
+    const resolve_impl = realm.heap.allocateFunctionNative(realm, aggResolveElement, 1, "") catch return error.OutOfMemory;
     resolve_impl.proto = realm.intrinsics.function_prototype;
     resolve_impl.has_construct = false;
     sc.push(heap_mod.taggedFunction(resolve_impl)) catch return error.OutOfMemory;
-    const resolve_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const resolve_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     resolve_fn.proto = realm.intrinsics.function_prototype;
     resolve_fn.has_construct = false;
     sc.push(heap_mod.taggedFunction(resolve_fn)) catch return error.OutOfMemory;
     realm.heap.setBoundTarget(resolve_fn, resolve_impl);
     realm.heap.setBoundThis(resolve_fn, heap_mod.taggedObject(wrapper));
 
-    const reject_impl = realm.heap.allocateFunctionNative(aggRejectElement, 1, "") catch return error.OutOfMemory;
+    const reject_impl = realm.heap.allocateFunctionNative(realm, aggRejectElement, 1, "") catch return error.OutOfMemory;
     reject_impl.proto = realm.intrinsics.function_prototype;
     reject_impl.has_construct = false;
     sc.push(heap_mod.taggedFunction(reject_impl)) catch return error.OutOfMemory;
-    const reject_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const reject_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     reject_fn.proto = realm.intrinsics.function_prototype;
     reject_fn.has_construct = false;
     sc.push(heap_mod.taggedFunction(reject_fn)) catch return error.OutOfMemory;
@@ -2077,19 +2078,19 @@ fn promiseWithResolvers(realm: *Realm, this_value: Value, args: []const Value) N
     // functions have name = "" and are not constructors. The
     // 1-arg `length` matches spec (single (resolution) / (reason)
     // parameter).
-    const resolve_impl = realm.heap.allocateFunctionNative(promiseResolveImpl, 1, "") catch return error.OutOfMemory;
+    const resolve_impl = realm.heap.allocateFunctionNative(realm, promiseResolveImpl, 1, "") catch return error.OutOfMemory;
     resolve_impl.proto = realm.intrinsics.function_prototype;
     resolve_impl.has_construct = false;
-    const resolve_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const resolve_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     resolve_fn.proto = realm.intrinsics.function_prototype;
     resolve_fn.has_construct = false;
     realm.heap.setBoundTarget(resolve_fn, resolve_impl);
     realm.heap.setBoundThis(resolve_fn, promise_v);
 
-    const reject_impl = realm.heap.allocateFunctionNative(promiseRejectImpl, 1, "") catch return error.OutOfMemory;
+    const reject_impl = realm.heap.allocateFunctionNative(realm, promiseRejectImpl, 1, "") catch return error.OutOfMemory;
     reject_impl.proto = realm.intrinsics.function_prototype;
     reject_impl.has_construct = false;
-    const reject_fn = realm.heap.allocateFunctionNative(boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
+    const reject_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
     reject_fn.proto = realm.intrinsics.function_prototype;
     reject_fn.has_construct = false;
     realm.heap.setBoundTarget(reject_fn, reject_impl);

--- a/src/runtime/builtins/proxy.zig
+++ b/src/runtime/builtins/proxy.zig
@@ -107,7 +107,7 @@ fn proxyRevocable(realm: *Realm, this_value: Value, args: []const Value) NativeE
     // length 0, and is not a constructor. The native body itself
     // is a no-op stub; the interpreter inspects `revocable_proxy`
     // before calling it.
-    const revoke_fn = realm.heap.allocateFunctionNative(proxyRevokeNoop, 0, "") catch return error.OutOfMemory;
+    const revoke_fn = realm.heap.allocateFunctionNative(realm, proxyRevokeNoop, 0, "") catch return error.OutOfMemory;
     revoke_fn.proto = realm.intrinsics.function_prototype;
     revoke_fn.has_construct = false;
     revoke_fn.revocable_proxy = proxy_obj;

--- a/src/runtime/builtins/shadow_realm.zig
+++ b/src/runtime/builtins/shadow_realm.zig
@@ -391,7 +391,7 @@ fn wrappedFunctionCreate(caller_realm: *Realm, target: Value) NativeError!*JSFun
     // Use a trampoline native that never actually runs — call
     // dispatch detects `!wrapped_target.isUndefined()` and short-
     // circuits before reaching the native body.
-    const wrapped = caller_realm.heap.allocateFunctionNative(wrappedTrampoline, 0, "") catch return error.OutOfMemory;
+    const wrapped = caller_realm.heap.allocateFunctionNative(caller_realm, wrappedTrampoline, 0, "") catch return error.OutOfMemory;
     wrapped.proto = caller_realm.intrinsics.function_prototype;
     wrapped.realm = caller_realm;
     wrapped.wrapped_target = target;

--- a/src/runtime/builtins/symbol.zig
+++ b/src/runtime/builtins/symbol.zig
@@ -96,7 +96,7 @@ pub fn install(realm: *Realm) !void {
     // returns the underlying Symbol primitive regardless of
     // hint. Descriptor `{ w:false, e:false, c:true }` per the
     // spec; `.length === 1` because it accepts the hint arg.
-    const to_prim = try realm.heap.allocateFunctionNative(symbolToPrimitive, 1, "[Symbol.toPrimitive]");
+    const to_prim = try realm.heap.allocateFunctionNative(realm, symbolToPrimitive, 1, "[Symbol.toPrimitive]");
     to_prim.proto = realm.intrinsics.function_prototype;
     to_prim.has_construct = false;
     try proto.setWithFlags(realm.allocator, "@@toPrimitive", heap_mod.taggedFunction(to_prim), .{

--- a/src/runtime/builtins/typed_array.zig
+++ b/src/runtime/builtins/typed_array.zig
@@ -325,9 +325,8 @@ pub fn install(realm: *Realm) !void {
         // Each concrete constructor has the same arity as
         // %TypedArray% itself (signature is up to (buffer,
         // byteOffset, length) or one of the other 3-arg forms).
-        const ctor = try realm.heap.allocateFunctionNative(typedArrayConstructorBuilder(variant.kind, variant.name), 3, variant.name);
+        const ctor = try realm.heap.allocateFunctionNative(realm, typedArrayConstructorBuilder(variant.kind, variant.name), 3, variant.name);
         ctor.is_class_constructor = true;
-        ctor.realm = realm;
         // §23.2.5.1 — argument processing (ToIndex on a length arg,
         // the typed-array / buffer brand checks, the detached-buffer
         // TypeError) all precede AllocateTypedArray, which is the

--- a/src/runtime/builtins/uri.zig
+++ b/src/runtime/builtins/uri.zig
@@ -23,16 +23,16 @@ const newURIError = intrinsics.newURIError;
 pub fn install(realm: *Realm) !void {
     // §20.1.1 — none of these globals implement [[Construct]];
     // `new encodeURI(...)` etc. must throw TypeError.
-    const eu = try realm.heap.allocateFunctionNative(globalEncodeURI, 1, "encodeURI");
+    const eu = try realm.heap.allocateFunctionNative(realm, globalEncodeURI, 1, "encodeURI");
     eu.has_construct = false;
     try realm.globals.put(realm.allocator, "encodeURI", heap_mod.taggedFunction(eu));
-    const euc = try realm.heap.allocateFunctionNative(globalEncodeURIComponent, 1, "encodeURIComponent");
+    const euc = try realm.heap.allocateFunctionNative(realm, globalEncodeURIComponent, 1, "encodeURIComponent");
     euc.has_construct = false;
     try realm.globals.put(realm.allocator, "encodeURIComponent", heap_mod.taggedFunction(euc));
-    const du = try realm.heap.allocateFunctionNative(globalDecodeURI, 1, "decodeURI");
+    const du = try realm.heap.allocateFunctionNative(realm, globalDecodeURI, 1, "decodeURI");
     du.has_construct = false;
     try realm.globals.put(realm.allocator, "decodeURI", heap_mod.taggedFunction(du));
-    const duc = try realm.heap.allocateFunctionNative(globalDecodeURIComponent, 1, "decodeURIComponent");
+    const duc = try realm.heap.allocateFunctionNative(realm, globalDecodeURIComponent, 1, "decodeURIComponent");
     duc.has_construct = false;
     try realm.globals.put(realm.allocator, "decodeURIComponent", heap_mod.taggedFunction(duc));
 }

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -30,6 +30,7 @@ const utf16 = @import("utf16.zig");
 const JSFunction = @import("function.zig").JSFunction;
 const HeapKind = @import("function.zig").HeapKind;
 const JSObject = @import("object.zig").JSObject;
+const Realm = @import("realm.zig").Realm;
 const ShapeTree = @import("shape.zig").ShapeTree;
 const Environment = @import("environment.zig").Environment;
 const Chunk = @import("../bytecode/chunk.zig").Chunk;
@@ -794,6 +795,7 @@ pub const Heap = struct {
     /// chunk; the Call opcode dispatches to it directly.
     pub fn allocateFunctionNative(
         self: *Heap,
+        realm: *Realm,
         callback: @import("function.zig").NativeFn,
         param_count: u8,
         name: []const u8,
@@ -801,6 +803,13 @@ pub const Heap = struct {
         const f = try JSFunction.initNative(self.allocator, callback, param_count, name);
         errdefer f.deinit(self.allocator);
         f.heap = self;
+        // §10.2.5 — every native function carries `[[Realm]]`, the
+        // realm that allocated it. Set at allocation time (rather
+        // than left to each caller) so cross-realm identity checks
+        // never see a null realm; for a shared heap (a ShadowRealm
+        // child) this is the *allocating* realm, which the caller
+        // passes — the heap can't infer it.
+        f.realm = realm;
         // §20.2.3 — a native function's `[[Prototype]]` is
         // %Function.prototype%. Wire it here so it holds for
         // functions allocated lazily after realm init (the init

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -343,10 +343,9 @@ pub fn install(realm: *Realm) !void {
     // `lda_arguments` opcode can wire the same function into
     // every strict-mode arguments object.
     {
-        const t = try realm.heap.allocateFunctionNative(throwTypeErrorThrower, 0, "");
+        const t = try realm.heap.allocateFunctionNative(realm, throwTypeErrorThrower, 0, "");
         t.proto = realm.intrinsics.function_prototype;
         t.has_construct = false;
-        t.realm = realm;
         // §10.2.4 — non-extensible. `length` and `name` are
         // already non-writable / non-configurable per §17 (set in
         // `installFunctionLengthAndName`); but the spec requires
@@ -473,9 +472,8 @@ pub fn install(realm: *Realm) !void {
     // Wire it as a throwing native (length 1, !construct) so
     // `eval !== null` is true, `eval(...)` raises EvalError, and
     // typeof eval === "function".
-    const eval_fn = try realm.heap.allocateFunctionNative(globalEvalNotSupported, 1, "eval");
+    const eval_fn = try realm.heap.allocateFunctionNative(realm, globalEvalNotSupported, 1, "eval");
     eval_fn.has_construct = false;
-    eval_fn.realm = realm;
     try realm.globals.put(realm.allocator, "eval", heap_mod.taggedFunction(eval_fn));
 
     // §19.1 — `undefined`, `NaN`, `Infinity` are frozen data
@@ -795,16 +793,14 @@ fn installSyntheticAccessorPair(
     // Allocate the getter / setter JSFunctions. The native body
     // is a placeholder — call dispatch short-circuits on
     // `synth_accessor != null` before invoking it.
-    const get_fn = try realm.heap.allocateFunctionNative(synthAccessorPlaceholder, 0, "");
+    const get_fn = try realm.heap.allocateFunctionNative(realm, synthAccessorPlaceholder, 0, "");
     get_fn.synth_accessor = get_cell;
     get_fn.has_construct = false;
     get_fn.extensible = false;
-    get_fn.realm = realm;
-    const set_fn = try realm.heap.allocateFunctionNative(synthAccessorPlaceholder, 1, "");
+    const set_fn = try realm.heap.allocateFunctionNative(realm, synthAccessorPlaceholder, 1, "");
     set_fn.synth_accessor = set_cell;
     set_fn.has_construct = false;
     set_fn.extensible = false;
-    set_fn.realm = realm;
 
     // The shape system only models data properties; an accessor
     // install MUST demote first or the IC's shape lookup would
@@ -855,8 +851,7 @@ fn installStubConstructor(
 ) !*JSObject {
     // §17 — every spec'd stub built-in (Array, String, Number,
     // Boolean, Function) has `length === 1`.
-    const fn_obj = try realm.heap.allocateFunctionNative(stubConstructorNative, 1, name);
-    fn_obj.realm = realm;
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, stubConstructorNative, 1, name);
     const proto = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(proto, parent_proto);
     try setNonEnumerable(proto, realm.allocator, "constructor", heap_mod.taggedFunction(fn_obj));
@@ -884,8 +879,7 @@ fn installStubConstructor(
 /// every plain object chains to.
 fn installCtorReusingProto(realm: *Realm, name: []const u8, proto: *JSObject) !void {
     // §20.1.1 — `Object` constructor's `length` is 1.
-    const fn_obj = try realm.heap.allocateFunctionNative(stubConstructorNative, 1, name);
-    fn_obj.realm = realm;
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, stubConstructorNative, 1, name);
     try setNonEnumerable(proto, realm.allocator, "constructor", heap_mod.taggedFunction(fn_obj));
     realm.heap.setFunctionPrototype(fn_obj, proto);
     // §17 — same non-writable-prototype default as the stub path above.
@@ -928,9 +922,8 @@ fn stubConstructorNative(realm: *Realm, this_value: Value, args: []const Value) 
 ///   - `[[Prototype]]` = `%Function.prototype%` (§20.2.3) — already
 ///     wired by `allocateFunctionNative`.
 pub fn makeNativeFunction(realm: *Realm, native: NativeFn, params: u8, name: []const u8) !*JSFunction {
-    const fn_obj = try realm.heap.allocateFunctionNative(native, params, name);
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, native, params, name);
     fn_obj.has_construct = false;
-    fn_obj.realm = realm;
     return fn_obj;
 }
 
@@ -1013,13 +1006,11 @@ pub const ConstructorSpec = struct {
 /// install methods, accessors, and statics. Replaces ~10
 /// near-identical hand-rolled blocks across `install<Builtin>`.
 pub fn installConstructor(realm: *Realm, spec: ConstructorSpec) !struct { ctor: *JSFunction, proto: *JSObject } {
-    const fn_obj = try realm.heap.allocateFunctionNative(spec.ctor, spec.arity, spec.name);
+    // §10.2.5 [[Realm]] (used by cross-realm species checks,
+    // §23.1.3.34 et al.) is wired inside allocateFunctionNative.
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, spec.ctor, spec.arity, spec.name);
     fn_obj.is_class_constructor = spec.is_class;
     fn_obj.proto = realm.intrinsics.function_prototype;
-    // §10.2.5 — built-in constructors carry their installing realm
-    // so cross-realm species checks (§23.1.3.34 et al.) can detect
-    // when the constructor's `realm` differs from the caller's.
-    fn_obj.realm = realm;
     const proto = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(proto, realm.intrinsics.object_prototype);
     if (spec.install_constructor_property) {
@@ -1582,8 +1573,7 @@ fn replaceGlobalNative(realm: *Realm, name: []const u8, native: NativeFn) !void 
     // at the new function; the prototype keeps its identity.
     const old_v = realm.globals.get(name) orelse return;
     const old_fn = heap_mod.valueAsFunction(old_v) orelse return;
-    const fresh = try realm.heap.allocateFunctionNative(native, 1, name);
-    fresh.realm = realm;
+    const fresh = try realm.heap.allocateFunctionNative(realm, native, 1, name);
     realm.heap.setFunctionPrototype(fresh, old_fn.prototype);
     if (fresh.prototype) |p| {
         try p.set(realm.allocator, "constructor", heap_mod.taggedFunction(fresh));

--- a/src/runtime/lantern/generator.zig
+++ b/src/runtime/lantern/generator.zig
@@ -250,7 +250,7 @@ pub fn ensureGeneratorPrototype(realm: *Realm) !*JSObject {
     // Stored under the well-known-Symbol's stringified key
     // `"@@iterator"`. Our property-access path looks up by
     // string, so this coexists with future Symbol-typed keys.
-    const sym_iter_fn = try realm.heap.allocateFunctionNative(genSymbolIterator, 0, "[Symbol.iterator]");
+    const sym_iter_fn = try realm.heap.allocateFunctionNative(realm, genSymbolIterator, 0, "[Symbol.iterator]");
     sym_iter_fn.proto = realm.intrinsics.function_prototype;
     try proto.set(realm.allocator, "@@iterator", heap_mod.taggedFunction(sym_iter_fn));
 
@@ -291,7 +291,7 @@ pub fn ensureAsyncIteratorPrototype(realm: *Realm) !*JSObject {
     if (realm.intrinsics.async_iterator_prototype) |p| return p;
     const proto = try realm.heap.allocateObject();
     realm.heap.setObjectPrototype(proto, realm.intrinsics.object_prototype);
-    const sym_iter_fn = try realm.heap.allocateFunctionNative(genSymbolIterator, 0, "[Symbol.asyncIterator]");
+    const sym_iter_fn = try realm.heap.allocateFunctionNative(realm, genSymbolIterator, 0, "[Symbol.asyncIterator]");
     sym_iter_fn.proto = realm.intrinsics.function_prototype;
     try proto.setWithFlags(realm.allocator, "@@asyncIterator", heap_mod.taggedFunction(sym_iter_fn), .{
         .writable = true,
@@ -303,7 +303,7 @@ pub fn ensureAsyncIteratorPrototype(realm: *Realm) !*JSObject {
     // calls `return()` if present, and unwraps the result to
     // `undefined`. The `await using` declaration awaits this Promise
     // when its bound async iterator goes out of scope.
-    const sym_disp_fn = try realm.heap.allocateFunctionNative(asyncIteratorSymbolAsyncDispose, 0, "[Symbol.asyncDispose]");
+    const sym_disp_fn = try realm.heap.allocateFunctionNative(realm, asyncIteratorSymbolAsyncDispose, 0, "[Symbol.asyncDispose]");
     sym_disp_fn.proto = realm.intrinsics.function_prototype;
     try proto.setWithFlags(realm.allocator, "@@asyncDispose", heap_mod.taggedFunction(sym_disp_fn), .{
         .writable = true,
@@ -389,7 +389,7 @@ fn asyncIteratorSymbolAsyncDispose(realm: *Realm, this_value: Value, args: []con
         };
         break :blk r;
     };
-    const unwrap_fn = try realm.heap.allocateFunctionNative(asyncDisposeUnwrap, 1, "");
+    const unwrap_fn = try realm.heap.allocateFunctionNative(realm, asyncDisposeUnwrap, 1, "");
     unwrap_fn.proto = realm.intrinsics.function_prototype;
     const then_args = [_]Value{ heap_mod.taggedFunction(unwrap_fn), Value.undefined_ };
     return promise_mod.promiseThenExported(realm, wrapped, &then_args) catch |err| switch (err) {
@@ -963,6 +963,7 @@ pub fn wrapAsyncGenResult(realm: *Realm, raw: Value, done: bool) @import("../fun
     // constructor-lookup.js` counts on that tick.
     const outer = intrinsics_mod.allocatePromiseFor(realm, null, .pending, Value.undefined_) catch return error.OutOfMemory;
     const wrap_fn = realm.heap.allocateFunctionNative(
+        realm,
         if (done) iterResultDoneTrue else iterResultDoneFalse,
         1,
         "asyncGenYield",

--- a/src/runtime/lantern/iterator.zig
+++ b/src/runtime/lantern/iterator.zig
@@ -261,7 +261,7 @@ pub fn openIteratorOpts(
     const state = realm.allocator.create(object_mod.ArrayLikeIterState) catch return error.OutOfMemory;
     state.* = .{ .target = iterable };
     iter.array_like_iter = state;
-    const next_fn = realm.heap.allocateFunctionNative(arrayLikeIterNext, 0, "next") catch return error.OutOfMemory;
+    const next_fn = realm.heap.allocateFunctionNative(realm, arrayLikeIterNext, 0, "next") catch return error.OutOfMemory;
     next_fn.proto = realm.intrinsics.function_prototype;
     iter.set(realm.allocator, "next", heap_mod.taggedFunction(next_fn)) catch return error.OutOfMemory;
     return heap_mod.taggedObject(iter);
@@ -610,7 +610,7 @@ pub fn openForInIterator(
     const state = realm.allocator.create(@import("../object.zig").ArrayLikeIterState) catch return error.OutOfMemory;
     state.* = .{ .target = heap_mod.taggedObject(arr), .idx = 0, .done = false, .for_in_source = obj_v };
     iter.array_like_iter = state;
-    const next_fn = realm.heap.allocateFunctionNative(arrayLikeIterNext, 0, "next") catch return error.OutOfMemory;
+    const next_fn = realm.heap.allocateFunctionNative(realm, arrayLikeIterNext, 0, "next") catch return error.OutOfMemory;
     next_fn.proto = realm.intrinsics.function_prototype;
     iter.set(realm.allocator, "next", heap_mod.taggedFunction(next_fn)) catch return error.OutOfMemory;
     return heap_mod.taggedObject(iter);

--- a/src/runtime/lantern/promise.zig
+++ b/src/runtime/lantern/promise.zig
@@ -456,10 +456,10 @@ fn runModuleImportJob(
 /// the value, `bound_target` = a `this`-returning native) so no
 /// per-call closure state is needed.
 fn makeReturnThisHandler(realm: *Realm, value: Value) !Value {
-    const impl = try realm.heap.allocateFunctionNative(returnThisValueNative, 1, "");
+    const impl = try realm.heap.allocateFunctionNative(realm, returnThisValueNative, 1, "");
     impl.proto = realm.intrinsics.function_prototype;
     impl.has_construct = false;
-    const bound = try realm.heap.allocateFunctionNative(returnThisValueNative, 1, "");
+    const bound = try realm.heap.allocateFunctionNative(realm, returnThisValueNative, 1, "");
     bound.proto = realm.intrinsics.function_prototype;
     bound.has_construct = false;
     realm.heap.setBoundTarget(bound, impl);
@@ -512,19 +512,19 @@ fn runThenableJob(
     // via `isConstructor(reject)` from `harness/isConstructor.js`, which
     // tries `Reflect.construct(function(){}, [], reject)`).
     const promise_mod = @import("../builtins/promise.zig");
-    const resolve_impl = realm.heap.allocateFunctionNative(promise_mod.promiseResolveImplExported, 1, "") catch return error.OutOfMemory;
+    const resolve_impl = realm.heap.allocateFunctionNative(realm, promise_mod.promiseResolveImplExported, 1, "") catch return error.OutOfMemory;
     resolve_impl.proto = realm.intrinsics.function_prototype;
     resolve_impl.has_construct = false;
-    const resolve_fn = realm.heap.allocateFunctionNative(promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
+    const resolve_fn = realm.heap.allocateFunctionNative(realm, promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
     resolve_fn.proto = realm.intrinsics.function_prototype;
     resolve_fn.has_construct = false;
     realm.heap.setBoundTarget(resolve_fn, resolve_impl);
     realm.heap.setBoundThis(resolve_fn, outer_promise);
 
-    const reject_impl = realm.heap.allocateFunctionNative(promise_mod.promiseRejectImplExported, 1, "") catch return error.OutOfMemory;
+    const reject_impl = realm.heap.allocateFunctionNative(realm, promise_mod.promiseRejectImplExported, 1, "") catch return error.OutOfMemory;
     reject_impl.proto = realm.intrinsics.function_prototype;
     reject_impl.has_construct = false;
-    const reject_fn = realm.heap.allocateFunctionNative(promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
+    const reject_fn = realm.heap.allocateFunctionNative(realm, promise_mod.boundResolveTrampolineExported, 1, "") catch return error.OutOfMemory;
     reject_fn.proto = realm.intrinsics.function_prototype;
     reject_fn.has_construct = false;
     realm.heap.setBoundTarget(reject_fn, reject_impl);

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -6662,7 +6662,7 @@ test "later: GetPrototypeFromConstructor derives default proto from newTarget's 
 
     // Mint `C` in the child realm with a non-object `prototype`
     // (the fixture's `C.prototype = null`).
-    const C = try parent.heap.allocateFunctionNative(Noop.body, 0, "C");
+    const C = try parent.heap.allocateFunctionNative(&parent, Noop.body, 0, "C");
     C.realm = &child;
     try C.setWithFlags(testing.allocator, "prototype", Value.null_, .{
         .writable = true,
@@ -6713,7 +6713,7 @@ test "later: Array [[Construct]] derives result proto from newTarget's realm" {
     try testing.expect(child_array.prototype != null);
     try testing.expect(parent_array.prototype != child_array.prototype);
 
-    const C = try parent.heap.allocateFunctionNative(Noop.body, 0, "C");
+    const C = try parent.heap.allocateFunctionNative(&parent, Noop.body, 0, "C");
     C.realm = &child;
     try C.setWithFlags(testing.allocator, "prototype", Value.null_, .{
         .writable = true,
@@ -6770,7 +6770,7 @@ test "later: Function [[Construct]] derives result proto from newTarget's realm"
     try testing.expect(child_fn_proto != null);
     try testing.expect(parent_fn_proto != child_fn_proto);
 
-    const C = try parent.heap.allocateFunctionNative(Noop.body, 0, "C");
+    const C = try parent.heap.allocateFunctionNative(&parent, Noop.body, 0, "C");
     C.realm = &child;
     try C.setWithFlags(testing.allocator, "prototype", Value.null_, .{
         .writable = true,

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -1422,7 +1422,7 @@ pub const Realm = struct {
         // queued and any realm sharing the heap can drain it.
         self.heap.setFinalizationEnqueue(self, finalizationEnqueueJob);
 
-        const print_fn = try self.heap.allocateFunctionNative(printNative, 1, "print");
+        const print_fn = try self.heap.allocateFunctionNative(self, printNative, 1, "print");
         try self.globals.put(self.allocator, "print", heap_mod.taggedFunction(print_fn));
 
         // Minimal `console` object with a `log` method bound to
@@ -1462,7 +1462,7 @@ pub const Realm = struct {
         // way to ask for a deterministic GC trigger from
         // `built-ins/WeakRef` / `built-ins/FinalizationRegistry`
         // fixtures and inline tests with the same shape.
-        const gc_fn = try self.heap.allocateFunctionNative(collectGarbageNative, 0, "__collectGarbage");
+        const gc_fn = try self.heap.allocateFunctionNative(self, collectGarbageNative, 0, "__collectGarbage");
         try self.globals.put(self.allocator, "__collectGarbage", heap_mod.taggedFunction(gc_fn));
 
         // Companion to `__collectGarbage`: synchronously runs
@@ -1472,7 +1472,7 @@ pub const Realm = struct {
         // drop of the per-job kept-alive list so a follow-up
         // `__collectGarbage()` can actually weak-clear a WeakRef
         // target the constructor / `deref()` pinned.
-        const ck_fn = try self.heap.allocateFunctionNative(clearKeptObjectsNative, 0, "__clearKeptObjects");
+        const ck_fn = try self.heap.allocateFunctionNative(self, clearKeptObjectsNative, 0, "__clearKeptObjects");
         try self.globals.put(self.allocator, "__clearKeptObjects", heap_mod.taggedFunction(ck_fn));
 
         // Forces a microtask-queue drain. Real ECMAScript hosts
@@ -1480,7 +1480,7 @@ pub const Realm = struct {
         // CLI does the same around `cynic eval` / `cynic run`,
         // but inline tests asserting microtask ordering need
         // direct access. Lives on `globalThis.__drainMicrotasks`.
-        const drain_fn = try self.heap.allocateFunctionNative(@import("builtins/promise.zig").microtaskDrainNative, 0, "__drainMicrotasks");
+        const drain_fn = try self.heap.allocateFunctionNative(self, @import("builtins/promise.zig").microtaskDrainNative, 0, "__drainMicrotasks");
         try self.globals.put(self.allocator, "__drainMicrotasks", heap_mod.taggedFunction(drain_fn));
 
         // Re-stamp the freeze contract over the just-installed

--- a/src/runtime/surface_audit_test.zig
+++ b/src/runtime/surface_audit_test.zig
@@ -550,3 +550,27 @@ test "constructor-registration shape: Error constructors carry [[Realm]] and the
         try testing.expect(!flags.configurable);
     }
 }
+
+test "native-allocation realm: raw-allocated global functions carry [[Realm]] (§10.2.5)" {
+    var realm = Realm.init(testing.allocator);
+    realm.hardened = false;
+    defer realm.deinit();
+    try realm.installBuiltins();
+
+    // §10.2.5 — every native function carries `[[Realm]]`. These
+    // globals are allocated straight via `allocateFunctionNative`
+    // (no makeNativeFunction wrapper), so they exercise the
+    // allocation-time realm wiring rather than a caller fix-up.
+    const fns = [_][]const u8{
+        "encodeURI", "encodeURIComponent",
+        "decodeURI", "decodeURIComponent",
+    };
+    for (fns) |name| {
+        const v = realm.globals.get(name) orelse {
+            std.debug.print("[native-alloc] no global {s}\n", .{name});
+            return error.NoGlobalFn;
+        };
+        const fn_obj = heap_mod.valueAsFunction(v) orelse return error.NotAFunction;
+        try testing.expect(fn_obj.realm == &realm);
+    }
+}

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -316,13 +316,13 @@ fn test262CreateRealm(
     // `.evalScript(source)` — evaluates `source` IN THE CHILD
     // REALM. Receiver is the wrapper, which carries the child
     // pointer in `host_data`.
-    const eval_trampoline = realm.heap.allocateFunctionNative(test262ChildEvalScript, 1, "evalScript") catch return error.OutOfMemory;
+    const eval_trampoline = realm.heap.allocateFunctionNative(realm, test262ChildEvalScript, 1, "evalScript") catch return error.OutOfMemory;
     wrapper.set(realm.allocator, "evalScript", cynic.runtime.heap.taggedFunction(eval_trampoline)) catch return error.OutOfMemory;
 
     // Pass-through hooks — operate on the parent's heap state
     // because the relevant objects (ArrayBuffer storage etc.)
     // live there too.
-    const gc_fn = realm.heap.allocateFunctionNative(test262Gc, 0, "gc") catch return error.OutOfMemory;
+    const gc_fn = realm.heap.allocateFunctionNative(realm, test262Gc, 0, "gc") catch return error.OutOfMemory;
     wrapper.set(realm.allocator, "gc", cynic.runtime.heap.taggedFunction(gc_fn)) catch return error.OutOfMemory;
 
     return cynic.runtime.heap.taggedObject(wrapper);
@@ -390,16 +390,16 @@ fn install262(realm: *cynic.runtime.Realm) !void {
         try obj.set(realm.allocator, "global", cynic.runtime.Value.undefined_);
     }
 
-    const eval_fn = try heap.allocateFunctionNative(test262EvalScript, 1, "evalScript");
+    const eval_fn = try heap.allocateFunctionNative(realm, test262EvalScript, 1, "evalScript");
     try obj.set(realm.allocator, "evalScript", cynic.runtime.heap.taggedFunction(eval_fn));
 
-    const gc_fn = try heap.allocateFunctionNative(test262Gc, 0, "gc");
+    const gc_fn = try heap.allocateFunctionNative(realm, test262Gc, 0, "gc");
     try obj.set(realm.allocator, "gc", cynic.runtime.heap.taggedFunction(gc_fn));
 
-    const detach_fn = try heap.allocateFunctionNative(test262DetachArrayBuffer, 1, "detachArrayBuffer");
+    const detach_fn = try heap.allocateFunctionNative(realm, test262DetachArrayBuffer, 1, "detachArrayBuffer");
     try obj.set(realm.allocator, "detachArrayBuffer", cynic.runtime.heap.taggedFunction(detach_fn));
 
-    const cr_fn = try heap.allocateFunctionNative(test262CreateRealm, 0, "createRealm");
+    const cr_fn = try heap.allocateFunctionNative(realm, test262CreateRealm, 0, "createRealm");
     try obj.set(realm.allocator, "createRealm", cynic.runtime.heap.taggedFunction(cr_fn));
 
     // Cynic doesn't have `IsHTMLDDA` — that feature is on our
@@ -2341,7 +2341,7 @@ fn classifyAndRun(
     // the globalThis object's properties, so `globalThis.$DONE`
     // sees the binding without a hand-mirror.
     {
-        const done_fn = realm.heap.allocateFunctionNative(test262Done, 1, "$DONE") catch return fail_reject_or_ch;
+        const done_fn = realm.heap.allocateFunctionNative(&realm, test262Done, 1, "$DONE") catch return fail_reject_or_ch;
         const done_v = cynic.runtime.heap.taggedFunction(done_fn);
         realm.globals.put(realm.allocator, "$DONE", done_v) catch return fail_reject_or_ch;
     }


### PR DESCRIPTION
## Summary

`allocateFunctionNative` left `[[Realm]]` for each caller to set with a follow-up `fn.realm = realm` — so any caller that forgot shipped a native function with a **null realm**. That's the §10.2.5 gap I fixed piecemeal for accessors (#11) and Error constructors (#12). This threads the allocating realm into `allocateFunctionNative` itself and sets `f.realm` there, so **every native function carries its realm from birth** — the root-cause fix.

### Why an explicit param, not a `Heap` back-pointer
A ShadowRealm child **shares its parent's `Heap`** (`Realm.initChild`: `heap = parent.heap, owns_heap = false`). A single `heap.realm` back-pointer would be wrong for the child's functions — only the caller knows which of the sharing realms is allocating. Every one of the 70+ call sites already had the owning realm as the `<R>.heap.allocateFunctionNative(...)` receiver, so each passes that same `<R>` (fully mechanical).

### Cleanup
Dropped the 11 now-redundant `fn.realm = realm` follow-ups. **Kept** the few that intentionally set a *different* realm:
- `Function()` mints in the caller's realm (`active_native_fn_realm`)
- bound functions inherit the target's realm
- user closures route through the non-native `allocateFunction` path
- a cross-realm test mints in `&child`

### Tests
A characterization test pins `[[Realm]]` on raw-allocated globals (`encodeURI` / `decodeURI` / `encodeURIComponent` / `decodeURIComponent`) that bypass the `makeNativeFunction` wrapper — went red without the fix.

## Verification
- `zig build test` → exit 0 (new test red→green)
- `zig fmt --check src/` → clean
- Full test262 sweep → **no regression**: passing 40178 hardened / 44074 unhardened, failing 593 / 600 — identical to baseline

Net: +116 / −95 across 23 files (the bulk is the mechanical call-site threading; `fmt` re-flowed a few multi-line calls).