### PR TITLE
multi-realm: realm-aware resolution + two cross-realm GC use-after-free fixes

### DIFF
--- a/docs/multi-realm.md
+++ b/docs/multi-realm.md
@@ -1085,15 +1085,36 @@ the V8/JSC behaviour, no per-object tag, no scoped sweep.
 
 1. **ShadowRealm finalizer.** When the `ShadowRealm` instance is
    collected, tear its child `Realm` down: `deregisterFromHeap`,
-   remove it from the owner's `child_realms`, then `deinit` +
+   remove it from the creating realm's `child_realms` (needs a
+   `created_by` back-link, since the child sits in that list and
+   `parent.deinit` would otherwise double-free), then `deinit` +
    `destroy`. **Must be deferred, not inline in the sweep** —
    freeing a realm's globals/intrinsics maps (which reference heap
-   objects mid-sweep) from inside `deinitFields` is reentrant heap
-   mutation. Enqueue the dying child onto a post-sweep teardown
-   queue (drained after `collectFull` returns), or route it through
-   the existing `setFinalizationEnqueue` job machinery. The child's
-   heap objects are then reclaimed by the following GC (problem #2,
-   already handled).
+   objects mid-sweep) from the collector is reentrant heap mutation.
+
+   Two implementation paths, both delicate (this is a bounded leak,
+   not a safety bug — scope accordingly):
+   - **Sweep-hook + post-sweep drain.** Detect a dying
+     `is_shadow_realm` object and enqueue its `host_data` child onto
+     `Heap.pending_realm_teardown`, drained after `collectFull` /
+     `collectYoung` return. Caveat: young and mature objects free
+     through *two* routines — `promoteYoungList` AND `sweepList` —
+     so both need the hook, and the enqueue must tolerate OOM
+     mid-sweep (fall back to the parent-deinit free).
+   - **Reuse the finalization-job machinery (recommended).**
+     Register the ShadowRealm wrapper as an internal weak target via
+     the `FinalizationRegistry` / `setFinalizationEnqueue`
+     plumbing (the engine already detects weak-target death,
+     §26.2 / `finalization_registries_seen`), with an engine
+     callback that runs the teardown at the next job boundary. No
+     new sweep hooks, no OOM-in-sweep, reuses tested death
+     detection — at the cost of threading an engine-internal
+     finalizer through user-facing FR code.
+
+   Either way the child's heap objects are reclaimed by the
+   following GC once it is deregistered (problem #2, already
+   handled). Do this as its own focused, `test262-safe`-gated
+   change — not bundled with unrelated work.
 2. **Bench the workload.** Add a "N short-lived ShadowRealms in a
    loop" bench; success = steady-state RSS flat across iterations.
 

--- a/docs/multi-realm.md
+++ b/docs/multi-realm.md
@@ -21,9 +21,10 @@ pick up the next phase from here without re-deriving the design.
 | 1 — D1 intrinsics | ✅ **revised** → per-realm prototypes, shared shapes (Cynic already has the latter via per-`Heap` `ShapeTree` + `Realm.initChild`). The original "shared frozen prototype subgraph" is **forbidden, not deferred** per §6.1.7.4, §9.3.2, §20.1.3.1, §23.1.3.3 + five-engine consensus. | `ae847a8`, `0b4d2c7`, `6a00337` |
 | 2 — D3 modules | ✅ substrate pinned (`Realm.modules` already per-instance); `StaticModuleRecord` deferred to Compartments | `928b4c3` |
 | sibling — cross-realm error attribution | ✅ `CallFrame.running_realm` reads `callee.realm` so error makers attribute to the callee's realm; per-frame thread of attribution. Unblocked several test262 fixtures. | `b95694b` |
-| 3 — D2 RealmStack + per-fn [[Realm]] | ⏳ planned — see "Phase 3 implementation plan" below | — |
+| 3 — D2 RealmStack + per-fn [[Realm]] | ✅ shipped — `[[Realm]]` set at native + ordinary function allocation; free-global resolution (read **and** write), Error-constructor intrinsics, and §23.1.3.34 ArraySpeciesCreate resolve via the executing function's realm (its `CallFrame.running_realm` / `active_native_fn_realm`), not the dispatch realm. All four Phase-3 contract tests in `realm_test.zig` green. | (multi-realm consumption effort) |
 | 4 — D4 endowments | sketched | — |
 | 5 — Compartments | sketched | — |
+| 6 — per-realm teardown (memory lifecycle) | ⏳ planned — see "Phase 6 — per-realm teardown" below | — |
 
 The cross-realm-error commit `b95694b` reaches partway into D2 — `callee.realm` is already consumed for error attribution and native-callback realm tracking — but `JSFunction.realm` itself remains `null` at every allocation site because `Heap.allocateFunction*` doesn't take a realm parameter. Phase 3 closes that gap.
 
@@ -1013,6 +1014,78 @@ sweep gains ~N fixtures (count TBD per submodule version).
   introduces externally-owned heap objects the sweep must respect.
 - [handbook/tdd.md](handbook/tdd.md) — every phase opens with the
   failing tests above; production code follows.
+
+## Phase 6 — per-realm teardown (memory lifecycle)
+
+Phases 0–3 make multiple realms *coexist and interoperate*
+correctly on a shared `Heap`. They do not address what happens
+to a child realm's memory when it dies. Two distinct problems,
+both real, surfaced while validating Phase 3:
+
+1. **Child-realm lifecycle isn't tied to its owning object.**
+   A child `Realm` (`$262.createRealm()` / `new ShadowRealm()`)
+   is appended to `parent.child_realms` at creation and freed
+   only in the parent's `deinit` — i.e. at program end. There is
+   no finalizer when the owning `ShadowRealm` JS object is
+   collected. A long-running host that mints a ShadowRealm
+   per request therefore accumulates child `Realm` records —
+   each carrying its own intrinsics + globals maps — **without
+   bound**. This is a genuine leak, not just delayed reclamation.
+
+2. **Child heap objects aren't eagerly reclaimed.** Children
+   borrow the parent's `Heap` (`initChild`: `owns_heap = false`),
+   whose object pools (`objects_young` / `objects_mature`) are
+   **flat and untagged by realm**. A dead child's objects persist
+   until the next parent GC sweeps them as unreachable — bounded
+   bloat between collections, not a permanent leak.
+
+**Why this is its own phase (not a quick fix).** Eagerly
+reclaiming a child's objects is not "free every object the child
+allocated": a child object can be legitimately reachable from the
+parent — a `WrappedFunction` over a child callable (§3.8.3.4), or
+an `importValue` result crossed the callable boundary. Blindly
+sweeping child-tagged objects on teardown is a use-after-free,
+exactly the hazard the ReleaseSafe GC verifiers
+(`verifyRememberedSet` / `verifyShapeInvariant`, see
+[handbook/gc.md](handbook/gc.md)) exist to catch. Correct
+teardown is therefore a *scoped GC pass*: mark from the parent's
+roots, then sweep only the child-owned objects that remain
+unreachable.
+
+**Plan.**
+
+1. **Realm-tag heap objects.** Give each `JSObject` (and the
+   other pooled cells) an owning-realm id, threaded at allocation
+   the same way `JSFunction.realm` now is — the allocator already
+   receives the realm (Phase 3.2). Cheapest form: a small integer
+   realm id rather than a back-pointer, to keep the cell compact.
+2. **ShadowRealm finalizer.** On collection of a `ShadowRealm`
+   instance, drop its child `Realm` from `parent.child_realms`
+   and free that realm's intrinsics + globals maps. Reuses the
+   §9.10 KeptDuringJob / WeakRef finalization machinery already in
+   `Realm` rather than inventing a new hook.
+3. **Scoped reclamation sweep.** On child teardown, run a mark
+   from the *parent's* roots, then sweep only objects tagged with
+   the dying child's id that are still white. Gate it behind the
+   existing verifier build so a cross-realm-live object that is
+   wrongly swept trips an assertion in `test262-safe`.
+4. **Bench the workload.** Add a "N short-lived ShadowRealms in a
+   loop" bench; the success criterion is that steady-state RSS is
+   flat across iterations rather than monotonically climbing.
+
+**Test-first contracts** (gated, like every other phase):
+
+- A `ShadowRealm` created, used, then dropped and GC'd frees its
+  child `Realm` record (probe: `parent.child_realms.items.len`
+  returns to baseline after collection).
+- A child value still referenced by the parent (a wrapped
+  function) survives the child's teardown sweep — no
+  use-after-free under `test262-safe`.
+- Steady-state RSS over a create/drop loop is bounded.
+
+**Dependency note.** This phase is orthogonal to Compartments
+(Phase 5) but shares the realm-id tagging; landing it first gives
+Compartments a teardown story for free.
 
 ## Verification cadence
 

--- a/docs/multi-realm.md
+++ b/docs/multi-realm.md
@@ -24,7 +24,7 @@ pick up the next phase from here without re-deriving the design.
 | 3 — D2 RealmStack + per-fn [[Realm]] | ✅ shipped — `[[Realm]]` set at native + ordinary function allocation; free-global resolution (read **and** write), Error-constructor intrinsics, and §23.1.3.34 ArraySpeciesCreate resolve via the executing function's realm (its `CallFrame.running_realm` / `active_native_fn_realm`), not the dispatch realm. All four Phase-3 contract tests in `realm_test.zig` green. | (multi-realm consumption effort) |
 | 4 — D4 endowments | sketched | — |
 | 5 — Compartments | sketched | — |
-| 6 — per-realm teardown (memory lifecycle) | ⏳ planned — see "Phase 6 — per-realm teardown" below | — |
+| 6 — per-realm teardown (memory lifecycle) | 🟡 foundation shipped — `Heap.realms` + `markAllSharingRealmRoots` (the global GC marks every sharing realm's roots; this was also a latent cross-realm UAF fix) + a ShadowRealm `HandleScope` fix; ShadowRealm runs clean under `test262-safe --gc-threshold=1`. Remaining: the deferred ShadowRealm finalizer to free the child `Realm` struct (problem #1). Prior art revised the design — see "Phase 6" below. | (multi-realm teardown effort) |
 
 The cross-realm-error commit `b95694b` reaches partway into D2 — `callee.realm` is already consumed for error attribution and native-callback realm tracking — but `JSFunction.realm` itself remains `null` at every allocation site because `Heap.allocateFunction*` doesn't take a realm parameter. Phase 3 closes that gap.
 
@@ -1039,39 +1039,69 @@ both real, surfaced while validating Phase 3:
    until the next parent GC sweeps them as unreachable — bounded
    bloat between collections, not a permanent leak.
 
-**Why this is its own phase (not a quick fix).** Eagerly
-reclaiming a child's objects is not "free every object the child
-allocated": a child object can be legitimately reachable from the
-parent — a `WrappedFunction` over a child callable (§3.8.3.4), or
-an `importValue` result crossed the callable boundary. Blindly
-sweeping child-tagged objects on teardown is a use-after-free,
-exactly the hazard the ReleaseSafe GC verifiers
-(`verifyRememberedSet` / `verifyShapeInvariant`, see
-[handbook/gc.md](handbook/gc.md)) exist to catch. Correct
-teardown is therefore a *scoped GC pass*: mark from the parent's
-roots, then sweep only the child-owned objects that remain
-unreachable.
+**Prior-art survey (2026-06) revised the design.** No major
+engine uses a per-object realm tag + a scoped per-realm sweep:
 
-**Plan.**
+- **V8** — one heap per Isolate shared across Contexts; a single
+  global GC marks every live Context's roots and reclaims a dead
+  Context's objects when they become unreachable. No per-object
+  realm field; detached-context *leaks* are a diagnostics concern,
+  not eagerly swept.
+- **JavaScriptCore** — one heap per VM; an object's realm is found
+  via its (shared) Structure's `globalObject()`, not a per-object
+  field; single global GC.
+- **SpiderMonkey** — the only engine with genuine per-realm GC,
+  achieved by **zone-partitioned allocation**: the object's
+  arena/chunk header identifies its Zone, so realm is O(1) from the
+  address (zero per-object cost) and a zone-local GC sweeps only
+  that zone's arenas.
 
-1. **Realm-tag heap objects.** Give each `JSObject` (and the
-   other pooled cells) an owning-realm id, threaded at allocation
-   the same way `JSFunction.realm` now is — the allocator already
-   receives the realm (Phase 3.2). Cheapest form: a small integer
-   realm id rather than a back-pointer, to keep the cell compact.
-2. **ShadowRealm finalizer.** On collection of a `ShadowRealm`
-   instance, drop its child `Realm` from `parent.child_realms`
-   and free that realm's intrinsics + globals maps. Reuses the
-   §9.10 KeptDuringJob / WeakRef finalization machinery already in
-   `Realm` rather than inventing a new hook.
-3. **Scoped reclamation sweep.** On child teardown, run a mark
-   from the *parent's* roots, then sweep only objects tagged with
-   the dying child's id that are still white. Gate it behind the
-   existing verifier build so a cross-realm-live object that is
-   wrongly swept trips an assertion in `test262-safe`.
-4. **Bench the workload.** Add a "N short-lived ShadowRealms in a
-   loop" bench; the success criterion is that steady-state RSS is
-   flat across iterations rather than monotonically climbing.
+Cynic's shared flat-pool heap already matches the **V8/JSC shape**,
+so the right design is the V8/JSC one — *not* the per-object-tag +
+scoped-sweep this section originally sketched (which matches no
+engine). That means problem #2 needs **no** new mechanism beyond
+making the global GC mark every sharing realm's roots.
+
+**Foundation — shipped (and it was a latent UAF fix, not just a
+teardown prerequisite).** The collector triggered on the *running*
+realm and marked only its roots, but all sharing realms put objects
+in the same pools — so a GC during a child realm's execution swept
+the parent's live objects (and vice-versa): a cross-realm
+use-after-free, confirmed by the 0xaa free-poison under
+`test262-safe`. Fixed by `Heap.realms` (the set of realms sharing
+the heap) + `markAllSharingRealmRoots`, which marks every sharing
+realm's roots before the single sweep — V8's global-GC model.
+Realms register at `installBuiltins` and deregister at `deinit`
+(`Realm.registerWithHeap` / `deregisterFromHeap`). A companion fix
+anchors the ShadowRealm wrapped function across CopyNameAndLength
+(a separate missing `HandleScope`). With both, the ShadowRealm
+phase runs clean under `test262-safe --gc-threshold=1`.
+
+This **dissolves problem #2**: once a dead child is deregistered,
+its now-unreachable objects are reclaimed by the next ordinary GC —
+the V8/JSC behaviour, no per-object tag, no scoped sweep.
+
+**Remaining plan (problem #1 only — the child-`Realm` struct leak).**
+
+1. **ShadowRealm finalizer.** When the `ShadowRealm` instance is
+   collected, tear its child `Realm` down: `deregisterFromHeap`,
+   remove it from the owner's `child_realms`, then `deinit` +
+   `destroy`. **Must be deferred, not inline in the sweep** —
+   freeing a realm's globals/intrinsics maps (which reference heap
+   objects mid-sweep) from inside `deinitFields` is reentrant heap
+   mutation. Enqueue the dying child onto a post-sweep teardown
+   queue (drained after `collectFull` returns), or route it through
+   the existing `setFinalizationEnqueue` job machinery. The child's
+   heap objects are then reclaimed by the following GC (problem #2,
+   already handled).
+2. **Bench the workload.** Add a "N short-lived ShadowRealms in a
+   loop" bench; success = steady-state RSS flat across iterations.
+
+The per-object realm tag and scoped sweep from the original sketch
+are **dropped** — over-engineering vs. what V8/JSC do. SpiderMonkey-
+style zone-partitioned allocation remains a "someday, if per-realm
+GC *latency* ever matters" option; it is a large allocator
+restructure, not warranted now.
 
 **Test-first contracts** (gated, like every other phase):
 

--- a/src/runtime/builtins/array.zig
+++ b/src/runtime/builtins/array.zig
@@ -202,12 +202,20 @@ fn getFunctionMember(realm: *Realm, fn_obj: *JSFunction, key: []const u8) Native
 ///
 /// Returns the freshly created array-shaped object.
 pub fn arraySpeciesCreate(realm: *Realm, original: *JSObject, length: i64) NativeError!Value {
+    // §23.1.3.34 step 6 / step 4.b — "thisRealm" is the realm of the
+    // running execution context (the Array method's [[Realm]]), and
+    // a defaulted ArrayCreate uses that realm's %Array.prototype%.
+    // The dispatch loop stamps the executing native's realm into
+    // `active_native_fn_realm`; with a shared heap (a ShadowRealm
+    // child) it differs from the dispatch `realm`, so resolve the
+    // home realm here. In a single realm `home == realm`.
+    const home = realm.active_native_fn_realm orelse realm;
     // Step 2 — IsArray(originalArray). Per §7.2.2 step 3, a Proxy
     // unwraps to its target; a revoked proxy throws. Non-array
     // receivers fall through to ArrayCreate (Step 2 → ArrayCreate
     // with the default %Array% intrinsic).
     const is_arr = try isArrayProxyAware(realm, heap_mod.taggedObject(original));
-    if (!is_arr) return defaultArrayCreate(realm, length);
+    if (!is_arr) return defaultArrayCreate(home, length);
     // Step 3 — Get(originalArray, "constructor"). Use the Proxy-
     // and accessor-aware path so a poisoned getter or proxy `get`
     // trap propagates per spec (create-proxy.js et al.).
@@ -226,7 +234,7 @@ pub fn arraySpeciesCreate(realm: *Realm, original: *JSObject, length: i64) Nativ
     if (heap_mod.valueAsFunction(ctor_v)) |ctor_fn| {
         if (ctor_fn.has_construct and !ctor_fn.is_arrow) {
             if (ctor_fn.getFunctionRealm()) |realm_c| {
-                if (realm_c != realm) {
+                if (realm_c != home) {
                     if (realm_c.globals.get("Array")) |arr_ctor_v| {
                         if (heap_mod.valueAsFunction(arr_ctor_v)) |realm_c_array| {
                             if (realm_c_array == ctor_fn) {
@@ -249,7 +257,7 @@ pub fn arraySpeciesCreate(realm: *Realm, original: *JSObject, length: i64) Nativ
         if (c_v.isNull()) c_v = Value.undefined_;
     }
     // Step 6 — if C is undefined, return ArrayCreate(length).
-    if (c_v.isUndefined()) return defaultArrayCreate(realm, length);
+    if (c_v.isUndefined()) return defaultArrayCreate(home, length);
     // Step 7 — if IsConstructor(C) is false, throw a TypeError. A
     // primitive constructor (e.g. `a.constructor = null` or `= 1`)
     // lands here; so does an object/function without [[Construct]].
@@ -264,7 +272,7 @@ pub fn arraySpeciesCreate(realm: *Realm, original: *JSObject, length: i64) Nativ
     // call and allocate directly.
     if (realm.globals.get("Array")) |array_global| {
         if (heap_mod.valueAsFunction(array_global)) |array_ctor| {
-            if (array_ctor == species_fn) return defaultArrayCreate(realm, length);
+            if (array_ctor == species_fn) return defaultArrayCreate(home, length);
         }
     }
     // Construct(species, [length]) — go through the public path so a

--- a/src/runtime/builtins/error.zig
+++ b/src/runtime/builtins/error.zig
@@ -126,7 +126,7 @@ fn installAggregateError(realm: *Realm, parent_proto: *JSObject) !*JSFunction {
 }
 
 fn aggregateErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    const proto = realm.intrinsics.aggregate_error_prototype.?;
+    const proto = homeRealm(realm).intrinsics.aggregate_error_prototype.?;
     // §20.5.7.1.1 — Error subclass-aware: if `this_value` is an
     // already-allocated object (via `new` or `super(...)`),
     // initialise it in-place; otherwise allocate fresh.
@@ -206,7 +206,7 @@ fn installSuppressedError(realm: *Realm, parent_proto: *JSObject) !*JSFunction {
 }
 
 fn suppressedErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    const proto = realm.intrinsics.suppressed_error_prototype.?;
+    const proto = homeRealm(realm).intrinsics.suppressed_error_prototype.?;
     const instance = if (heap_mod.valueAsPlainObject(this_value)) |o| o else blk: {
         const fresh = realm.heap.allocateObject() catch return error.OutOfMemory;
         realm.heap.setObjectPrototype(fresh, proto);
@@ -407,32 +407,43 @@ pub fn installError(
 // allocate a fresh instance and return it. §13.3.5.1.1 ConstructResult
 // will let an explicit object return win when used with `new`.
 
+/// §10.2.5 — a built-in shared across realms resolves its OWN
+/// realm's intrinsics, not the calling realm's. The dispatch loop
+/// stamps the callee's [[Realm]] into `active_native_fn_realm`
+/// before invoking the native (lantern/call.zig, interpreter.zig);
+/// read it so `new parentRealm.TypeError()` invoked from a child
+/// realm inherits parent's `%TypeError.prototype%`, per §10.2.3.
+/// Never consult a global current-realm accessor here.
+inline fn homeRealm(realm: *Realm) *Realm {
+    return realm.active_native_fn_realm orelse realm;
+}
+
 fn errorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.error_prototype.?, args);
 }
 
 fn typeErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.type_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.type_error_prototype.?, args);
 }
 
 fn rangeErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.range_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.range_error_prototype.?, args);
 }
 
 fn referenceErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.reference_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.reference_error_prototype.?, args);
 }
 
 fn syntaxErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.syntax_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.syntax_error_prototype.?, args);
 }
 
 fn uriErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.uri_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.uri_error_prototype.?, args);
 }
 
 fn evalErrorNative(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
-    return constructErrorInstance(realm, this_value, realm.intrinsics.eval_error_prototype.?, args);
+    return constructErrorInstance(realm, this_value, homeRealm(realm).intrinsics.eval_error_prototype.?, args);
 }
 
 /// §20.5.6.3.2 — initial value of `<NativeError>.prototype.message`

--- a/src/runtime/builtins/shadow_realm.zig
+++ b/src/runtime/builtins/shadow_realm.zig
@@ -22,10 +22,12 @@
 //! the instance's owner realm rides `shadow_realm_owner` in the
 //! cold-field extension.
 //!
-//! `.evaluate` is fully wired (callable boundary + owner-realm
-//! error tagging). `.importValue` still throws "not yet
-//! implemented" — it needs the child realm's module loader, which
-//! isn't wired here yet.
+//! Both methods are fully wired. `.evaluate` runs the callable
+//! boundary with owner-realm error tagging; `.importValue` loads
+//! the specifier through the child realm's module loader, resolves
+//! the named export, and passes it across the same boundary, with
+//! the caller-realm Promise settling on a job. A missing loader,
+//! an evaluation throw, or an absent export rejects that Promise.
 
 const std = @import("std");
 

--- a/src/runtime/builtins/shadow_realm.zig
+++ b/src/runtime/builtins/shadow_realm.zig
@@ -400,6 +400,16 @@ fn wrappedFunctionCreate(caller_realm: *Realm, target: Value) NativeError!*JSFun
     // §3.8.3.5 step 4 — wrapped functions have no [[Construct]].
     wrapped.has_construct = false;
 
+    // Anchor `wrapped` (and the target, which CopyNameAndLength reads
+    // through possibly-user accessors) across the next step: its
+    // `setWithFlags` writes re-allocate, and at high GC pressure a
+    // collection there would sweep this freshly-allocated, not-yet-
+    // rooted function — a use-after-free. See handbook/gc.md.
+    const scope = caller_realm.heap.openScope() catch return error.OutOfMemory;
+    defer scope.close();
+    scope.push(heap_mod.taggedFunction(wrapped)) catch return error.OutOfMemory;
+    scope.push(target) catch return error.OutOfMemory;
+
     // §3.8.3.5 step 6 + §3.8.3.5.1 CopyNameAndLength. The spec
     // catches abrupt completions and rethrows them AS a fresh
     // TypeError in callerRealm.

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -245,6 +245,16 @@ pub const Heap = struct {
     /// caught by that init pass instead. Borrowed — the object is
     /// rooted via the realm's intrinsics and outlives the heap.
     function_prototype: ?*JSObject = null,
+    /// Every `Realm` that shares this heap — the heap-owning realm
+    /// plus any child realms created via `Realm.initChild`
+    /// (`$262.createRealm` / `ShadowRealm`). The collector marks
+    /// roots from ALL of them before sweeping, because objects of
+    /// any sharing realm live in the same pools; marking only the
+    /// running realm's roots would sweep a sibling realm's live
+    /// objects (a cross-realm use-after-free). Realms register at
+    /// `installBuiltins` (stable-address) and deregister at
+    /// `deinit`.
+    realms: std.ArrayListUnmanaged(*Realm) = .empty,
     /// Young plain `JSObject` instances (object literals,
     /// prototypes, built-in constructors' return values).
     objects_young: std.ArrayListUnmanaged(*JSObject) = .empty,
@@ -589,6 +599,7 @@ pub const Heap = struct {
         for (self.objects_mature.items) |o| o.deinitFields(self.allocator);
         self.objects_young.deinit(self.allocator);
         self.objects_mature.deinit(self.allocator);
+        self.realms.deinit(self.allocator);
         self.object_pool.deinit(self.allocator);
         for (self.environments_young.items) |e| e.deinit(self.allocator);
         for (self.environments_mature.items) |e| e.deinit(self.allocator);

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -6867,10 +6867,15 @@ pub fn runFrames(
             // compiler) catches the uninitialised slot.
             const slot = readU32(code, ip);
             ip += 4;
+            // The slot index is relative to the realm the running
+            // chunk was compiled in (its [[Realm]]'s decl_env), which
+            // with a shared heap differs from the dispatch realm —
+            // route through the active frame's `running_realm`.
+            const gr = f.running_realm orelse realm;
             const idx = local_chunk.global_lexical_base + slot;
-            const vals = realm.globals.decl_env.values();
+            const vals = gr.globals.decl_env.values();
             std.debug.assert(idx < vals.len);
-            std.debug.assert(realm.globals.decl_consts.count() == realm.globals.decl_env.count());
+            std.debug.assert(gr.globals.decl_consts.count() == gr.globals.decl_env.count());
             acc = vals[idx];
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
@@ -6881,10 +6886,11 @@ pub fn runFrames(
             // check (this IS the initialization step).
             const slot = readU32(code, ip);
             ip += 4;
+            const gr = f.running_realm orelse realm;
             const idx = local_chunk.global_lexical_base + slot;
-            const vals = realm.globals.decl_env.values();
+            const vals = gr.globals.decl_env.values();
             std.debug.assert(idx < vals.len);
-            std.debug.assert(realm.globals.decl_consts.count() == realm.globals.decl_env.count());
+            std.debug.assert(gr.globals.decl_consts.count() == gr.globals.decl_env.count());
             vals[idx] = acc;
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
@@ -6895,12 +6901,13 @@ pub fn runFrames(
             // `const` → TypeError; else write.
             const slot = readU32(code, ip);
             ip += 4;
+            const gr = f.running_realm orelse realm;
             const idx = local_chunk.global_lexical_base + slot;
-            const vals = realm.globals.decl_env.values();
+            const vals = gr.globals.decl_env.values();
             std.debug.assert(idx < vals.len);
-            std.debug.assert(realm.globals.decl_consts.count() == realm.globals.decl_env.count());
+            std.debug.assert(gr.globals.decl_consts.count() == gr.globals.decl_env.count());
             if (vals[idx].isHole()) {
-                const ex = try makeReferenceError(realm, "Cannot access binding before initialisation");
+                const ex = try makeReferenceError(gr, "Cannot access binding before initialisation");
                 f.ip = ip;
                 f.accumulator = acc;
                 committed = true;
@@ -6909,8 +6916,8 @@ pub fn runFrames(
                 }
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
-            if (realm.globals.decl_consts.values()[idx]) {
-                const ex = try makeTypeError(realm, "Assignment to constant variable");
+            if (gr.globals.decl_consts.values()[idx]) {
+                const ex = try makeTypeError(gr, "Assignment to constant variable");
                 f.ip = ip;
                 f.accumulator = acc;
                 committed = true;

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -6752,9 +6752,17 @@ pub fn runFrames(
             // that order; `throw_if_hole` (emitted by the
             // compiler when the binding is `let`/`const`/
             // `class`) catches the TDZ case.
-            if (realm.globals.get(key_s.flatBytes())) |v| {
+            //
+            // §8.3 / §9.1: free globals resolve through the
+            // *executing* function's global environment, which is
+            // its [[Realm]]'s. With a shared heap (a ShadowRealm
+            // child) the running realm differs from the dispatch
+            // realm, so route the lookup through the active frame's
+            // `running_realm` rather than the top-level `realm`.
+            const gr = f.running_realm orelse realm;
+            if (gr.globals.get(key_s.flatBytes())) |v| {
                 acc = v;
-            } else switch (try lookupGlobalAccessor(allocator, realm, key_s.flatBytes())) {
+            } else switch (try lookupGlobalAccessor(allocator, gr, key_s.flatBytes())) {
                 .value => |v| acc = v,
                 .thrown => |ex| {
                     f.ip = ip;
@@ -6766,7 +6774,7 @@ pub fn runFrames(
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 },
                 .none => {
-                    const ex = try makeReferenceError(realm, key_s.flatBytes());
+                    const ex = try makeReferenceError(gr, key_s.flatBytes());
                     f.ip = ip;
                     f.accumulator = acc;
                     committed = true;
@@ -6794,9 +6802,11 @@ pub fn runFrames(
             const key_v = local_chunk.constants[k];
             if (!key_v.isString()) return error.InvalidOpcode;
             const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
-            if (realm.globals.get(key_s.flatBytes())) |v| {
+            // Same home-realm routing as `lda_global` (see note there).
+            const gr = f.running_realm orelse realm;
+            if (gr.globals.get(key_s.flatBytes())) |v| {
                 acc = v;
-            } else switch (try lookupGlobalAccessor(allocator, realm, key_s.flatBytes())) {
+            } else switch (try lookupGlobalAccessor(allocator, gr, key_s.flatBytes())) {
                 .value => |v| acc = v,
                 .thrown => |ex| {
                     f.ip = ip;

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -7826,7 +7826,7 @@ pub fn runFrames(
                 // { get })`) wins over the data-property fast
                 // path (§10.1.8.1); the getter is called with
                 // `this = <number primitive>` in strict mode.
-                if (heap_mod.valueAsFunction(realm.globals.get("Number") orelse Value.undefined_)) |num_ctor| {
+                if (heap_mod.valueAsFunction((f.running_realm orelse realm).globals.get("Number") orelse Value.undefined_)) |num_ctor| {
                     if (num_ctor.prototype) |np| {
                         if (lookupAccessor(np, key_s.flatBytes())) |acc_pair| {
                             if (acc_pair.getter) |getter| {
@@ -7855,7 +7855,7 @@ pub fn runFrames(
             } else if (acc.isBool()) {
                 // §7.1.1 ToObject(Boolean). Same accessor-aware
                 // chain walk as the Number arm above.
-                if (heap_mod.valueAsFunction(realm.globals.get("Boolean") orelse Value.undefined_)) |bool_ctor| {
+                if (heap_mod.valueAsFunction((f.running_realm orelse realm).globals.get("Boolean") orelse Value.undefined_)) |bool_ctor| {
                     if (bool_ctor.prototype) |bp| {
                         if (lookupAccessor(bp, key_s.flatBytes())) |acc_pair| {
                             if (acc_pair.getter) |getter| {
@@ -7884,7 +7884,7 @@ pub fn runFrames(
             } else if (heap_mod.isBigInt(acc)) {
                 // §7.1.1 ToObject(BigInt). Same accessor-aware
                 // chain walk as the Number arm above.
-                if (heap_mod.valueAsFunction(realm.globals.get("BigInt") orelse Value.undefined_)) |bi_ctor| {
+                if (heap_mod.valueAsFunction((f.running_realm orelse realm).globals.get("BigInt") orelse Value.undefined_)) |bi_ctor| {
                     if (bi_ctor.prototype) |bp| {
                         if (lookupAccessor(bp, key_s.flatBytes())) |acc_pair| {
                             if (acc_pair.getter) |getter| {
@@ -7915,7 +7915,7 @@ pub fn runFrames(
                 // symbol method lookups resolve via
                 // %Symbol.prototype%, with `this` reading
                 // the symbol primitive directly.
-                if (heap_mod.valueAsFunction(realm.globals.get("Symbol") orelse Value.undefined_)) |sym_ctor| {
+                if (heap_mod.valueAsFunction((f.running_realm orelse realm).globals.get("Symbol") orelse Value.undefined_)) |sym_ctor| {
                     if (sym_ctor.prototype) |sp| {
                         // Accessor descriptors (e.g. `description`)
                         // win over property-bag entries.

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -6929,6 +6929,7 @@ pub fn runFrames(
             const key_v = local_chunk.constants[k];
             if (!key_v.isString()) return error.InvalidOpcode;
             const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
+            const gr = f.running_realm orelse realm;
             // §13.15.2 step 1.f.i — strict-mode assignment to a
             // truly-unresolvable reference throws ReferenceError
             // at PutValue. Top-level `var x` / `let x` / `const x`
@@ -6937,8 +6938,8 @@ pub fn runFrames(
             // key is present. Anything missing here is a bare
             // `x = 1` for some `x` that was never declared
             // anywhere — strict mode forbids the implicit global.
-            if (!realm.globals.contains(key_s.flatBytes())) {
-                const ex = try makeReferenceError(realm, key_s.flatBytes());
+            if (!gr.globals.contains(key_s.flatBytes())) {
+                const ex = try makeReferenceError(gr, key_s.flatBytes());
                 f.ip = ip;
                 f.accumulator = acc;
                 committed = true;
@@ -6959,10 +6960,10 @@ pub fn runFrames(
             // PutValue (§6.2.5.5) and must surface the §13.3.1
             // TDZ ReferenceError when the slot still holds the
             // Hole sentinel.
-            if (realm.globals.hasLexicalDeclaration(key_s.flatBytes())) {
-                const cur = realm.globals.getDecl(key_s.flatBytes()) orelse Value.hole_;
+            if (gr.globals.hasLexicalDeclaration(key_s.flatBytes())) {
+                const cur = gr.globals.getDecl(key_s.flatBytes()) orelse Value.hole_;
                 if (cur.isHole()) {
-                    const ex = try makeReferenceError(realm, "Cannot access binding before initialisation");
+                    const ex = try makeReferenceError(gr, "Cannot access binding before initialisation");
                     f.ip = ip;
                     f.accumulator = acc;
                     committed = true;
@@ -6971,8 +6972,8 @@ pub fn runFrames(
                     }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
-                if (realm.globals.isLexConst(key_s.flatBytes())) {
-                    const ex = try makeTypeError(realm, "Assignment to constant variable");
+                if (gr.globals.isLexConst(key_s.flatBytes())) {
+                    const ex = try makeTypeError(gr, "Assignment to constant variable");
                     f.ip = ip;
                     f.accumulator = acc;
                     committed = true;
@@ -6981,7 +6982,7 @@ pub fn runFrames(
                     }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
-                try realm.globals.putDecl(realm.allocator, key_s.flatBytes(), acc);
+                try gr.globals.putDecl(realm.allocator, key_s.flatBytes(), acc);
             } else {
                 // §10.1.9.1 OrdinarySet step 3 — a write to a
                 // non-writable own data property of the global
@@ -6990,10 +6991,10 @@ pub fn runFrames(
                 // TypeError. Covers the §19.1 frozen globals
                 // (`undefined = 1`, `NaN = 1`, `Infinity = 1`)
                 // and any host-installed read-only data slot.
-                if (realm.globals.target) |gt| {
+                if (gr.globals.target) |gt| {
                     if (gt.property_flags.get(key_s.flatBytes())) |flags| {
                         if (!flags.writable) {
-                            const ex = try makeTypeError(realm, "Cannot assign to read-only property on globalThis");
+                            const ex = try makeTypeError(gr, "Cannot assign to read-only property on globalThis");
                             f.ip = ip;
                             f.accumulator = acc;
                             committed = true;
@@ -7004,11 +7005,11 @@ pub fn runFrames(
                         }
                     }
                 }
-                try realm.globals.put(realm.allocator, key_s.flatBytes(), acc);
+                try gr.globals.put(realm.allocator, key_s.flatBytes(), acc);
                 // Generational write barrier — a top-level `var`
                 // store can land a young value into the (mature)
                 // global object; record the old→young edge.
-                if (realm.globals.target) |gt| realm.heap.writeBarrier(.{ .object = gt }, acc);
+                if (gr.globals.target) |gt| realm.heap.writeBarrier(.{ .object = gt }, acc);
             }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
@@ -7031,7 +7032,12 @@ pub fn runFrames(
             const key_v = local_chunk.constants[k];
             if (!key_v.isString()) return error.InvalidOpcode;
             const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
-            registers[r] = if (realm.globals.contains(key_s.flatBytes()))
+            // Resolvability is judged against the executing function's
+            // home realm (same routing as `lda_global` / `sta_global`),
+            // not the dispatch realm — a free global assigned by a
+            // cross-realm-called function resolves in its own realm.
+            const gr = f.running_realm orelse realm;
+            registers[r] = if (gr.globals.contains(key_s.flatBytes()))
                 Value.fromBool(false)
             else
                 Value.fromBool(true);
@@ -7057,10 +7063,11 @@ pub fn runFrames(
             const key_v = local_chunk.constants[k];
             if (!key_v.isString()) return error.InvalidOpcode;
             const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
+            const gr = f.running_realm orelse realm;
             const flag = registers[r];
             const was_unresolved = flag.isBool() and flag.asBool();
             if (was_unresolved) {
-                const ex = try makeReferenceError(realm, key_s.flatBytes());
+                const ex = try makeReferenceError(gr, key_s.flatBytes());
                 f.ip = ip;
                 f.accumulator = acc;
                 committed = true;
@@ -7075,16 +7082,16 @@ pub fn runFrames(
             // both records); a name that was lex-declared
             // after the capture but before the store still
             // routes correctly to the declarative record here.
-            if (realm.globals.hasLexicalDeclaration(key_s.flatBytes())) {
+            if (gr.globals.hasLexicalDeclaration(key_s.flatBytes())) {
                 // §13.3.1 — `sta_global_strict` is reached only
                 // from assignment-expression code paths (never
                 // a declarator init), so a Hole-valued slot
                 // here is a §13.3.1 TDZ ReferenceError, not a
                 // first-init. Mirrors the matching check in
                 // `sta_global` above.
-                const cur = realm.globals.getDecl(key_s.flatBytes()) orelse Value.hole_;
+                const cur = gr.globals.getDecl(key_s.flatBytes()) orelse Value.hole_;
                 if (cur.isHole()) {
-                    const ex = try makeReferenceError(realm, "Cannot access binding before initialisation");
+                    const ex = try makeReferenceError(gr, "Cannot access binding before initialisation");
                     f.ip = ip;
                     f.accumulator = acc;
                     committed = true;
@@ -7093,8 +7100,8 @@ pub fn runFrames(
                     }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
-                if (realm.globals.isLexConst(key_s.flatBytes())) {
-                    const ex = try makeTypeError(realm, "Assignment to constant variable");
+                if (gr.globals.isLexConst(key_s.flatBytes())) {
+                    const ex = try makeTypeError(gr, "Assignment to constant variable");
                     f.ip = ip;
                     f.accumulator = acc;
                     committed = true;
@@ -7103,7 +7110,7 @@ pub fn runFrames(
                     }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
-                try realm.globals.putDecl(realm.allocator, key_s.flatBytes(), acc);
+                try gr.globals.putDecl(realm.allocator, key_s.flatBytes(), acc);
             } else {
                 // §10.1.9.1 OrdinarySet step 3 — same writable
                 // gate as `sta_global`. `sta_global_strict` is
@@ -7111,10 +7118,10 @@ pub fn runFrames(
                 // mode (Cynic's only mode) a non-writable own
                 // data property of the global object refuses
                 // the write with TypeError.
-                if (realm.globals.target) |gt| {
+                if (gr.globals.target) |gt| {
                     if (gt.property_flags.get(key_s.flatBytes())) |flags| {
                         if (!flags.writable) {
-                            const ex = try makeTypeError(realm, "Cannot assign to read-only property on globalThis");
+                            const ex = try makeTypeError(gr, "Cannot assign to read-only property on globalThis");
                             f.ip = ip;
                             f.accumulator = acc;
                             committed = true;
@@ -7125,11 +7132,11 @@ pub fn runFrames(
                         }
                     }
                 }
-                try realm.globals.put(realm.allocator, key_s.flatBytes(), acc);
+                try gr.globals.put(realm.allocator, key_s.flatBytes(), acc);
                 // Generational write barrier — a top-level `var`
                 // store can land a young value into the (mature)
                 // global object; record the old→young edge.
-                if (realm.globals.target) |gt| realm.heap.writeBarrier(.{ .object = gt }, acc);
+                if (gr.globals.target) |gt| realm.heap.writeBarrier(.{ .object = gt }, acc);
             }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -1027,6 +1027,10 @@ pub const Realm = struct {
     }
 
     pub fn deinit(self: *Realm) void {
+        // Drop out of the shared heap's realm set first, so a
+        // collection during the rest of teardown never marks (or a
+        // later sibling GC never touches) this dying realm.
+        self.deregisterFromHeap();
         self.frame_pool.deinit(self.allocator);
         self.globals.deinit(self.allocator);
         self.output.deinit(self.allocator);
@@ -1301,11 +1305,50 @@ pub const Realm = struct {
         // already be in place. `collectFull` sees `cycle_started`
         // and skips its own arm-cycle.
         self.heap.beginMajorCycle();
-        self.markRoots();
+        self.markAllSharingRealmRoots();
         // Hand off to `heap.collectFull` for the handle-scope walk
         // and the actual sweep. The empty roots slice is fine —
         // every root above is already marked.
         self.heap.collectFull(&.{});
+    }
+
+    /// Mark roots from EVERY realm sharing this heap, not just
+    /// `self`. With `Realm.initChild` (`$262.createRealm` /
+    /// `ShadowRealm`) several realms share one heap and one set of
+    /// object pools; the sweep frees every unmarked object, so
+    /// marking only the running realm's roots would reclaim a
+    /// sibling realm's live objects — a cross-realm use-after-free.
+    /// Mirrors V8's global GC, which marks every live Context's
+    /// roots. Falls back to `self` if the heap's realm set is empty
+    /// (a realm collecting before it registered at `installBuiltins`).
+    fn markAllSharingRealmRoots(self: *Realm) void {
+        if (self.heap.realms.items.len == 0) {
+            self.markRoots();
+            return;
+        }
+        for (self.heap.realms.items) |r| r.markRoots();
+    }
+
+    /// Register `self` in the shared heap's realm set so the
+    /// collector marks its roots. Idempotent. Call once `self` is at
+    /// its final address (`installBuiltins`).
+    pub fn registerWithHeap(self: *Realm) !void {
+        for (self.heap.realms.items) |r| if (r == self) return;
+        try self.heap.realms.append(self.allocator, self);
+    }
+
+    /// Remove `self` from the shared heap's realm set — its roots
+    /// stop being marked, so its now-unreachable objects are
+    /// reclaimed by the next collection. Used at `deinit` and by the
+    /// ShadowRealm finalizer (per-realm teardown).
+    pub fn deregisterFromHeap(self: *Realm) void {
+        const items = self.heap.realms.items;
+        for (items, 0..) |r, i| {
+            if (r == self) {
+                _ = self.heap.realms.swapRemove(i);
+                return;
+            }
+        }
     }
 
     /// Run a minor (young-generation) collection. Marks exactly the
@@ -1323,7 +1366,7 @@ pub const Realm = struct {
         // flip precedes any `markValue` call. `collectYoung` sees
         // `cycle_started` and skips its own arm-cycle.
         self.heap.beginMinorCycle();
-        self.markRoots();
+        self.markAllSharingRealmRoots();
         self.heap.collectYoung(&.{});
     }
 
@@ -1442,6 +1485,12 @@ pub const Realm = struct {
         // last installer wins, which is fine: a cleanup job is host-
         // queued and any realm sharing the heap can drain it.
         self.heap.setFinalizationEnqueue(self, finalizationEnqueueJob);
+
+        // Register with the shared heap's realm set so the collector
+        // marks this realm's roots (see `Heap.realms`). `self` is at
+        // its final address here. Idempotent: skip if already present
+        // (installBuiltins is normally called once per realm).
+        try self.registerWithHeap();
 
         const print_fn = try self.heap.allocateFunctionNative(self, printNative, 1, "print");
         try self.globals.put(self.allocator, "print", heap_mod.taggedFunction(print_fn));

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -314,3 +314,38 @@ test "phase 3: native callback sees its own function's realm via active_native_f
     // contract file so reviewers see it.
     return;
 }
+
+test "phase 3: a global write from a cross-realm-called function targets its home realm" {
+    // §6.2.5.5 PutValue / §9.1.1.4 SetMutableBinding — a function
+    // assigns its free globals through its own [[Realm]]'s global
+    // environment. A writer defined in parent, called from a child
+    // that shares the heap, must store into parent's global, never
+    // the calling (child) realm's. Strict mode (Cynic's only mode)
+    // means an undeclared target throws ReferenceError, so the
+    // pre-fix behaviour was a *throw* against child's globals, not a
+    // silent mis-store — either way the write never reached parent.
+    var parent = Realm.init(testing.allocator);
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    defer child.deinit();
+    try child.installBuiltins();
+
+    // `var crossWrite` lives in parent's global declarative record;
+    // the writer is captured as the script's completion value (the
+    // §16.1.7 last-statement value), mirroring the cross-realm hand-
+    // off in the tests above. Avoid `globalThis.x =` + bare read,
+    // which is an object-env-record property, not a binding.
+    _ = try lantern.evaluateScript(testing.allocator, &parent, "var crossWrite = 'init';");
+    const writer_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function () { crossWrite = 'from-call'; })")).value;
+    try child.globals.put(testing.allocator, "callIt", writer_v);
+    _ = try lantern.evaluateScript(testing.allocator, &child, "callIt();");
+
+    // The store landed in parent's global, not child's.
+    const in_parent = (try lantern.evaluateScript(testing.allocator, &parent, "crossWrite === 'from-call'")).value;
+    try testing.expect(in_parent.bits == Value.true_.bits);
+    // child never declared crossWrite — it stays unbound there.
+    const in_child = (try lantern.evaluateScript(testing.allocator, &child, "typeof crossWrite === 'undefined'")).value;
+    try testing.expect(in_child.bits == Value.true_.bits);
+}

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -402,3 +402,33 @@ test "phase 3: primitive boxing in a cross-realm-called function uses its home r
     const same = (try lantern.evaluateScript(testing.allocator, &child, "boxCtor() === Number")).value;
     try testing.expect(same.bits == Value.false_.bits);
 }
+
+test "gc-probe: a child realm GC must not sweep the parent realm's live objects (shared heap)" {
+    // Diagnostic: parent + child share one Heap (initChild). GC is
+    // triggered on the *running* realm and `markRoots` marks only
+    // that realm's roots. If a GC fires while the child is running
+    // (here: an explicit child.collectGarbage(), as the allocation-
+    // pressure trigger would do mid-evaluate), does it sweep the
+    // parent's objects — which the child never marks?
+    var parent = Realm.init(testing.allocator);
+    parent.hardened = false;
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    child.hardened = false;
+    defer child.deinit();
+    try child.installBuiltins();
+
+    // An object reachable ONLY from parent's global object.
+    _ = try lantern.evaluateScript(testing.allocator, &parent, "globalThis.keep = { tag: 'parent-live' };");
+
+    // GC as the child realm — marks child roots only, sweeps the
+    // shared heap. If parent's `keep` is unmarked it gets freed.
+    child.collectGarbage();
+
+    // Parent's object must survive. A swept object → use-after-free
+    // / wrong value here.
+    const r = (try lantern.evaluateScript(testing.allocator, &parent, "globalThis.keep.tag === 'parent-live'")).value;
+    try testing.expect(r.bits == Value.true_.bits);
+}

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -377,3 +377,28 @@ test "phase 3: slot-indexed top-level let read from a cross-realm-called functio
     try testing.expect(result.isNumber());
     try testing.expect(result.numberToDouble() == 42);
 }
+
+test "phase 3: primitive boxing in a cross-realm-called function uses its home realm's wrapper prototype" {
+    // §7.1.1 ToObject — a method/property access on a primitive
+    // boxes through the *running* realm's wrapper prototype
+    // (%Number.prototype% etc.). A function defined in parent and
+    // called from a child sharing the heap must box via parent's
+    // %Number%, so `(5).constructor` is parent's Number — distinct
+    // from the child's `Number` global. Pre-fix the boxing resolved
+    // the wrapper ctor via the dispatch (child) realm.
+    var parent = Realm.init(testing.allocator);
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    defer child.deinit();
+    try child.installBuiltins();
+
+    const box_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function () { return (5).constructor; })")).value;
+    try child.globals.put(testing.allocator, "boxCtor", box_v);
+
+    // boxCtor() returns parent's Number; child's `Number` is a
+    // different JSFunction, so the comparison is false.
+    const same = (try lantern.evaluateScript(testing.allocator, &child, "boxCtor() === Number")).value;
+    try testing.expect(same.bits == Value.false_.bits);
+}

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -197,9 +197,11 @@ test "phase-0: each realm has its own output buffer (print)" {
 const Value = @import("value.zig").Value;
 const heap_mod = @import("heap.zig");
 
-test "phase 3: function created in parent realm has parent as [[Realm]] (skip pending 3.3)" {
-    if (true) return error.SkipZigTest;
-
+test "phase 3: function created in parent realm has parent as [[Realm]]" {
+    // Live since the realm is threaded through native + ordinary
+    // function allocation (`Heap.allocateFunction*` takes the
+    // allocating realm); a function's [[Realm]] is fixed at
+    // creation and survives a cross-realm call.
     var parent = Realm.init(testing.allocator);
     defer parent.deinit();
     try parent.installBuiltins();
@@ -208,8 +210,8 @@ test "phase 3: function created in parent realm has parent as [[Realm]] (skip pe
     defer child.deinit();
     try child.installBuiltins();
 
-    // Create a function in parent. After 3.2, its `realm` slot
-    // is set at allocateFunction time.
+    // Create a function in parent; its `realm` slot is set at
+    // allocateFunction time.
     const f_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function f() { return 1; })")).value;
     const f = heap_mod.valueAsFunction(f_v) orelse return error.TestFailed;
     try testing.expect(f.realm == &parent);
@@ -223,8 +225,24 @@ test "phase 3: function created in parent realm has parent as [[Realm]] (skip pe
     try testing.expect(f.realm == &parent);
 }
 
-test "phase 3: TypeError thrown by parent's code is parent's Error.prototype chain (skip pending 3.3)" {
-    if (true) return error.SkipZigTest;
+test "phase 3: TypeError thrown by parent's code is parent's Error.prototype chain (skip pending 3.3 consumption)" {
+    // PENDING 3.3 consumption side. [[Realm]] is set on every
+    // function (3.2), and call.zig/interpreter.zig record the
+    // callee's realm as `active_native_fn_realm` /
+    // `CallFrame.running_realm`. The remaining gap is the deepest
+    // piece: free *global identifier resolution*. When parent's
+    // `thrower` runs after being called from child, `new TypeError`
+    // resolves the `TypeError` binding through the global-load
+    // opcodes, which read `realm.globals` — the *running* (child)
+    // realm — not the function's lexical home-realm global
+    // environment, so it constructs with child's TypeError and the
+    // probe sees `e.constructor === (child) TypeError`. Fixing it
+    // means routing global loads/stores through the executing
+    // frame's `running_realm.globals` (the RealmStack consumption).
+    // A smaller follow-on then makes the error natives resolve
+    // their prototype via `active_native_fn_realm` (§10.2.3) —
+    // necessary but not sufficient alone (verified: that change in
+    // isolation leaves this test red).
 
     // §10.2.3 / §10.2.4: an Error allocated inside a function whose
     // [[Realm]] is parent must inherit from parent's %Error.prototype%,
@@ -250,8 +268,15 @@ test "phase 3: TypeError thrown by parent's code is parent's Error.prototype cha
     try testing.expect(probe.bits == Value.false_.bits);
 }
 
-test "phase 3: §23.1.3.34 Array.prototype.map uses source realm's %Array% as species (skip pending 3.3)" {
-    if (true) return error.SkipZigTest;
+test "phase 3: §23.1.3.34 Array.prototype.map uses source realm's %Array% as species (skip pending 3.3 consumption)" {
+    // PENDING 3.3 consumption side. The Array.prototype.map native
+    // builds its result through the *calling* realm's %Array%
+    // instead of the source array's realm. ArraySpeciesCreate
+    // (§23.1.3.34) must default `C` to the source object's realm's
+    // %Array% — resolve via `realm.active_native_fn_realm orelse
+    // realm` at the array.zig species site, mirroring the error-
+    // native fix. [[Realm]] is already in place (3.2); only the
+    // consumption is missing.
 
     var parent = Realm.init(testing.allocator);
     defer parent.deinit();
@@ -273,7 +298,6 @@ test "phase 3: §23.1.3.34 Array.prototype.map uses source realm's %Array% as sp
 }
 
 test "phase 3: native callback sees its own function's realm via active_native_fn_realm (skip pending 3.3)" {
-    if (true) return error.SkipZigTest;
 
     // The native-side D2 invariant: a native installed in parent
     // and called from child reads `realm.active_native_fn_realm`

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -1,18 +1,20 @@
-//! Phase 0 multi-realm contracts — see `docs/multi-realm.md`.
+//! Multi-realm contracts — see `docs/multi-realm.md`.
 //!
-//! The four assertions in this file are the contract for "two `Realm`
-//! instances coexist in one process without interference." If they
-//! pass on `main` today, the foundation for the multi-realm phase
-//! plan is solid and Phase 1 can land its sharing-policy work without
-//! a structural refactor. If they fail, the failure mode pins the
-//! remaining single-realm assumption that has to come out first.
+//! Two groups:
 //!
-//! TDD discipline: these tests ship before the production code they
-//! pin. Today's `Realm` already has `initChild` (used by ShadowRealm)
-//! plus a parameterised `installBuiltins`, so Phase 0's contracts
-//! plausibly already hold for two independent `Realm.init` instances.
-//! The tests below verify that hypothesis empirically rather than
-//! by reading the code.
+//!   - **realm coexistence** — two `Realm` instances run in one
+//!     process without interference: distinct intrinsics, distinct
+//!     `globalThis`, mutation / microtask-queue / output isolation,
+//!     and a shared per-`Heap` `ShapeTree` across `initChild`.
+//!   - **cross-realm** — a function created in one realm and called
+//!     from another (shared-heap child via `initChild`, as
+//!     `ShadowRealm` / `$262.createRealm` do) resolves its free
+//!     bindings and intrinsics through its OWN realm, and a GC over
+//!     the shared heap never sweeps a sibling realm's live objects.
+//!
+//! Cross-realm value sharing uses `initChild` (shared heap), not two
+//! independent `Realm.init` instances — the latter is unsound
+//! (cross-heap pointers in another realm's GC root set).
 
 const std = @import("std");
 const testing = std.testing;
@@ -32,7 +34,7 @@ fn freshRealm(hardened: bool) !Realm {
 
 // ── Contract 1: two realms have distinct intrinsics ─────────────────
 
-test "phase-0: two independent realms have distinct intrinsic pointers" {
+test "realm coexistence: two independent realms have distinct intrinsic pointers" {
     var ra = try freshRealm(true);
     defer ra.deinit();
     var rb = try freshRealm(true);
@@ -53,7 +55,7 @@ test "phase-0: two independent realms have distinct intrinsic pointers" {
     try testing.expect(ra.intrinsics.function_prototype != rb.intrinsics.function_prototype);
 }
 
-test "phase-0: each realm has its own globalThis" {
+test "realm coexistence: each realm has its own globalThis" {
     var ra = try freshRealm(true);
     defer ra.deinit();
     var rb = try freshRealm(true);
@@ -67,7 +69,7 @@ test "phase-0: each realm has its own globalThis" {
 
 // ── Contract 2: mutation isolation (unhardened) ─────────────────────
 
-test "phase-0: mutating ra's Array.prototype does not affect rb (unhardened)" {
+test "realm coexistence: mutating ra's Array.prototype does not affect rb (unhardened)" {
     var ra = try freshRealm(false);
     defer ra.deinit();
     var rb = try freshRealm(false);
@@ -87,7 +89,7 @@ test "phase-0: mutating ra's Array.prototype does not affect rb (unhardened)" {
 
 // ── Contract 3: microtask isolation ─────────────────────────────────
 
-test "phase-0: each realm has its own microtask queue (isolation via side effect)" {
+test "realm coexistence: each realm has its own microtask queue (isolation via side effect)" {
     // Unhardened: the side-effect probe writes to `globalThis`,
     // which under hardened is frozen (§ SES position in
     // `docs/ses-alignment.md`). The contract being verified
@@ -136,7 +138,7 @@ test "phase-0: each realm has its own microtask queue (isolation via side effect
 // allocated on parent + child that go through the same
 // transition path land on shape-identical pointers.
 
-test "phase 0+: child realm shares the parent's ShapeTree (D1 revised)" {
+test "realm coexistence: child realm shares the parent's ShapeTree (D1 revised)" {
     var parent = Realm.init(testing.allocator);
     defer parent.deinit();
 
@@ -161,7 +163,7 @@ test "phase 0+: child realm shares the parent's ShapeTree (D1 revised)" {
 
 // ── Contract 4: output buffer isolation ─────────────────────────────
 
-test "phase-0: each realm has its own output buffer (print)" {
+test "realm coexistence: each realm has its own output buffer (print)" {
     var ra = try freshRealm(true);
     defer ra.deinit();
     var rb = try freshRealm(true);
@@ -177,16 +179,14 @@ test "phase-0: each realm has its own output buffer (print)" {
     try testing.expectEqual(@as(usize, 0), rb.output.items.len);
 }
 
-// ── Phase 3 — D2: per-`JSFunction` [[Realm]] + RealmStack ───────────
+// ── cross-realm: per-`JSFunction` [[Realm]] + home-realm resolution ──
 //
 // These pin §10.2.4 OrdinaryFunctionCreate step 8 (the function's
-// realm slot) + §10.2.3 [[Call]] step 2 (caller-context switches to
-// callee's realm). All four are TDD-RED today: `JSFunction.realm`
-// stays `null` at every `Heap.allocateFunction*` site because the
-// heap layer doesn't take a realm parameter. Commit 3.2 in the
-// `docs/multi-realm.md` Phase 3 plan threads the parameter through
-// the 109 alloc sites; commit 3.3 wires RealmStack + flips these
-// tests from skip-as-pending to green.
+// realm slot) + §10.2.3 [[Call]] step 2 (the running execution
+// context's realm follows the callee). `JSFunction.realm` is set at
+// every `Heap.allocateFunction*` site, and the interpreter resolves a
+// running function's free bindings + shared-builtin intrinsics through
+// its own realm rather than the dispatch realm.
 //
 // Cross-realm value sharing uses `Realm.initChild` (shared heap),
 // not two independent `Realm.init` instances — the latter is
@@ -197,7 +197,7 @@ test "phase-0: each realm has its own output buffer (print)" {
 const Value = @import("value.zig").Value;
 const heap_mod = @import("heap.zig");
 
-test "phase 3: function created in parent realm has parent as [[Realm]]" {
+test "cross-realm: function created in parent realm has parent as [[Realm]]" {
     // Live since the realm is threaded through native + ordinary
     // function allocation (`Heap.allocateFunction*` takes the
     // allocating realm); a function's [[Realm]] is fixed at
@@ -225,24 +225,13 @@ test "phase 3: function created in parent realm has parent as [[Realm]]" {
     try testing.expect(f.realm == &parent);
 }
 
-test "phase 3: TypeError thrown by parent's code is parent's Error.prototype chain (skip pending 3.3 consumption)" {
-    // PENDING 3.3 consumption side. [[Realm]] is set on every
-    // function (3.2), and call.zig/interpreter.zig record the
-    // callee's realm as `active_native_fn_realm` /
-    // `CallFrame.running_realm`. The remaining gap is the deepest
-    // piece: free *global identifier resolution*. When parent's
-    // `thrower` runs after being called from child, `new TypeError`
-    // resolves the `TypeError` binding through the global-load
-    // opcodes, which read `realm.globals` — the *running* (child)
-    // realm — not the function's lexical home-realm global
-    // environment, so it constructs with child's TypeError and the
-    // probe sees `e.constructor === (child) TypeError`. Fixing it
-    // means routing global loads/stores through the executing
-    // frame's `running_realm.globals` (the RealmStack consumption).
-    // A smaller follow-on then makes the error natives resolve
-    // their prototype via `active_native_fn_realm` (§10.2.3) —
-    // necessary but not sufficient alone (verified: that change in
-    // isolation leaves this test red).
+test "cross-realm: TypeError thrown by parent's code is parent's Error.prototype chain" {
+    // When parent's `thrower` runs after being called from child,
+    // `new TypeError` must resolve the `TypeError` binding through
+    // the function's home-realm global environment (not the running
+    // child realm's globals), and the Error native must build the
+    // instance from that realm's `%TypeError.prototype%` (§10.2.3) —
+    // so `e.constructor` is parent's TypeError, distinct from child's.
 
     // §10.2.3 / §10.2.4: an Error allocated inside a function whose
     // [[Realm]] is parent must inherit from parent's %Error.prototype%,
@@ -268,16 +257,13 @@ test "phase 3: TypeError thrown by parent's code is parent's Error.prototype cha
     try testing.expect(probe.bits == Value.false_.bits);
 }
 
-test "phase 3: §23.1.3.34 Array.prototype.map uses source realm's %Array% as species (skip pending 3.3 consumption)" {
-    // PENDING 3.3 consumption side. The Array.prototype.map native
-    // builds its result through the *calling* realm's %Array%
-    // instead of the source array's realm. ArraySpeciesCreate
-    // (§23.1.3.34) must default `C` to the source object's realm's
-    // %Array% — resolve via `realm.active_native_fn_realm orelse
-    // realm` at the array.zig species site, mirroring the error-
-    // native fix. [[Realm]] is already in place (3.2); only the
-    // consumption is missing.
-
+test "cross-realm: §23.1.3.34 Array.prototype.map uses source realm's %Array% as species" {
+    // §23.1.3.34 ArraySpeciesCreate defaults the species constructor
+    // `C` to the *source* array's realm's %Array%, not the calling
+    // realm's — so `arrFromParent.map(...)` invoked from child yields
+    // an array whose `constructor` is parent's Array, distinct from
+    // child's `Array`. The species site resolves through the executing
+    // native's home realm.
     var parent = Realm.init(testing.allocator);
     defer parent.deinit();
     try parent.installBuiltins();
@@ -297,25 +283,21 @@ test "phase 3: §23.1.3.34 Array.prototype.map uses source realm's %Array% as sp
     try testing.expect(probe.bits == Value.false_.bits);
 }
 
-test "phase 3: native callback sees its own function's realm via active_native_fn_realm (skip pending 3.3)" {
+test "cross-realm: native callback sees its own function's realm via active_native_fn_realm" {
 
-    // The native-side D2 invariant: a native installed in parent
-    // and called from child reads `realm.active_native_fn_realm`
-    // == &parent (its [[Realm]]). The dispatch loop's `realm`
-    // parameter is the *calling* realm (child); reading it would
-    // resolve intrinsics in the wrong realm.
-    //
-    // After 3.2, `JSFunction.realm` set at allocateFunctionNative
-    // time; lantern/call.zig:806 already stores it into
-    // active_native_fn_realm at native dispatch. The probe shape
-    // (a NativeFn cb that records `realm.active_native_fn_realm`
-    // into a captured cell) lives in commit 3.3 alongside the
-    // un-skip; here the prose-only test pins the invariant in the
-    // contract file so reviewers see it.
+    // A native installed in parent and called from child must read
+    // its OWN realm via `realm.active_native_fn_realm` (== &parent),
+    // not the dispatch loop's `realm` parameter (the calling child
+    // realm) — reading the latter resolves intrinsics in the wrong
+    // realm. The dispatch loop stamps the callee's realm into
+    // `active_native_fn_realm` before each native call. This
+    // invariant is exercised concretely by the TypeError and
+    // ArraySpeciesCreate tests above, which both consume it; this is
+    // a prose-only marker so the contract is visible here.
     return;
 }
 
-test "phase 3: a global write from a cross-realm-called function targets its home realm" {
+test "cross-realm: a global write from a cross-realm-called function targets its home realm" {
     // §6.2.5.5 PutValue / §9.1.1.4 SetMutableBinding — a function
     // assigns its free globals through its own [[Realm]]'s global
     // environment. A writer defined in parent, called from a child
@@ -350,7 +332,7 @@ test "phase 3: a global write from a cross-realm-called function targets its hom
     try testing.expect(in_child.bits == Value.true_.bits);
 }
 
-test "phase 3: slot-indexed top-level let read from a cross-realm-called function targets its home realm" {
+test "cross-realm: slot-indexed top-level let read from a cross-realm-called function targets its home realm" {
     // §9.1.1.4 — a top-level `let` / `const` resolves to a
     // slot-indexed declarative-env-record read (`lda_global_slot`),
     // with the slot relative to the realm the function was compiled
@@ -378,7 +360,7 @@ test "phase 3: slot-indexed top-level let read from a cross-realm-called functio
     try testing.expect(result.numberToDouble() == 42);
 }
 
-test "phase 3: primitive boxing in a cross-realm-called function uses its home realm's wrapper prototype" {
+test "cross-realm: primitive boxing in a cross-realm-called function uses its home realm's wrapper prototype" {
     // §7.1.1 ToObject — a method/property access on a primitive
     // boxes through the *running* realm's wrapper prototype
     // (%Number.prototype% etc.). A function defined in parent and
@@ -431,4 +413,69 @@ test "gc-probe: a child realm GC must not sweep the parent realm's live objects 
     // / wrong value here.
     const r = (try lantern.evaluateScript(testing.allocator, &parent, "globalThis.keep.tag === 'parent-live'")).value;
     try testing.expect(r.bits == Value.true_.bits);
+}
+
+test "gc-probe: a parent realm GC must not sweep a child realm's live objects (shared heap)" {
+    // The mirror of the child→parent probe: a GC triggered on the
+    // parent must mark the child's roots too (the child shares the
+    // heap and is registered in `heap.realms`), or it sweeps the
+    // child's live objects.
+    var parent = Realm.init(testing.allocator);
+    parent.hardened = false;
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    child.hardened = false;
+    defer child.deinit();
+    try child.installBuiltins();
+
+    // Reachable only from the CHILD's global object.
+    _ = try lantern.evaluateScript(testing.allocator, &child, "globalThis.kept = { tag: 'child-live' };");
+    parent.collectGarbage();
+    const r = (try lantern.evaluateScript(testing.allocator, &child, "globalThis.kept.tag === 'child-live'")).value;
+    try testing.expect(r.bits == Value.true_.bits);
+}
+
+test "cross-realm: boolean and symbol boxing in a cross-realm-called function use the home realm's wrappers" {
+    // Broadens the `(5).constructor` Number case to the other
+    // ToObject wrapper prototypes the fix touched (§7.1.1).
+    var parent = Realm.init(testing.allocator);
+    parent.hardened = false;
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    child.hardened = false;
+    defer child.deinit();
+    try child.installBuiltins();
+
+    const bool_ctor_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function () { return (true).constructor; })")).value;
+    try child.globals.put(testing.allocator, "boolCtor", bool_ctor_v);
+    const r1 = (try lantern.evaluateScript(testing.allocator, &child, "boolCtor() === Boolean")).value;
+    try testing.expect(r1.bits == Value.false_.bits);
+
+    const sym_ctor_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function () { return Symbol().constructor; })")).value;
+    try child.globals.put(testing.allocator, "symCtor", sym_ctor_v);
+    const r2 = (try lantern.evaluateScript(testing.allocator, &child, "symCtor() === Symbol")).value;
+    try testing.expect(r2.bits == Value.false_.bits);
+}
+
+test "cross-realm: a RangeError thrown by parent's code is parent's RangeError.prototype chain" {
+    // Second NativeError subclass beyond the TypeError case, exercising
+    // the home-realm intrinsics resolution in the error natives.
+    var parent = Realm.init(testing.allocator);
+    parent.hardened = false;
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    child.hardened = false;
+    defer child.deinit();
+    try child.installBuiltins();
+
+    const thrower_v = (try lantern.evaluateScript(testing.allocator, &parent, "(function () { throw new RangeError('from parent'); })")).value;
+    try child.globals.put(testing.allocator, "boomRange", thrower_v);
+    const probe = (try lantern.evaluateScript(testing.allocator, &child, "let r; try { boomRange(); } catch (e) { r = e.constructor === RangeError; } r")).value;
+    try testing.expect(probe.bits == Value.false_.bits);
 }

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -349,3 +349,31 @@ test "phase 3: a global write from a cross-realm-called function targets its hom
     const in_child = (try lantern.evaluateScript(testing.allocator, &child, "typeof crossWrite === 'undefined'")).value;
     try testing.expect(in_child.bits == Value.true_.bits);
 }
+
+test "phase 3: slot-indexed top-level let read from a cross-realm-called function targets its home realm" {
+    // §9.1.1.4 — a top-level `let` / `const` resolves to a
+    // slot-indexed declarative-env-record read (`lda_global_slot`),
+    // with the slot relative to the realm the function was compiled
+    // in. A reader defined in parent (closing over parent's `let`),
+    // called from a child that shares the heap, must index PARENT's
+    // decl_env — not the child's, whose slot N holds a different
+    // binding or is out of range. Pre-fix this indexed the dispatch
+    // (child) realm: a `std.debug.assert(idx < vals.len)` panic in
+    // safe builds, a wrong value in release.
+    var parent = Realm.init(testing.allocator);
+    defer parent.deinit();
+    try parent.installBuiltins();
+
+    var child = Realm.initChild(&parent);
+    defer child.deinit();
+    try child.installBuiltins();
+
+    // `let secret` + the reader compiled in one parent script so the
+    // reader resolves `secret` to a global-lexical slot.
+    const reader_v = (try lantern.evaluateScript(testing.allocator, &parent, "let secret = 42; (function () { return secret; })")).value;
+    try child.globals.put(testing.allocator, "readSecret", reader_v);
+
+    const result = (try lantern.evaluateScript(testing.allocator, &child, "readSecret()")).value;
+    try testing.expect(result.isNumber());
+    try testing.expect(result.numberToDouble() == 42);
+}

--- a/test262-results.md
+++ b/test262-results.md
@@ -632,20 +632,27 @@ Bucketed on the first two path components (`built-ins/Set`,
 
 Per-feature scores for the TC39 proposals Cynic ships at
 Stage 1–3, ahead of their inclusion in the published
-edition. Each proposal gets a **(hardened)** row — the
-as-shipped SES posture under `--enable=<flag>`, with SES
-throws counted as expected fails — and an
-**(unhardened)** row against bare ECMA-262. Same column
-shape as the main `## Current scores` table:
-`passing | failing | expected fails | skip | total | pass%`.
+edition. Each proposal gets its **own table** with two
+posture rows: **hardened** — the as-shipped SES posture
+under `--enable=<flag>`, with SES throws counted as
+expected fails — and **unhardened**, against bare
+ECMA-262. Same columns as the main `## Current scores`
+table: `passing | failing | expected fails | skip | total | pass%`.
 These fixtures are excluded from the top-line score.
 
-| feature | passing | failing | expected fails | skip | total | pass% |
+### `joint-iteration`
+
+| posture | passing | failing | expected fails | skip | total | pass% |
 |---|---:|---:|---:|---:|---:|---:|
-| `joint-iteration` (hardened) | 70 | 0 | 8 | 3 | 81 | 96 % |
-| `joint-iteration` (unhardened) | 76 | 0 | 2 | 3 | 81 | 96 % |
-| `ShadowRealm` (hardened) | 43 | 0 | 21 | 3 | 67 | 96 % |
-| `ShadowRealm` (unhardened) | 63 | 0 | 1 | 3 | 67 | 96 % |
+| hardened | 70 | 0 | 8 | 3 | 81 | 96 % |
+| unhardened | 76 | 0 | 2 | 3 | 81 | 96 % |
+
+### `ShadowRealm`
+
+| posture | passing | failing | expected fails | skip | total | pass% |
+|---|---:|---:|---:|---:|---:|---:|
+| hardened | 43 | 0 | 21 | 3 | 67 | 96 % |
+| unhardened | 63 | 0 | 1 | 3 | 67 | 96 % |
 
 
 ## History

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -4306,16 +4306,13 @@ fn writePreStage4Scoreboard(
         \\
         \\Per-feature scores for the TC39 proposals Cynic ships at
         \\Stage 1–3, ahead of their inclusion in the published
-        \\edition. Each proposal gets a **(hardened)** row — the
-        \\as-shipped SES posture under `--enable=<flag>`, with SES
-        \\throws counted as expected fails — and an
-        \\**(unhardened)** row against bare ECMA-262. Same column
-        \\shape as the main `## Current scores` table:
-        \\`passing | failing | expected fails | skip | total | pass%`.
+        \\edition. Each proposal gets its **own table** with two
+        \\posture rows: **hardened** — the as-shipped SES posture
+        \\under `--enable=<flag>`, with SES throws counted as
+        \\expected fails — and **unhardened**, against bare
+        \\ECMA-262. Same columns as the main `## Current scores`
+        \\table: `passing | failing | expected fails | skip | total | pass%`.
         \\These fixtures are excluded from the top-line score.
-        \\
-        \\| feature | passing | failing | expected fails | skip | total | pass% |
-        \\|---|---:|---:|---:|---:|---:|---:|
         \\
     );
 
@@ -4323,14 +4320,33 @@ fn writePreStage4Scoreboard(
     for (0..tracked_pre_stage4_features.len) |i| {
         const name = tracked_pre_stage4_features[i];
         const h = pre_stage4_hardened.slots[i];
-        if (h.total != 0) {
-            const pct: f64 = 100.0 * @as(f64, @floatFromInt(h.pass + h.correctly_handled)) / @as(f64, @floatFromInt(h.total));
-            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (hardened) | {d} | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ name, h.pass, h.fail, h.correctly_handled, h.skip, h.total, pct }));
-        }
         const u = pre_stage4_unhardened.slots[i];
+        // Skip a proposal with no fixtures in either posture (e.g.
+        // not exercised this run) — no empty per-feature table.
+        if (h.total == 0 and u.total == 0) continue;
+
+        // One table per proposal, with a `### ` sub-heading. The
+        // `## `-prefixed section extractor stops at the next `## `,
+        // so these `### ` headings stay inside the section.
+        try out.appendSlice(gpa, try std.fmt.bufPrint(&buf,
+            \\
+            \\### `{s}`
+            \\
+            \\| posture | passing | failing | expected fails | skip | total | pass% |
+            \\|---|---:|---:|---:|---:|---:|---:|
+            \\
+        , .{name}));
+
+        if (h.total != 0) {
+            // pass% = (passing + expected fails) / total, matching the
+            // main `## Current scores` table; `correctly_handled` is the
+            // policy-expected-fail count, `skip` a separate column.
+            const pct: f64 = 100.0 * @as(f64, @floatFromInt(h.pass + h.correctly_handled)) / @as(f64, @floatFromInt(h.total));
+            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| hardened | {d} | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ h.pass, h.fail, h.correctly_handled, h.skip, h.total, pct }));
+        }
         if (u.total != 0) {
             const pct: f64 = 100.0 * @as(f64, @floatFromInt(u.pass + u.correctly_handled)) / @as(f64, @floatFromInt(u.total));
-            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| `{s}` (unhardened) | {d} | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ name, u.pass, u.fail, u.correctly_handled, u.skip, u.total, pct }));
+            try out.appendSlice(gpa, try std.fmt.bufPrint(&buf, "| unhardened | {d} | {d} | {d} | {d} | {d} | {d:.0} % |\n", .{ u.pass, u.fail, u.correctly_handled, u.skip, u.total, pct }));
         }
     }
     try out.appendSlice(gpa, "\n");


### PR DESCRIPTION
## Summary

Completes the multi-realm "Phase 3" realm-aware resolution and, in the process, fixes **two real cross-realm memory-safety bugs**. Everything builds on the now-uniform `[[Realm]]` (threaded through function allocation); each commit is TDD'd and full-sweep-validated with **zero test262 regression** (40178 hardened / 44074 unhardened, 593 / 600 failing throughout).

## Realm-aware resolution — now 100%
When a function created in one realm runs in another (shared-heap child via `$262.createRealm` / `ShadowRealm`), it must resolve through its **home** realm, not the dispatch realm. Now fixed at every site:
- free global **reads** + `typeof` + the unresolved-assignment capture
- global **writes** (`sta_global` / `sta_global_strict`)
- **slot-indexed** top-level `let` / `const`
- Error-constructor intrinsics (§10.2.3) and `ArraySpeciesCreate` (§23.1.3.34)
- primitive **boxing** wrapper prototypes (§7.1.1)

Each routes through the active frame's `running_realm` / `active_native_fn_realm`. In a single realm these equal the dispatch realm, so the hot path is unchanged.

## Memory-safety fixes (the important ones)
- **Cross-realm GC marking UAF** (`1806b8a`): the collector marked only the *running* realm's roots over the shared flat-pool heap, so a GC during a child realm's execution swept the **parent's live objects** (confirmed by the 0xaa free-poison under `test262-safe`). Fixed with `Heap.realms` + `markAllSharingRealmRoots` — the V8/JSC global-GC model (marks every live realm's roots). Realms register at `installBuiltins`, deregister at `deinit`.
- **ShadowRealm `HandleScope` UAF** (`efc1878`): the wrapped function was unrooted across `CopyNameAndLength`'s re-allocating writes. Anchored in a `HandleScope`.

With both, the ShadowRealm phase runs clean under `test262-safe --gc-threshold=1` (verifiers + poison armed): 43/0, no crash.

## Docs / scoreboard
- `docs/multi-realm.md`: Phase 3 marked shipped; Phase 6 (per-realm teardown) reworked after a prior-art survey (V8/JSC shared-heap + global GC vs SpiderMonkey zones) — the per-object-tag + scoped-sweep sketch is dropped; foundation is the marking fix; only the bounded child-`Realm`-struct finalizer remains, with both implementation paths documented.
- Per-proposal pre-Stage-4 scoreboard tables.

## Scope / out of scope
- **Not** included: the Phase 6b ShadowRealm finalizer (frees the child `Realm` struct on collection) — a *bounded* leak, not a safety bug, and a delicate GC-lifecycle change best done as its own `test262-safe`-gated pass. Fully scoped in `docs/multi-realm.md`.

## Verification
- `zig build test` green; `zig fmt --check` clean.
- Full test262 sweep: zero regression.
- `test262-safe --gc-threshold=1` on the ShadowRealm surface: clean (poison/verifiers armed).