### PR TITLE
eval: implement runtime code construction behind --allow=eval

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,18 +90,24 @@ These are project rules — they apply to everyone.
     SpiderMonkey — accepts the Annex B forms; Cynic's non-browser
     target is why it doesn't.) See
     [docs/ROADMAP.md](docs/ROADMAP.md) under "Regex".
-  - **`eval` and runtime code construction** — out by
-    default. `eval()` itself, `new Function(string)` /
-    `new GeneratorFunction(string)` / `new AsyncFunction(string)`,
-    and dynamic-code-from-string generally aren't shipped.
-    Aligns with [SES / Hardened JavaScript](https://github.com/endojs/endo/tree/main/packages/ses)
-    and removes a major optimization fence. Cynic's host-level
-    `Realm.evaluateScript` (powering multi-file `cynic run`,
-    the test262 harness loader, and a future REPL) is a
-    different mechanism — it's not exposed to user JS.
-    Opt back in with `--allow=eval` (the implementation lands
-    in a separate effort — see
-    [docs/ses-alignment.md](docs/ses-alignment.md)).
+  - **`eval` and runtime code construction** — off by
+    default, opt in with `--allow=eval`. `eval()` itself,
+    `new Function(string)` / `new GeneratorFunction(string)` /
+    `new AsyncFunction(string)`, and dynamic-code-from-string
+    generally refuse by SES policy (a `SyntaxError`) unless the
+    gate is open. Aligns with [SES / Hardened JavaScript](https://github.com/endojs/endo/tree/main/packages/ses).
+    Cynic's host-level `Realm.evaluateScript` (powering multi-file
+    `cynic run`, the test262 harness loader, and a future REPL) is
+    a different mechanism — it's not exposed to user JS.
+    **With `--allow=eval` the engine ships** (§19.2.1 PerformEval —
+    direct + indirect; §20.2.1.1.1 CreateDynamicFunction): eval'd
+    code runs *in the realm*, so the hardened-default frozen
+    primordials confine it (`eval("Array.prototype.push=1")` throws);
+    `--unhardened` gives it mutable primordials. Cynic is strict-only,
+    so every eval is a strict eval (§19.2.1.3) — direct eval reads the
+    caller's scope but never injects `var` / function bindings into it.
+    Full SES Compartment confinement is deferred. See
+    [docs/ses-alignment.md](docs/ses-alignment.md) "The eval engine".
 - **SES-aligned by default; `--unhardened` opts out.** Cynic
   isn't just "SES-friendly" (every modern edge runtime is that);
   Cynic ships **hardened by default**:
@@ -130,11 +136,12 @@ These are project rules — they apply to everyone.
     SES is a coherent package — atomic toggle matches how users
     decide, vs the granular per-piece flags an earlier design
     iteration sketched.
-  - **`--allow=eval`** stays separate (when eval ships) because
-    it's a compile-time optimization fence (per-function escape
-    analysis + conservative bytecode); bundling with
-    `--unhardened` would impose that cost on users who just want
-    mutable primordials.
+  - **`--allow=eval`** stays separate from `--unhardened` because
+    the two are orthogonal capabilities (a build can be unhardened
+    yet eval-off, or hardened yet eval-on); bundling them would
+    force the eval surface on users who just want mutable
+    primordials. Now shipped (§19.2.1 / §20.2.1.1.1) — see the
+    `eval` bullet above and `docs/ses-alignment.md`.
   Three distinct CLI verbs to keep separate: **`--enable=<name>`**
   turns on a not-yet-stable spec feature (`joint-iteration` is
   the only one shipping today; `upsert` graduated to default-on
@@ -286,11 +293,15 @@ sweeps.
 `--filter=<substring>`, `--list-failures=<n>`, `--quiet`, `--verbose`,
 `--phase=<spec>` (`main` runs the hardened ECMA-262 sweep with
 pre-Stage-4 fixtures excluded; `unhardened` runs the same
-fixture set with `realm.hardened = false`; `feature:<name>` runs
-only that proposal's dedicated isolated sweep — only its realm
-flag on, only its tagged fixtures included. Default: main +
-unhardened; `--write-results` additionally runs every tracked
-feature in sequence), `--no-harness` (disable the `sta.js` +
+fixture set with `realm.hardened = false`; `eval` runs it with
+`realm.allow_eval = true` (unhardened) so the eval surface
+(§19.2.1 / §20.2.1.1.1) runs for real and eval-policy failures
+count as real failures — the "what eval work remains" signal;
+`feature:<name>` runs only that proposal's dedicated isolated
+sweep — only its realm flag on, only its tagged fixtures
+included. Default: main + unhardened; `--write-results`
+additionally runs the eval phase and every tracked feature in
+sequence), `--no-harness` (disable the `sta.js` +
 `assert.js` preamble in runtime mode),
 `--write-results` (updates `test262-results.md`),
 `--only-failing` (skip-as-pass any test path listed in
@@ -377,8 +388,8 @@ Re-running for the same `(date, mode)` replaces that day's row.
 Each row records `passing`, `failing`, `expected fails`,
 `total`, and `pass%`. `test262-results.md` opens with
 a `## Current scores` snapshot (3 rows: `unhardened, --allow=eval`
-as a placeholder until the eval opt-in ships, then `unhardened`,
-then `hardened`), a `## Legend`, a `## Where the engine fails,
+— now a measured `--phase=eval` sweep, not a placeholder — then
+`unhardened`, then `hardened`), a `## Legend`, a `## Where the engine fails,
 by area` per-bucket scoreboard sourced from the hardened sweep
 and sorted by raw fail count, a `## Pre-Stage-4 proposals
 shipped` section with one per-proposal table (a `### <feature>`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,8 +94,11 @@ These are project rules — they apply to everyone.
     default, opt in with `--allow=eval`. `eval()` itself,
     `new Function(string)` / `new GeneratorFunction(string)` /
     `new AsyncFunction(string)`, and dynamic-code-from-string
-    generally refuse by SES policy (a `SyntaxError`) unless the
-    gate is open. Aligns with [SES / Hardened JavaScript](https://github.com/endojs/endo/tree/main/packages/ses).
+    generally refuse unless the gate is open — §19.2.1.2
+    HostEnsureCanCompileStrings throws an `EvalError` (the
+    host-refusal type Node's `--disallow-code-generation-from-strings`
+    and browser CSP use; the spec leaves the error type host-defined).
+    Aligns with [SES / Hardened JavaScript](https://github.com/endojs/endo/tree/main/packages/ses).
     Cynic's host-level `Realm.evaluateScript` (powering multi-file
     `cynic run`, the test262 harness loader, and a future REPL) is
     a different mechanism — it's not exposed to user JS.

--- a/docs/ses-alignment.md
+++ b/docs/ses-alignment.md
@@ -423,9 +423,13 @@ Revisit Compartments when:
 ## The eval engine (`--allow=eval`)
 
 Shipped behind the `--allow=eval` gate (`realm.allow_eval`, default
-false). With the gate closed Cynic refuses runtime code construction
-by SES policy (a `SyntaxError`) exactly as before; with it open the
-following run for real:
+false). With the gate closed Cynic refuses runtime code construction:
+§19.2.1.2 HostEnsureCanCompileStrings throws an `EvalError` (the spec
+leaves the error type host-defined; `EvalError` matches Node's
+`--disallow-code-generation-from-strings` and browser CSP). A genuine
+parse failure *after* the gate opens is a `SyntaxError` instead — the
+two are distinct (capability refusal vs parse outcome). With the gate
+open the following run for real:
 
 - **`eval(x)` — §19.2.1.** Indirect eval (`(0, eval)(s)`,
   `globalThis.eval(s)`) evaluates `s` as global-scope code through the

--- a/docs/ses-alignment.md
+++ b/docs/ses-alignment.md
@@ -41,7 +41,7 @@ guarantee against Cynic's status:
 
 | # | SES requirement | Cynic today | This doc covers |
 |---|---|---|---|
-| 1 | Ban `eval` / `new Function(string)` family | ✅ permanent | — |
+| 1 | Ban `eval` / `new Function(string)` family | ✅ default (gated by `--allow=eval`) | Phase 4 |
 | 2 | Strict mode only, no sloppy code paths | ✅ permanent | — |
 | 3 | No Annex B (HTML comments, legacy octal, `with`, etc.) | ✅ permanent | — |
 | 4 | **Freeze all primordials at realm init** | ✅ shipped | Phase 1 |
@@ -169,7 +169,7 @@ is intentionally minimal:
 | Flag | Effect |
 |---|---|
 | `--unhardened` | Disables the **entire SES posture** atomically: primordials stay mutable (Phase 1 skipped), `globalThis` stays extensible, the `harden()` global is not installed (Phase 2), the override-mistake fix is skipped (Phase 3). Spec-literal `OrdinarySetWithOwnDescriptor` semantics. The single switch a user flips for full compatibility with general-purpose JS that monkey-patches `Array.prototype.X`, polyfills missing methods, or relies on the spec's "assign-to-frozen-proto throws" behaviour. |
-| `--allow=eval` | Independent opt-in for `eval`, `new Function(string)`, and the `GeneratorFunction` / `AsyncFunction` / `AsyncGeneratorFunction` constructors. **Not bundled** with `--unhardened` because eval is a compile-time optimization fence — every function eval-reachable gets per-function escape analysis + a conservative bytecode variant. Users who want mutable primordials WITHOUT paying the eval-taint compile cost stay on `--unhardened` alone. Requires the full eval implementation (deferred — see notes below). |
+| `--allow=eval` | Independent opt-in for `eval`, `new Function(string)`, and the `GeneratorFunction` / `AsyncFunction` / `AsyncGeneratorFunction` constructors. **Not bundled** with `--unhardened` because the two are orthogonal capabilities (a build can be unhardened yet eval-off, or hardened yet eval-on). **Shipped** — see "The eval engine" below. |
 
 Why one umbrella switch instead of per-constraint flags:
 
@@ -410,15 +410,74 @@ Revisit Compartments when:
   Compartments there's nothing to tame against.
 - **Enforcing `lockdown()`-style intrinsic shape restrictions
   beyond freezing** — SES does extra work to remove "powerful"
-  intrinsics. Cynic doesn't ship most of them anyway (no `eval`,
-  no `Function(string)`, no `RegExp` legacy globals).
+  intrinsics. Cynic doesn't ship most of them anyway (`eval` /
+  `Function(string)` are off unless `--allow=eval`; no `RegExp`
+  legacy globals).
 - **`StaticModuleRecord` / `SyntheticModuleRecord`** — module API
   for Compartments. Deferred with Compartments.
-- **The full eval-implementation work** for `--allow=eval` — this
-  is its own multi-month project (see the design conversation in
-  session history; eval is a major optimization fence and needs
-  per-function escape analysis). The flag is reserved here; the
-  implementation lands in a separate effort.
+- **Compartment confinement of eval'd code** — `--allow=eval` runs
+  eval'd source in the realm itself, not a sandbox (see "The eval
+  engine"). True SES Compartment confinement (endowment-only globals)
+  is deferred with Compartments.
+
+## The eval engine (`--allow=eval`)
+
+Shipped behind the `--allow=eval` gate (`realm.allow_eval`, default
+false). With the gate closed Cynic refuses runtime code construction
+by SES policy (a `SyntaxError`) exactly as before; with it open the
+following run for real:
+
+- **`eval(x)` — §19.2.1.** Indirect eval (`(0, eval)(s)`,
+  `globalThis.eval(s)`) evaluates `s` as global-scope code through the
+  existing `evaluateEval` pipeline. Direct eval (the syntactic
+  `eval(...)` form) is detected at compile time and lowered to a
+  dedicated `direct_eval` opcode that captures a snapshot of the
+  caller's visible env-slot bindings; at runtime the eval'd source is
+  compiled against a synthetic outer scope rebuilt from that snapshot
+  and run in a frame whose environment is parented to the caller's, so
+  free identifiers resolve against the caller's locals and the eval
+  inherits the caller's `this` / `new.target` / home object. A
+  non-string argument is returned unchanged (§19.2.1 step 2). The
+  runtime re-checks that the callee is actually `%eval%`, so a
+  reassigned `globalThis.eval` is an ordinary call, not a direct eval.
+- **`Function` / `GeneratorFunction` / `AsyncFunction` /
+  `AsyncGeneratorFunction` string constructors — §20.2.1.1.1
+  CreateDynamicFunction.** Implemented by source synthesis: the
+  parameter strings + body are wrapped in a parenthesized function
+  expression with the kind's prefix and run through `evaluateEval`, so
+  the new function's scope is the global environment per spec.
+
+**Strict-only simplification.** Cynic parses all source as strict, so
+every eval is a strict eval (§19.2.1.3): direct eval reads the
+caller's scope but never injects `var` / function bindings into it.
+Corollary: test262 fixtures asserting *indirect* eval runs as sloppy
+can never pass and stay permanently out of scope
+(`strict_only_exact_paths` in `tools/test262/skip.zig`).
+
+**Posture interaction.** The eval engine is posture-agnostic; the
+realm's existing freeze state does the confinement. Under the hardened
+default, eval'd code sees the frozen primordials + override-mistake
+fix — so `eval("Array.prototype.push = 1")` throws, and that freeze
+*is* the confinement Cynic can offer pre-Compartments. Under
+`--unhardened` the same eval'd code sees mutable primordials. No fake
+endowment / confinement layer is built; full SES Compartment
+confinement is deferred (see "Out of scope").
+
+**Known limitation.** Indirect/direct strict eval that declares a
+top-level `var` currently binds it on the global environment rather
+than an eval-local variable environment — an observable §19.2.1.3 gap
+for the rare fixture that probes post-eval `var` isolation, not a
+crash. The completion-value and free-reference semantics that the bulk
+of the eval corpus exercises are correct.
+
+**test262.** The eval surface (~2,100 fixtures) runs in every phase.
+Eval-off phases (`main` / `unhardened`) classify an eval-surface
+failure as `correctly_handled` (a by-design refusal) via
+`skip_rules.pathPolicyKind`'s `.eval` policy. A dedicated `--phase=eval`
+sweep (unhardened + `realm.allow_eval = true`) drops that policy so the
+eval fixtures run for real and their failures count as genuine
+failures — the live "what eval work remains" signal, surfaced as the
+`unhardened, --allow=eval` row in `test262-results.md`.
 
 ## Verification
 

--- a/docs/ses-alignment.md
+++ b/docs/ses-alignment.md
@@ -452,11 +452,17 @@ open the following run for real:
   the new function's scope is the global environment per spec.
 
 **Strict-only simplification.** Cynic parses all source as strict, so
-every eval is a strict eval (§19.2.1.3): direct eval reads the
-caller's scope but never injects `var` / function bindings into it.
-Corollary: test262 fixtures asserting *indirect* eval runs as sloppy
-can never pass and stay permanently out of scope
-(`strict_only_exact_paths` in `tools/test262/skip.zig`).
+every eval is a strict eval (§19.2.1.3): the eval body gets its own
+variable environment, so top-level `var` / function declarations bind
+eval-locally and never leak to the global env (indirect eval) or the
+caller's scope (direct eval). Direct eval still *reads* the caller's
+scope for free identifiers. Implemented via the compiler's `eval_local`
+mode, which routes the eval body's top-level bindings through the same
+non-global path module bodies use; `ShadowRealm.prototype.evaluate`
+stays on Script evaluation (var → the shadow realm's global env,
+§3.8.3.7) and is unaffected. Corollary: test262 fixtures asserting
+*indirect* eval runs as sloppy can never pass and stay permanently out
+of scope (`strict_only_exact_paths` in `tools/test262/skip.zig`).
 
 **Posture interaction.** The eval engine is posture-agnostic; the
 realm's existing freeze state does the confinement. Under the hardened
@@ -466,13 +472,6 @@ fix — so `eval("Array.prototype.push = 1")` throws, and that freeze
 `--unhardened` the same eval'd code sees mutable primordials. No fake
 endowment / confinement layer is built; full SES Compartment
 confinement is deferred (see "Out of scope").
-
-**Known limitation.** Indirect/direct strict eval that declares a
-top-level `var` currently binds it on the global environment rather
-than an eval-local variable environment — an observable §19.2.1.3 gap
-for the rare fixture that probes post-eval `var` isolation, not a
-crash. The completion-value and free-reference semantics that the bulk
-of the eval corpus exercises are correct.
 
 **test262.** The eval surface (~2,100 fixtures) runs in every phase.
 Eval-off phases (`main` / `unhardened`) classify an eval-surface

--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -24,6 +24,7 @@ const Op = @import("op.zig").Op;
 const Span = @import("../source.zig").Span;
 const Value = @import("../runtime/value.zig").Value;
 const Shape = @import("../runtime/shape.zig").Shape;
+const BindingKind = @import("scope.zig").BindingKind;
 
 /// Inline-cache cell — one per property-access callsite. The
 /// interpreter records the last receiver's `(shape, slot)` after a
@@ -347,6 +348,40 @@ pub const FieldTemplate = struct {
     computed_key_index: i16 = -1,
 };
 
+/// §19.2.1 direct eval — one enclosing env-slot binding visible at a
+/// direct-`eval(...)` call site, captured at compile time so the
+/// eval'd source can resolve it against the caller's runtime
+/// environment. Only *env-slot* bindings are captured: a free name
+/// the eval body doesn't find here falls through to `lda_global`
+/// (which resolves top-level `let` / `const` / `var` and builtins by
+/// name), so globals need no snapshot entry. `name` borrows from the
+/// chunk's source text (realm-lifetime).
+pub const DirectEvalBinding = struct {
+    name: []const u8,
+    /// Compile-time function-nesting depth of the binding (as in
+    /// `scope.Binding.env_depth`). The eval compiler emits
+    /// `lda_env [caller_env_depth + 1 - env_depth] [env_slot]` — the
+    /// `+1` accounts for the eval body's own environment sitting one
+    /// level below the caller's innermost env at runtime.
+    env_depth: u8,
+    env_slot: u8,
+    kind: BindingKind,
+    is_fn_expr_name: bool = false,
+    is_using: bool = false,
+};
+
+/// §19.2.1 direct eval — the lexical snapshot captured at one
+/// direct-`eval(...)` call site. Indexed by the `direct_eval` opcode's
+/// scope operand.
+pub const DirectEvalScope = struct {
+    /// Visible env-slot bindings, innermost-first (so the first match
+    /// per name shadows correctly when reconstructed).
+    bindings: []const DirectEvalBinding,
+    /// The caller's compile-time `env_depth` at the eval call site —
+    /// drives the runtime depth offset (see `DirectEvalBinding`).
+    caller_env_depth: u8,
+};
+
 pub const Chunk = struct {
     code: []const u8,
     constants: []const Value,
@@ -354,6 +389,11 @@ pub const Chunk = struct {
     handlers: []const Handler,
     function_templates: []FunctionTemplate,
     class_templates: []ClassTemplate,
+    /// §19.2.1 direct-eval scope snapshots — one per `direct_eval`
+    /// opcode emit, indexed by its scope operand. Empty for chunks
+    /// with no direct `eval(...)` call sites (the overwhelming
+    /// majority). See `DirectEvalScope`.
+    direct_eval_scopes: []const DirectEvalScope = &.{},
     register_count: u8,
     /// Module base URL. Used by `module_load` to
     /// resolve relative specifiers. `null` for non-module
@@ -416,6 +456,11 @@ pub const Chunk = struct {
         allocator.free(self.function_templates);
         for (self.class_templates) |*t| t.deinit(allocator);
         allocator.free(self.class_templates);
+        // §19.2.1 — free the per-call-site direct-eval snapshots. The
+        // `name` slices inside each binding borrow source text (not
+        // owned); only the binding slices + the outer slice are freed.
+        for (self.direct_eval_scopes) |s| allocator.free(s.bindings);
+        allocator.free(self.direct_eval_scopes);
         allocator.free(self.inline_caches);
         allocator.free(self.inline_call_caches);
         for (self.literal_shape_templates) |*t| allocator.free(t.keys);
@@ -435,6 +480,9 @@ pub const Builder = struct {
     function_templates: std.ArrayListUnmanaged(FunctionTemplate) = .empty,
     class_templates: std.ArrayListUnmanaged(ClassTemplate) = .empty,
     literal_shape_templates: std.ArrayListUnmanaged(LiteralShapeTemplate) = .empty,
+    /// §19.2.1 direct-eval scope snapshots, surfaced on the finished
+    /// `Chunk` as `.direct_eval_scopes`. See `DirectEvalScope`.
+    direct_eval_scopes: std.ArrayListUnmanaged(DirectEvalScope) = .empty,
     register_count: u8 = 0,
     /// Surfaced on the finished `Chunk` as `.is_async_module`.
     /// Set by `compileModuleAsChunk` after walking the body's
@@ -473,6 +521,8 @@ pub const Builder = struct {
         self.class_templates.deinit(self.allocator);
         for (self.literal_shape_templates.items) |*t| self.allocator.free(t.keys);
         self.literal_shape_templates.deinit(self.allocator);
+        for (self.direct_eval_scopes.items) |s| self.allocator.free(s.bindings);
+        self.direct_eval_scopes.deinit(self.allocator);
     }
 
     pub fn addHandler(self: *Builder, h: Handler) !void {
@@ -488,6 +538,18 @@ pub const Builder = struct {
         }
         const k: u16 = @intCast(self.function_templates.items.len);
         try self.function_templates.append(self.allocator, t);
+        return k;
+    }
+
+    /// §19.2.1 — register a direct-eval scope snapshot, returning its
+    /// index for the `direct_eval` opcode's scope operand. Takes
+    /// ownership of `s.bindings` (freed at chunk/builder teardown).
+    pub fn addDirectEvalScope(self: *Builder, s: DirectEvalScope) !u16 {
+        if (self.direct_eval_scopes.items.len == std.math.maxInt(u16)) {
+            return error.TooManyFunctions;
+        }
+        const k: u16 = @intCast(self.direct_eval_scopes.items.len);
+        try self.direct_eval_scopes.append(self.allocator, s);
         return k;
     }
 
@@ -748,6 +810,7 @@ pub const Builder = struct {
             .function_templates = try self.function_templates.toOwnedSlice(self.allocator),
             .class_templates = try self.class_templates.toOwnedSlice(self.allocator),
             .literal_shape_templates = try self.literal_shape_templates.toOwnedSlice(self.allocator),
+            .direct_eval_scopes = try self.direct_eval_scopes.toOwnedSlice(self.allocator),
             .register_count = self.register_count,
             .is_async_module = self.is_async_module,
             .global_lexical_base = self.global_lexical_base,

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -225,6 +225,16 @@ pub const Compiler = struct {
     /// production engine. Free references resolve via `lda_global`
     /// regardless.
     eval_scope: bool = false,
+    /// §19.2.1.3 strict eval — when true, the eval body binds ALL its
+    /// top-level declarations in its own environment (var / function
+    /// included, not only let / const), so eval'd `var x` /
+    /// `function f` never escape to the global env. Set for indirect +
+    /// direct eval (both strict, since Cynic is strict-only). NOT set
+    /// for `ShadowRealm.prototype.evaluate` (that's Script evaluation —
+    /// var DOES target the shadow realm's global env and persists
+    /// across calls, §3.8.3.7) or for ordinary scripts. Reuses the
+    /// same non-global binding path modules already take.
+    eval_local: bool = false,
     /// §9.4.6.7 Module Namespace [[Get]] live binding propagation —
     /// maps a module-local binding name to the namespace key(s) it
     /// is exported under. Populated by `compileModuleAsChunk` from
@@ -476,7 +486,10 @@ pub const Compiler = struct {
         // (step 6, varEnv = [[GlobalEnv]]), so they persist across
         // evaluations and surface on globalThis. So `eval_scope`
         // suppresses the global path only for the lexical kinds.
-        const is_global = target.kind == .script and !self.is_module and
+        // §19.2.1.3 — strict eval (`eval_local`) binds every top-level
+        // kind in its own environment, so var / function are non-global
+        // too (not just the lex kinds `eval_scope` already localizes).
+        const is_global = target.kind == .script and !self.is_module and !self.eval_local and
             !(self.eval_scope and kind != .var_);
         const slot: u8 = if (is_global) 0 else try self.newEnvSlot();
         // Slot-indexed global-lexical access: a top-level script
@@ -12610,7 +12623,7 @@ pub fn compileScriptAsChunk(
     source: []const u8,
     diagnostics: ?*Diagnostics,
 ) CompileError!Chunk {
-    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, false, null, 0);
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, false, null, 0, false);
 }
 
 /// Compile eval code (§3.8.3.7 PerformShadowRealmEval today; the
@@ -12634,8 +12647,12 @@ pub fn compileEvalAsChunk(
     program: *const ast.program.Program,
     source: []const u8,
     diagnostics: ?*Diagnostics,
+    /// §19.2.1.3 — `true` for real indirect `eval` (strict eval: var /
+    /// function bind eval-locally); `false` for `ShadowRealm.evaluate`
+    /// (Script evaluation: var → the shadow realm's global env).
+    eval_local: bool,
 ) CompileError!Chunk {
-    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, null, 0);
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, null, 0, eval_local);
 }
 
 /// §19.2.1 direct eval — compile `program` as eval code whose free
@@ -12657,7 +12674,9 @@ pub fn compileDirectEvalAsChunk(
     caller_scope: ?*Scope,
     start_env_depth: u8,
 ) CompileError!Chunk {
-    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, caller_scope, start_env_depth);
+    // Direct eval is always strict eval (§19.2.1.3): top-level var /
+    // function bind in the eval body's own env, not the caller's.
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, caller_scope, start_env_depth, true);
 }
 
 fn compileScriptLikeChunk(
@@ -12674,12 +12693,17 @@ fn compileScriptLikeChunk(
     /// §19.2.1 direct eval — the eval body's starting env_depth
     /// (`caller_env_depth + 1`). `0` for scripts / indirect eval.
     start_env_depth: u8,
+    /// §19.2.1.3 strict eval — bind top-level var / function in the
+    /// eval body's own env (no leak to global). `false` for scripts
+    /// and ShadowRealm-style script evaluation.
+    eval_local: bool,
 ) CompileError!Chunk {
     var c = Compiler.init(allocator, realm, source);
     errdefer c.deinit();
     defer c.class_stack.deinit(c.allocator);
     defer c.pending_labels.deinit(c.allocator);
     c.diagnostics = diagnostics;
+    c.eval_local = eval_local;
     c.eval_scope = eval_scope;
 
     var script_scope: Scope = .{ .parent = direct_eval_parent, .kind = .script };

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -46,6 +46,7 @@ const Span = @import("../source.zig").Span;
 const Op = @import("op.zig").Op;
 const Builder = @import("chunk.zig").Builder;
 const Chunk = @import("chunk.zig").Chunk;
+const chunk_mod = @import("chunk.zig");
 const Handler = @import("chunk.zig").Handler;
 const scope_mod = @import("scope.zig");
 const Scope = scope_mod.Scope;
@@ -3656,6 +3657,23 @@ pub const Compiler = struct {
             return self.compileSpreadCall(c);
         }
 
+        // §19.2.1 direct eval — the callee is the bare identifier
+        // `eval` resolving to no in-scope binding (so it names the
+        // global %eval%, not a user shadow). Emit `direct_eval` with a
+        // snapshot of the enclosing env-slot bindings so the eval'd
+        // source can read the caller's locals. A non-optional call
+        // only — `eval?.(x)` / `eval(...x)` fall through to an ordinary
+        // (indirect) call, which is the spec-observable result anyway
+        // when those forms don't produce the direct-eval reference.
+        if (!c.optional and c.callee.* == .identifier_reference) {
+            const id_span = c.callee.identifier_reference.span;
+            const callee_name = self.source[id_span.start..id_span.end];
+            if (std.mem.eql(u8, callee_name, "eval")) {
+                const shadowed = if (self.scope) |s| s.resolve("eval") != null else false;
+                if (!shadowed) return self.compileDirectEvalCall(c);
+            }
+        }
+
         // Compile callee → acc, save in a temp.
         try self.compileExpression(c.callee);
         // §13.5.5 — `f?.(args)` short-circuits when `f` is nullish.
@@ -3685,6 +3703,71 @@ pub const Compiler = struct {
         try self.builder.emitU8(r_callee);
         try self.builder.emitU8(@intCast(c.arguments.len));
 
+        var j: u8 = 0;
+        while (j < reserved) : (j += 1) self.releaseTemp();
+        self.releaseTemp(); // r_callee
+    }
+
+    /// §19.2.1 direct eval — emit the `direct_eval` opcode with a
+    /// snapshot of the enclosing env-slot bindings. Called from
+    /// `compileCall` when the callee is the bare identifier `eval`
+    /// resolving to no in-scope binding. The runtime re-checks the
+    /// callee value is actually this realm's %eval% and otherwise
+    /// falls back to an ordinary call.
+    fn compileDirectEvalCall(self: *Compiler, c: ast.expression.CallExpr) CompileError!void {
+        // Capture visible env-slot bindings, innermost-first, deduped
+        // by name (innermost shadows). Globals / register-promoted /
+        // import bindings are skipped — a free name the eval body
+        // can't find here falls through to `lda_global`, which
+        // resolves top-level `let` / `const` / `var` and builtins.
+        var snap: std.ArrayListUnmanaged(chunk_mod.DirectEvalBinding) = .empty;
+        defer snap.deinit(self.allocator);
+        var seen: std.StringHashMapUnmanaged(void) = .empty;
+        defer seen.deinit(self.allocator);
+        var cursor: ?*Scope = self.scope;
+        while (cursor) |s| : (cursor = s.parent) {
+            for (s.bindings.items) |b| {
+                if (b.is_global or b.is_register or b.is_import) continue;
+                const gop = try seen.getOrPut(self.allocator, b.name);
+                if (gop.found_existing) continue;
+                try snap.append(self.allocator, .{
+                    .name = b.name,
+                    .env_depth = b.env_depth,
+                    .env_slot = b.env_slot,
+                    .kind = b.kind,
+                    .is_fn_expr_name = b.is_fn_expr_name,
+                    .is_using = b.is_using,
+                });
+            }
+        }
+        const bindings = try self.allocator.dupe(chunk_mod.DirectEvalBinding, snap.items);
+        const scope_k = self.builder.addDirectEvalScope(.{
+            .bindings = bindings,
+            .caller_env_depth = self.env_depth,
+        }) catch |err| {
+            self.allocator.free(bindings);
+            return err;
+        };
+
+        // Stage the callee + args exactly like `call`: compile the
+        // `eval` reference (→ `lda_global "eval"`) into r_callee, then
+        // each arg into consecutive temps `r_callee+1 ..`.
+        try self.compileExpression(c.callee);
+        const r_callee = try self.reserveTemp();
+        try self.builder.emitOp(.star, c.span);
+        try self.builder.emitU8(r_callee);
+        var reserved: u8 = 0;
+        for (c.arguments) |*arg| {
+            try self.compileExpression(arg);
+            const r = try self.reserveTemp();
+            reserved += 1;
+            try self.builder.emitOp(.star, c.span);
+            try self.builder.emitU8(r);
+        }
+        try self.builder.emitOp(.direct_eval, c.span);
+        try self.builder.emitU16(scope_k);
+        try self.builder.emitU8(r_callee);
+        try self.builder.emitU8(@intCast(c.arguments.len));
         var j: u8 = 0;
         while (j < reserved) : (j += 1) self.releaseTemp();
         self.releaseTemp(); // r_callee
@@ -12527,7 +12610,7 @@ pub fn compileScriptAsChunk(
     source: []const u8,
     diagnostics: ?*Diagnostics,
 ) CompileError!Chunk {
-    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, false);
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, false, null, 0);
 }
 
 /// Compile eval code (§3.8.3.7 PerformShadowRealmEval today; the
@@ -12552,7 +12635,29 @@ pub fn compileEvalAsChunk(
     source: []const u8,
     diagnostics: ?*Diagnostics,
 ) CompileError!Chunk {
-    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true);
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, null, 0);
+}
+
+/// §19.2.1 direct eval — compile `program` as eval code whose free
+/// references resolve against the caller's lexical environment.
+/// `caller_scope` is a synthetic outer scope reconstructed from the
+/// `direct_eval` snapshot (its bindings carry the caller's env_depths
+/// / env_slots); `start_env_depth` is `caller_env_depth + 1` so the
+/// eval body's own environment sits one level below the caller's
+/// innermost env at runtime (the eval frame's env is parented to the
+/// caller's — see the `direct_eval` opcode handler). Free names absent
+/// from `caller_scope` fall through to `lda_global` (top-level
+/// `let` / `const` / `var` + builtins).
+pub fn compileDirectEvalAsChunk(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    program: *const ast.program.Program,
+    source: []const u8,
+    diagnostics: ?*Diagnostics,
+    caller_scope: ?*Scope,
+    start_env_depth: u8,
+) CompileError!Chunk {
+    return compileScriptLikeChunk(allocator, realm, program, source, diagnostics, true, caller_scope, start_env_depth);
 }
 
 fn compileScriptLikeChunk(
@@ -12562,6 +12667,13 @@ fn compileScriptLikeChunk(
     source: []const u8,
     diagnostics: ?*Diagnostics,
     eval_scope: bool,
+    /// §19.2.1 direct eval — synthetic outer scope (the caller's
+    /// captured bindings) parented under the eval body, or `null` for
+    /// scripts and indirect eval (whose free refs resolve to globals).
+    direct_eval_parent: ?*Scope,
+    /// §19.2.1 direct eval — the eval body's starting env_depth
+    /// (`caller_env_depth + 1`). `0` for scripts / indirect eval.
+    start_env_depth: u8,
 ) CompileError!Chunk {
     var c = Compiler.init(allocator, realm, source);
     errdefer c.deinit();
@@ -12570,10 +12682,10 @@ fn compileScriptLikeChunk(
     c.diagnostics = diagnostics;
     c.eval_scope = eval_scope;
 
-    var script_scope: Scope = .{ .parent = null, .kind = .script };
+    var script_scope: Scope = .{ .parent = direct_eval_parent, .kind = .script };
     defer script_scope.deinit(c.allocator);
     c.scope = &script_scope;
-    c.env_depth = 0;
+    c.env_depth = start_env_depth;
     c.env_slot_count = 0;
 
     // §16.1.7 GlobalDeclarationInstantiation step 5-7 — validate

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -233,6 +233,25 @@ pub const Op = enum(u8) {
     /// extra IC isn't load-bearing. Falls back to ordinary
     /// `call_method` for exotic callees, same as `tail_call`.
     tail_call_method,
+    /// `[op] [scope:u16] [r_callee:u8] [argc:u8]` — §19.2.1 direct
+    /// eval. Emitted in place of `call` when the callee is the bare
+    /// syntactic identifier `eval` that resolves to no in-scope
+    /// binding (so it names the global %eval%). `scope` indexes
+    /// `Chunk.direct_eval_scopes` (the caller's captured env-slot
+    /// bindings); `r_callee` holds the resolved `eval` value, with
+    /// args at `r_callee+1 .. r_callee+argc`.
+    ///
+    /// Runtime: if the callee is NOT this realm's %eval% intrinsic
+    /// (e.g. `globalThis.eval` was reassigned), fall back to an
+    /// ordinary call. Otherwise §19.2.1: a non-String arg[0] is
+    /// returned unchanged; with the gate closed (`!allow_eval`) a
+    /// String arg is the SES policy SyntaxError; with the gate open
+    /// the source is compiled against a synthetic outer scope rebuilt
+    /// from `scope` and run in a fresh frame whose environment is
+    /// parented to the caller's, inheriting the caller's `this` /
+    /// `new.target` / home object (Cynic is strict-only, so eval'd
+    /// `var` / `let` stay in the eval body's own env per §19.2.1.3).
+    direct_eval,
     /// Load `this` from the current call frame into acc. Top-level
     /// `this` is `undefined` in strict mode (§10.2.1.2). Arrow
     /// functions inherit `this` from their captured frame; the
@@ -1135,6 +1154,7 @@ pub const Op = enum(u8) {
             .sta_env,
             => 2, // u8 + u8
             .tail_call_method => 3, // r_recv:u8 + r_callee:u8 + argc:u8
+            .direct_eval => 4, // scope:u16 + r_callee:u8 + argc:u8
             .sta_private, .super_set, .def_property => 3, // k:u16 + r_obj:u8
             .sta_property => 5, // k:u16 + r_obj:u8 + ic:u16 (inline-cache slot)
             .def_accessor => 4, // k:u16 + r_obj:u8 + is_setter:u8
@@ -1211,6 +1231,7 @@ pub const Op = enum(u8) {
             .new_call => "NewCall",
             .tail_call => "TailCall",
             .tail_call_method => "TailCallMethod",
+            .direct_eval => "DirectEval",
             .lda_this => "LdaThis",
             .lda_new_target => "LdaNewTarget",
             .instanceof_ => "InstanceOf",

--- a/src/root.zig
+++ b/src/root.zig
@@ -84,6 +84,7 @@ test {
     _ = @import("runtime/surface_audit_test.zig");
     _ = @import("runtime/annex_b_rejection_test.zig");
     _ = @import("runtime/eval_policy_test.zig");
+    _ = @import("runtime/eval_test.zig");
     _ = @import("runtime/realm_test.zig");
     _ = @import("runtime/module_test.zig");
     _ = @import("runtime/builtins/iterator.zig");

--- a/src/runtime/builtins/function.zig
+++ b/src/runtime/builtins/function.zig
@@ -125,18 +125,15 @@ pub fn installPrototypeMethods(realm: *Realm) !void {
 /// source compilation — aligns with SES / Hardened JavaScript.
 fn functionConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     if (args.len > 0) {
-        // §20.2.1.1.1 CreateDynamicFunction parses the source
-        // string and surfaces every early-error class — most
-        // notably §16.2.1.7 ImportMeta (`import.meta` outside a
-        // Module goal). Cynic permanently does not ship runtime
-        // source compilation (AGENTS.md), so we throw at the
-        // entry — but as a SyntaxError, matching the spec's
-        // observable completion when CreateDynamicFunction fails
-        // its parse step (test262
-        // `language/expressions/import.meta/syntax/goal-*-params-or-body.js`).
-        // Gated by `--allow=eval`: closed → policy SyntaxError; open →
-        // EvalError (enabled-but-unimplemented).
-        return @import("../intrinsics.zig").throwEvalUnsupported(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+        // §20.2.1.1.1 CreateDynamicFunction. Gated by `--allow=eval`:
+        // closed → SES policy SyntaxError (the spec-observable
+        // completion of a failed parse — test262
+        // `language/expressions/import.meta/syntax/goal-*-params-or-body.js`
+        // expects a SyntaxError); open → parse + build the function.
+        if (!realm.allow_eval) {
+            return @import("../intrinsics.zig").throwSyntaxError(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+        }
+        return createDynamicFunction(realm, this_value, args, .normal);
     }
     // §20.2.1.1 CreateDynamicFunction — the new function's realm is
     // the *constructor's* realm, not necessarily the active running
@@ -574,9 +571,9 @@ fn boundFunctionTrampoline(realm: *Realm, this_value: Value, args: []const Value
 /// would compile a string source — that's later); the
 /// intrinsics exist so introspection tests pass.
 pub fn installVariantPrototypes(realm: *Realm) !void {
-    realm.intrinsics.generator_function_prototype = try installVariantCtor(realm, "GeneratorFunction");
-    realm.intrinsics.async_function_prototype = try installVariantCtor(realm, "AsyncFunction");
-    realm.intrinsics.async_generator_function_prototype = try installVariantCtor(realm, "AsyncGeneratorFunction");
+    realm.intrinsics.generator_function_prototype = try installVariantCtor(realm, "GeneratorFunction", generatorFunctionConstructor);
+    realm.intrinsics.async_function_prototype = try installVariantCtor(realm, "AsyncFunction", asyncFunctionConstructor);
+    realm.intrinsics.async_generator_function_prototype = try installVariantCtor(realm, "AsyncGeneratorFunction", asyncGeneratorFunctionConstructor);
 }
 
 /// §27.3.4.3 GeneratorFunction.prototype.prototype = %GeneratorPrototype%
@@ -629,8 +626,8 @@ pub fn wireVariantInstancePrototypes(realm: *Realm) !void {
     }
 }
 
-fn installVariantCtor(realm: *Realm, name: []const u8) !*JSObject {
-    const fn_obj = try realm.heap.allocateFunctionNative(realm, variantCtorThrows, 1, name);
+fn installVariantCtor(realm: *Realm, name: []const u8, native: @import("../function.zig").NativeFn) !*JSObject {
+    const fn_obj = try realm.heap.allocateFunctionNative(realm, native, 1, name);
     fn_obj.proto = realm.intrinsics.function_prototype;
     // §27.3.1 / §27.4.1 / §27.7.1 — GeneratorFunction /
     // AsyncGeneratorFunction / AsyncFunction are subclasses of
@@ -681,21 +678,133 @@ fn installVariantCtor(realm: *Realm, name: []const u8) !*JSObject {
     return proto;
 }
 
-fn variantCtorThrows(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+/// §20.2.1.1.1 step 1 — the four function flavours CreateDynamicFunction
+/// builds, distinguished by the source-prefix keyword and the parse
+/// goal. Each variant constructor (`GeneratorFunction` etc.) routes to
+/// `createDynamicFunction` with its kind so the synthesized source uses
+/// the right `function` / `function*` / `async function` /
+/// `async function*` prefix.
+const DynamicFunctionKind = enum {
+    normal,
+    generator,
+    async_,
+    async_generator,
+
+    /// The leading keyword(s) for the synthesized
+    /// `(<prefix> anonymous(P) {B})` wrapper.
+    fn sourcePrefix(self: DynamicFunctionKind) []const u8 {
+        return switch (self) {
+            .normal => "function",
+            .generator => "function*",
+            .async_ => "async function",
+            .async_generator => "async function*",
+        };
+    }
+};
+
+fn generatorFunctionConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return variantConstructor(realm, this_value, args, .generator);
+}
+fn asyncFunctionConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return variantConstructor(realm, this_value, args, .async_);
+}
+fn asyncGeneratorFunctionConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+    return variantConstructor(realm, this_value, args, .async_generator);
+}
+
+/// Shared body for the `GeneratorFunction` / `AsyncFunction` /
+/// `AsyncGeneratorFunction` string constructors (§27.3.2 / §27.7.2 /
+/// §27.4.2 — each defers to §20.2.1.1.1 CreateDynamicFunction). Gated
+/// by `--allow=eval`: closed → SES policy SyntaxError (matching the
+/// spec-observable completion of the failed parse step, incl. §16.2.1.7
+/// ImportMeta outside a Module goal — test262
+/// `language/expressions/import.meta/syntax/goal-{generator,async-function,async-generator}-params-or-body.js`);
+/// open → parse + build the function.
+fn variantConstructor(realm: *Realm, this_value: Value, args: []const Value, kind: DynamicFunctionKind) NativeError!Value {
+    if (!realm.allow_eval) {
+        return @import("../intrinsics.zig").throwSyntaxError(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+    }
+    return createDynamicFunction(realm, this_value, args, kind);
+}
+
+/// §20.2.1.1.1 CreateDynamicFunction ( constructor, newTarget, kind,
+/// args ). Cynic implements the spec by *source synthesis*: it joins
+/// the parameter strings, appends the body, wraps them in a
+/// parenthesized function expression with the kind's prefix, and runs
+/// the wrapper through the eval pipeline (`evaluateEval`) — whose
+/// completion value is the function object. The new function's scope
+/// is therefore the global environment (§20.2.1.1.1 step 30: scope =
+/// realm.[[GlobalEnv]]), which is exactly what eval-as-global-code
+/// produces. Cynic is strict-only, so the body parses as strict code.
+///
+/// Caller has already confirmed `realm.allow_eval`. A parse failure
+/// surfaces as the SyntaxError CreateDynamicFunction's Parse step
+/// raises (§20.2.1.1.1 step 25/27). The function's [[Realm]] is the
+/// constructor's realm (cross-realm `new other.Function(...)`), tracked
+/// via `active_native_fn_realm`.
+fn createDynamicFunction(realm: *Realm, this_value: Value, args: []const Value, kind: DynamicFunctionKind) NativeError!Value {
     _ = this_value;
-    _ = args;
-    // Calling `GeneratorFunction("…")` / `AsyncFunction("…")` /
-    // `AsyncGeneratorFunction("…")` would invoke
-    // CreateDynamicFunction (§20.2.1.1.1) to parse the source,
-    // which surfaces every early-error class as a SyntaxError —
-    // including §16.2.1.7 ImportMeta outside a Module goal
-    // (test262
-    // `language/expressions/import.meta/syntax/goal-{generator,async-function,async-generator}-params-or-body.js`).
-    // Cynic ships no runtime source compilation; gated by
-    // `--allow=eval` (`realm.allow_eval`): closed → policy
-    // SyntaxError (matches the spec-observable completion of the
-    // failed parse step); open → EvalError (enabled-but-unimplemented).
-    return @import("../intrinsics.zig").throwEvalUnsupported(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+    const ctor_realm = realm.active_native_fn_realm orelse realm;
+
+    // §20.2.1.1.1 steps 8-16 — split args into parameter strings (all
+    // but the last) and the body (the last, or "" when no args). Each
+    // is coerced via §7.1.17 ToString (`stringifyArg`), which throws
+    // TypeError on a Symbol and fires a user `toString` per spec.
+    const body_str: []const u8 = if (args.len == 0)
+        ""
+    else
+        (try intrinsics.stringifyArg(realm, args[args.len - 1])).flatBytes();
+
+    // Build the comma-joined parameter list from args[0 .. len-1].
+    var params_buf: std.ArrayListUnmanaged(u8) = .empty;
+    defer params_buf.deinit(realm.allocator);
+    if (args.len > 1) {
+        for (args[0 .. args.len - 1], 0..) |p, i| {
+            if (i > 0) params_buf.append(realm.allocator, ',') catch return error.OutOfMemory;
+            const ps = try intrinsics.stringifyArg(realm, p);
+            params_buf.appendSlice(realm.allocator, ps.flatBytes()) catch return error.OutOfMemory;
+        }
+    }
+
+    // §20.2.1.1.1 step 22 — assemble the source. The wrapping parens
+    // make it an expression whose completion value is the function.
+    // Newlines isolate a `// line comment` or unterminated token in
+    // the param list / body from the surrounding braces, matching the
+    // spec's exact bracketing (`function anonymous(<P>\n) {\n<B>\n}`).
+    // The buffer must outlive the function (its template borrows a
+    // slice for `Function.prototype.toString`), so it's handed to the
+    // realm's `eval_sources` for teardown rather than freed here.
+    const wrapper = std.fmt.allocPrint(
+        ctor_realm.allocator,
+        "({s} anonymous({s}\n) {{\n{s}\n}})",
+        .{ kind.sourcePrefix(), params_buf.items, body_str },
+    ) catch return error.OutOfMemory;
+    defer ctor_realm.allocator.free(wrapper);
+    const source = ctor_realm.retainEvalSource(wrapper) catch return error.OutOfMemory;
+
+    // §20.2.1.1.1 steps 24-29 — Parse + evaluate the wrapper in the
+    // constructor's realm. A parse failure is a SyntaxError.
+    const result = lantern.evaluateEval(ctor_realm.allocator, ctor_realm, source) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        error.ParseError, error.CompileError => return @import("../intrinsics.zig").throwSyntaxError(realm, "Function constructor: SyntaxError in synthesized source"),
+        error.InvalidOpcode => return error.OutOfMemory,
+    };
+    const fn_val = switch (result) {
+        .value, .yielded => |v| v,
+        .thrown => |ex| {
+            realm.pending_exception = ex;
+            return error.NativeThrew;
+        },
+    };
+
+    // The wrapper's completion is the function expression's value.
+    // Defensive: a non-function completion would be an engine bug.
+    const fn_obj = heap_mod.valueAsFunction(fn_val) orelse {
+        return throwTypeError(realm, "Function constructor: synthesized source did not produce a function");
+    };
+    // §20.2.1.1.1 step 28 — the function's name is "anonymous". The
+    // `function anonymous` form already named it; nothing more to do.
+    return heap_mod.taggedFunction(fn_obj);
 }
 
 // ── Function.prototype.toString ─────────────────────────────────────────────

--- a/src/runtime/builtins/function.zig
+++ b/src/runtime/builtins/function.zig
@@ -125,13 +125,13 @@ pub fn installPrototypeMethods(realm: *Realm) !void {
 /// source compilation — aligns with SES / Hardened JavaScript.
 fn functionConstructor(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     if (args.len > 0) {
-        // §20.2.1.1.1 CreateDynamicFunction. Gated by `--allow=eval`:
-        // closed → SES policy SyntaxError (the spec-observable
-        // completion of a failed parse — test262
-        // `language/expressions/import.meta/syntax/goal-*-params-or-body.js`
-        // expects a SyntaxError); open → parse + build the function.
+        // §20.2.1.1.1 CreateDynamicFunction step 3 calls
+        // HostEnsureCanCompileStrings BEFORE the Parse step. Gated by
+        // `--allow=eval`: closed → host refusal (EvalError, matching
+        // Node + browser CSP); open → parse + build the function (a
+        // genuine parse failure is then a SyntaxError).
         if (!realm.allow_eval) {
-            return @import("../intrinsics.zig").throwSyntaxError(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+            return @import("../intrinsics.zig").throwEvalError(realm, @import("../intrinsics.zig").eval_disabled_msg);
         }
         return createDynamicFunction(realm, this_value, args, .normal);
     }
@@ -715,14 +715,13 @@ fn asyncGeneratorFunctionConstructor(realm: *Realm, this_value: Value, args: []c
 /// Shared body for the `GeneratorFunction` / `AsyncFunction` /
 /// `AsyncGeneratorFunction` string constructors (§27.3.2 / §27.7.2 /
 /// §27.4.2 — each defers to §20.2.1.1.1 CreateDynamicFunction). Gated
-/// by `--allow=eval`: closed → SES policy SyntaxError (matching the
-/// spec-observable completion of the failed parse step, incl. §16.2.1.7
-/// ImportMeta outside a Module goal — test262
-/// `language/expressions/import.meta/syntax/goal-{generator,async-function,async-generator}-params-or-body.js`);
-/// open → parse + build the function.
+/// by `--allow=eval`: closed → host refusal (EvalError, §19.2.1.2
+/// HostEnsureCanCompileStrings, matching Node + browser CSP); open →
+/// parse + build the function (a genuine parse failure — e.g. §16.2.1.7
+/// ImportMeta outside a Module goal — is then a SyntaxError).
 fn variantConstructor(realm: *Realm, this_value: Value, args: []const Value, kind: DynamicFunctionKind) NativeError!Value {
     if (!realm.allow_eval) {
-        return @import("../intrinsics.zig").throwSyntaxError(realm, "Function constructor from source string is not supported (Cynic ships no eval / runtime code construction)");
+        return @import("../intrinsics.zig").throwEvalError(realm, @import("../intrinsics.zig").eval_disabled_msg);
     }
     return createDynamicFunction(realm, this_value, args, kind);
 }

--- a/src/runtime/eval_policy_test.zig
+++ b/src/runtime/eval_policy_test.zig
@@ -77,11 +77,11 @@ test "ses-eval: new Function(string) throws" {
     // `Function` IS shipped as a constructor for the
     // binding-friendly bound-function shape (so `Function.
     // prototype.bind(...)` and friends work), but the string-
-    // body construction path is the SES carve-out per
-    // AGENTS.md. The throw class is currently SyntaxError (the
-    // CreateDynamicFunction parse step fails before the spec's
-    // TypeError gate runs); the observable guarantee for the
-    // policy commitment is just "the call does not return".
+    // body construction path is gated by `--allow=eval` per
+    // AGENTS.md. With the gate closed the throw class is EvalError
+    // (§19.2.1.2 HostEnsureCanCompileStrings host refusal — see
+    // `eval_test.zig` for the type-pinning tests); the guarantee
+    // for the policy commitment is just "the call does not return".
     try expectAbsent(
         \\let ok = 0;
         \\try {

--- a/src/runtime/eval_policy_test.zig
+++ b/src/runtime/eval_policy_test.zig
@@ -125,30 +125,21 @@ fn expectAbsentAllowEval(source: []const u8) !void {
     if (v.asInt32() != 1) return error.EvalPolicyFeatureUnexpectedlyPresent;
 }
 
-test "ses-eval: --allow=eval opens the gate but eval still throws (unimplemented)" {
-    // The `--allow=eval` flag wires the *posture*, not an eval
-    // engine: Cynic deliberately ships no runtime code construction
-    // (see AGENTS.md / docs/ses-alignment.md). With the gate open,
-    // `eval("1")` no longer refuses by SES policy — it throws an
-    // EvalError flagging the capability as enabled-but-unimplemented.
-    // The observable guarantee is still "the call does not return
-    // normally", so no string source ever executes regardless of the
-    // flag. (When the eval engine lands, this test flips to assert a
-    // real result.)
+test "ses-eval: --allow=eval opens the gate and eval evaluates" {
+    // `--allow=eval` opens the SES policy gate AND the eval engine is
+    // now implemented (§19.2.1), so `eval("1")` returns 1 rather than
+    // refusing. The positive engine behaviour is covered in depth by
+    // `eval_test.zig`; this pins the policy *transition* — the same
+    // realm that refuses with the gate closed (above) now runs source.
     try expectAbsentAllowEval(
-        \\let ok = 0;
-        \\try { eval("1"); } catch (e) { ok = (e instanceof EvalError) ? 1 : 0; }
-        \\ok;
+        \\eval("1");
     );
 }
 
-test "ses-eval: --allow=eval gate is still closed for Function(string)" {
-    // Same posture for the dynamic Function constructor: the gate
-    // opens but the string-body path is unimplemented, so it throws
-    // (EvalError) rather than compiling source.
+test "ses-eval: --allow=eval enables the dynamic Function constructor" {
+    // §20.2.1.1.1 CreateDynamicFunction — with the gate open,
+    // `new Function("return 1")()` builds + invokes a real function.
     try expectAbsentAllowEval(
-        \\let ok = 0;
-        \\try { new Function("return 1"); } catch (e) { ok = (e instanceof EvalError) ? 1 : 0; }
-        \\ok;
+        \\new Function("return 1")();
     );
 }

--- a/src/runtime/eval_test.zig
+++ b/src/runtime/eval_test.zig
@@ -1,0 +1,189 @@
+//! Positive coverage for the `--allow=eval` runtime-code-construction
+//! engine (§19.2.1 PerformEval, §20.2.1.1.1 CreateDynamicFunction).
+//!
+//! Sibling `eval_policy_test.zig` pins the *refusal* surface — the
+//! default (gate-closed) SES posture where `eval` / `Function(string)`
+//! throw, and the gate-open-but-stubbed transition. This file is the
+//! complement: with `realm.allow_eval = true` AND a real eval engine,
+//! the eval surface must actually execute source.
+//!
+//! Cynic parses all source as strict, so every eval is a strict eval
+//! (§19.2.1.3): the eval'd code gets its own declarative + variable
+//! environment and never injects `var` / function bindings into the
+//! caller's scope. Direct eval still resolves free identifiers against
+//! the caller's lexical environment for reads (and inherits the
+//! caller's `this` / `new.target`).
+
+const std = @import("std");
+const testing = std.testing;
+
+const Realm = @import("realm.zig").Realm;
+const lantern = @import("lantern/interpreter.zig");
+const Value = @import("value.zig").Value;
+
+/// Evaluate `source` against a realm with the eval gate open and
+/// return the completion value. A thrown completion is surfaced as a
+/// Zig error so a test asserting a value never silently passes on a
+/// throw.
+fn evalAllow(source: []const u8) !Value {
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.allow_eval = true;
+    try realm.installBuiltins();
+    const outcome = try lantern.evaluateScript(testing.allocator, &realm, source);
+    return switch (outcome) {
+        .value, .yielded => |v| v,
+        .thrown => error.EvalThrewUnexpectedly,
+    };
+}
+
+/// Evaluate `source` and assert the completion is the int32 `want`.
+fn expectIntAllow(source: []const u8, want: i32) !void {
+    const v = try evalAllow(source);
+    if (!v.isInt32()) {
+        std.debug.print("expected int32 {d}, got non-int value\n", .{want});
+        return error.EvalResultNotInt;
+    }
+    try testing.expectEqual(want, v.asInt32());
+}
+
+// ── §19.2.1 indirect eval ───────────────────────────────────────────
+
+test "eval: indirect (0,eval) evaluates as global code" {
+    // `(0, eval)(s)` is the canonical indirect form — the callee is
+    // the %eval% value but NOT the syntactic `eval(...)` reference,
+    // so §19.2.1.1 runs `s` as global-scope code.
+    try expectIntAllow("(0, eval)('1 + 1')", 2);
+}
+
+test "eval: indirect via globalThis.eval" {
+    try expectIntAllow("globalThis.eval('40 + 2')", 42);
+}
+
+test "eval: completion value is the last expression" {
+    // §19.2.1 returns the script's completion value; a trailing
+    // declaration has empty completion (undefined), an expression
+    // statement carries its value.
+    try expectIntAllow("eval('var a = 3; a * a')", 9);
+}
+
+test "eval: non-string argument returns unchanged" {
+    // §19.2.1 step 2 — a non-String argument is returned as-is even
+    // with the gate open.
+    try expectIntAllow("eval(123)", 123);
+}
+
+test "eval: nested eval" {
+    try expectIntAllow("eval('eval(\"2 + 5\")')", 7);
+}
+
+// ── §20.2.1.1.1 CreateDynamicFunction ───────────────────────────────
+
+test "Function: string constructor builds a callable" {
+    try expectIntAllow("new Function('a', 'b', 'return a + b')(2, 3)", 5);
+}
+
+test "Function: call form (no new) builds a callable too" {
+    try expectIntAllow("Function('x', 'return x * x')(6)", 36);
+}
+
+test "Function: single combined parameter list" {
+    // §20.2.1.1.1 — the parameter strings are joined with commas, so
+    // a single `"a, b, c"` argument is equivalent to three.
+    try expectIntAllow("new Function('a, b, c', 'return a + b + c')(1, 2, 3)", 6);
+}
+
+test "Function: zero-arg body" {
+    try expectIntAllow("new Function('return 7')()", 7);
+}
+
+test "GeneratorFunction: string constructor yields" {
+    try expectIntAllow(
+        \\const GF = (function*(){}).constructor;
+        \\const g = new GF('yield 11; yield 22')();
+        \\g.next().value;
+    , 11);
+}
+
+test "AsyncFunction: string constructor returns a promise" {
+    // The async function returns a Promise; we just confirm the
+    // constructor builds + invokes without throwing and the result is
+    // an object (the Promise).
+    const v = try evalAllow(
+        \\const AF = (async function(){}).constructor;
+        \\const p = new AF('return 1')();
+        \\(typeof p === 'object' && p !== null) ? 1 : 0;
+    );
+    try testing.expect(v.isInt32() and v.asInt32() == 1);
+}
+
+// ── §19.2.1 direct eval ─────────────────────────────────────────────
+
+test "eval: direct reads a caller function local" {
+    // The acceptance criterion. `x` is a top-level `let` (global
+    // lexical), `y` is the IIFE's function local — direct eval must
+    // resolve both against the caller's environment.
+    try expectIntAllow(
+        \\let x = 1;
+        \\(function () { let y = 2; return eval('x + y'); })();
+    , 3);
+}
+
+test "eval: direct sees a caller var binding" {
+    try expectIntAllow(
+        \\function f() { var n = 10; return eval('n + 5'); }
+        \\f();
+    , 15);
+}
+
+test "eval: direct inherits caller this" {
+    // §19.2.1 — direct eval inherits the caller's `this` binding.
+    try expectIntAllow(
+        \\const obj = { v: 8, m() { return eval('this.v'); } };
+        \\obj.m();
+    , 8);
+}
+
+test "eval: reassigned globalThis.eval is an ordinary call, not direct" {
+    // §19.2.1.1 — direct eval requires the callee to be the %eval%
+    // intrinsic. Reassigning `globalThis.eval` to another function
+    // makes `eval(...)` an ordinary call to that value; the runtime
+    // identity check on the `direct_eval` opcode catches this and
+    // falls back. In strict-only Cynic this is the ONLY non-direct
+    // path — `eval` can't be a binding name (`const eval` / param
+    // `eval` are SyntaxErrors per §13.1.1), so a user can't shadow it
+    // lexically. Uses an unhardened realm so `globalThis` is writable.
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.allow_eval = true;
+    realm.hardened = false;
+    try realm.installBuiltins();
+    const outcome = try lantern.evaluateScript(testing.allocator, &realm,
+        \\globalThis.eval = function (s) { return 99; };
+        \\eval('this would SyntaxError as real eval ===');
+    );
+    const v = switch (outcome) {
+        .value, .yielded => |val| val,
+        .thrown => return error.EvalThrewUnexpectedly,
+    };
+    try testing.expect(v.isInt32() and v.asInt32() == 99);
+}
+
+// ── posture: gate stays closed by default (regression guard) ─────────
+
+test "eval: gate closed (default) still throws SyntaxError" {
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    // allow_eval defaults to false — no flip.
+    try realm.installBuiltins();
+    const outcome = try lantern.evaluateScript(testing.allocator, &realm,
+        \\let cls = 'none';
+        \\try { eval('1'); } catch (e) { cls = e.constructor.name; }
+        \\cls === 'SyntaxError' ? 1 : 0;
+    );
+    const v = switch (outcome) {
+        .value, .yielded => |val| val,
+        .thrown => return error.EvalGateClosedThrew,
+    };
+    try testing.expect(v.isInt32() and v.asInt32() == 1);
+}

--- a/src/runtime/eval_test.zig
+++ b/src/runtime/eval_test.zig
@@ -67,6 +67,36 @@ test "eval: completion value is the last expression" {
     try expectIntAllow("eval('var a = 3; a * a')", 9);
 }
 
+test "eval: strict eval var does not leak to the global env (direct)" {
+    // §19.2.1.3 — strict eval gets its own variable environment, so a
+    // top-level `var` binds locally and never escapes to the caller /
+    // global. It works inside the eval, then is gone afterward.
+    try expectIntAllow("eval('var a = 3; a * a')", 9);
+    try expectIntAllow(
+        \\eval('var leaked = 1;');
+        \\(typeof globalThis.leaked === 'undefined' && !('leaked' in globalThis)) ? 1 : 0;
+    , 1);
+}
+
+test "eval: strict eval var does not leak to the global env (indirect)" {
+    try expectIntAllow("(0, eval)('var b = 4; b * b')", 16);
+    try expectIntAllow(
+        \\(0, eval)('var leaked2 = 1;');
+        \\(typeof globalThis.leaked2 === 'undefined') ? 1 : 0;
+    , 1);
+}
+
+test "eval: function declared in eval does not leak to the global env" {
+    // A top-level function declaration in eval'd code is part of the
+    // eval's own variable environment, callable within the eval but
+    // not installed on globalThis (§19.2.1.3 strict eval).
+    try expectIntAllow("eval('function f(){ return 7; } f()')", 7);
+    try expectIntAllow(
+        \\eval('function g(){}');
+        \\(typeof globalThis.g === 'undefined') ? 1 : 0;
+    , 1);
+}
+
 test "eval: non-string argument returns unchanged" {
     // §19.2.1 step 2 — a non-String argument is returned as-is even
     // with the gate open.

--- a/src/runtime/eval_test.zig
+++ b/src/runtime/eval_test.zig
@@ -171,7 +171,13 @@ test "eval: reassigned globalThis.eval is an ordinary call, not direct" {
 
 // ── posture: gate stays closed by default (regression guard) ─────────
 
-test "eval: gate closed (default) still throws SyntaxError" {
+test "eval: gate closed (default) throws EvalError (host refusal)" {
+    // §19.2.1.2 HostEnsureCanCompileStrings — when the host refuses
+    // code generation from strings (eval off by default), the thrown
+    // value is host-defined. Cynic raises EvalError, matching Node's
+    // `--disallow-code-generation-from-strings` and browser CSP
+    // (`unsafe-eval` blocked). The refusal happens BEFORE parsing, so
+    // a non-string operand still returns unchanged (covered above).
     var realm = Realm.init(testing.allocator);
     defer realm.deinit();
     // allow_eval defaults to false — no flip.
@@ -179,11 +185,48 @@ test "eval: gate closed (default) still throws SyntaxError" {
     const outcome = try lantern.evaluateScript(testing.allocator, &realm,
         \\let cls = 'none';
         \\try { eval('1'); } catch (e) { cls = e.constructor.name; }
-        \\cls === 'SyntaxError' ? 1 : 0;
+        \\cls === 'EvalError' ? 1 : 0;
     );
     const v = switch (outcome) {
         .value, .yielded => |val| val,
         .thrown => return error.EvalGateClosedThrew,
+    };
+    try testing.expect(v.isInt32() and v.asInt32() == 1);
+}
+
+test "eval: gate closed Function(string) throws EvalError too" {
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    try realm.installBuiltins();
+    const outcome = try lantern.evaluateScript(testing.allocator, &realm,
+        \\let cls = 'none';
+        \\try { new Function('return 1'); } catch (e) { cls = e.constructor.name; }
+        \\cls === 'EvalError' ? 1 : 0;
+    );
+    const v = switch (outcome) {
+        .value, .yielded => |val| val,
+        .thrown => return error.EvalGateClosedThrew,
+    };
+    try testing.expect(v.isInt32() and v.asInt32() == 1);
+}
+
+test "eval: gate OPEN, genuine parse error still throws SyntaxError" {
+    // §19.2.1 step 11 — once the gate is open and compilation proceeds,
+    // a real parse failure in the evaluated source is a SyntaxError
+    // (NOT the EvalError host refusal). The two are distinct: refusal
+    // is a capability gate, SyntaxError is a parse outcome.
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.allow_eval = true;
+    try realm.installBuiltins();
+    const outcome = try lantern.evaluateScript(testing.allocator, &realm,
+        \\let cls = 'none';
+        \\try { eval('var = ;'); } catch (e) { cls = e.constructor.name; }
+        \\cls === 'SyntaxError' ? 1 : 0;
+    );
+    const v = switch (outcome) {
+        .value, .yielded => |val| val,
+        .thrown => return error.EvalGateOpenParseThrew,
     };
     try testing.expect(v.isInt32() and v.asInt32() == 1);
 }

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -2316,6 +2316,11 @@ pub const newEvalError = @import("builtins/error.zig").newEvalError;
 pub const PromiseState = @import("builtins/promise.zig").PromiseState;
 pub const allocatePromiseFor = @import("builtins/promise.zig").allocatePromiseFor;
 
+/// Host-refusal message shared by every gate-closed runtime-code-
+/// construction site (`eval`, the dynamic `Function` family, direct
+/// eval). Phrased like Node's `--disallow-code-generation-from-strings`.
+pub const eval_disabled_msg = "code generation from strings disallowed: eval is off (pass --allow=eval to enable)";
+
 /// §19.2.1 eval(x) — the global `eval` function object. The binding
 /// always exists on globalThis (so `typeof eval === "function"` and
 /// `eval === null` probes resolve), but its behaviour depends on the
@@ -2323,10 +2328,12 @@ pub const allocatePromiseFor = @import("builtins/promise.zig").allocatePromiseFo
 ///
 ///   • non-String argument → returned unchanged (§19.2.1 step 2),
 ///     regardless of posture.
-///   • gate closed (default) → a String argument is the SES policy
-///     refusal: SyntaxError (AGENTS.md "eval and runtime code
+///   • gate closed (default) → a String argument is the host refusal
+///     (§19.2.1.2 HostEnsureCanCompileStrings): EvalError, matching
+///     Node + browser CSP (AGENTS.md "eval and runtime code
 ///     construction").
-///   • gate open (`--allow=eval`) → a String argument is evaluated.
+///   • gate open (`--allow=eval`) → a String argument is evaluated;
+///     a genuine parse failure is then a SyntaxError (§19.2.1 step 11).
 ///
 /// This native is reached only for an **indirect** eval — the
 /// syntactic direct `eval(...)` form compiles to a dedicated
@@ -2343,8 +2350,11 @@ fn globalEval(realm: *Realm, this_value: Value, args: []const Value) NativeError
     // §19.2.1 step 2 — a non-String operand is returned unchanged.
     if (!arg.isString()) return arg;
     if (!realm.allow_eval) {
-        // Gate closed → SES policy refusal (unchanged default).
-        return throwSyntaxError(realm, "Cynic does not support eval() of source strings");
+        // §19.2.1.2 HostEnsureCanCompileStrings — the host refuses code
+        // generation from strings (default SES posture). The thrown
+        // value is host-defined; Cynic raises EvalError, matching Node's
+        // `--disallow-code-generation-from-strings` and browser CSP.
+        return throwEvalError(realm, eval_disabled_msg);
     }
     const s: *JSString = @ptrCast(@alignCast(arg.asString()));
     return performIndirectEval(realm, s.flatBytes());

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -49,6 +49,11 @@ pub const Intrinsics = struct {
     function_prototype: ?*JSObject = null,
     array_prototype: ?*JSObject = null,
     string_prototype: ?*JSObject = null,
+    /// §19.2.1 %eval% — the global `eval` function object. Recorded
+    /// so the `direct_eval` opcode can check whether the call's
+    /// resolved callee IS the intrinsic (a direct eval) or a user
+    /// value that shadowed `globalThis.eval` (an ordinary call).
+    eval_function: ?*JSFunction = null,
 
     error_constructor: ?*JSFunction = null,
     error_prototype: ?*JSObject = null,
@@ -469,12 +474,17 @@ pub fn install(realm: *Realm) !void {
     // globalThis though — Sputnik fixtures (S10.2.3_*) and the
     // strict-mode global-property tests do `eval === null` etc.,
     // which fail with ReferenceError if `eval` is not a property.
-    // Wire it as a throwing native (length 1, !construct) so
-    // `eval !== null` is true, `eval(...)` raises EvalError, and
-    // typeof eval === "function".
-    const eval_fn = try realm.heap.allocateFunctionNative(realm, globalEvalNotSupported, 1, "eval");
+    // Wire it as a native (length 1, !construct) so `eval !== null`
+    // is true and typeof eval === "function". Its String-argument
+    // behaviour is posture-gated (`--allow=eval`): closed → policy
+    // SyntaxError, open → indirect eval (§19.2.1.1). See `globalEval`.
+    const eval_fn = try realm.heap.allocateFunctionNative(realm, globalEval, 1, "eval");
     eval_fn.has_construct = false;
     try realm.globals.put(realm.allocator, "eval", heap_mod.taggedFunction(eval_fn));
+    // §19.2.1 — record the %eval% identity so the `direct_eval`
+    // opcode can distinguish a genuine direct eval from a call to a
+    // reassigned `globalThis.eval`.
+    realm.intrinsics.eval_function = eval_fn;
 
     // §19.1 — `undefined`, `NaN`, `Infinity` are frozen data
     // properties: `{ w:false, e:false, c:false }`. They were just
@@ -1526,33 +1536,15 @@ pub fn throwSyntaxError(realm: *Realm, msg: []const u8) NativeError {
     return throwNative(realm, ex);
 }
 
+/// Throw a real `EvalError(msg)` (§20.5.5.2) from a native. Parallel
+/// to `throwSyntaxError` / `throwRangeError`. The runtime-code-
+/// construction gate no longer routes through here — `eval` /
+/// `Function(string)` now check `realm.allow_eval` directly and either
+/// run (gate open) or raise the SES policy `SyntaxError` (gate closed)
+/// — but the thrower is retained as standard error-type infrastructure.
 pub fn throwEvalError(realm: *Realm, msg: []const u8) NativeError {
     const ex = newEvalError(realm, msg) catch return error.OutOfMemory;
     return throwNative(realm, ex);
-}
-
-/// Gate for the runtime-code-construction surface — `eval(string)`
-/// and the `Function` / `Generator…Function` / `Async…Function`
-/// string-source constructors. Cynic ships no eval engine; this
-/// decides *which* failure the caller observes based on the
-/// `--allow=eval` posture (`realm.allow_eval`):
-///
-///   - default (gate closed) → a `SyntaxError` with `disabled_msg`:
-///     the SES-aligned policy refusal (AGENTS.md "eval and runtime
-///     code construction"). Spec-flavored so probes that expect a
-///     parse-time failure see the right shape.
-///   - `--allow=eval` (gate open) → an `EvalError` flagging the
-///     capability as enabled-but-unimplemented. The posture flag
-///     wires up here; the actual eval engine is a separate effort
-///     (docs/ses-alignment.md §Phase 4), so the call still can't
-///     execute source — it just fails for a *different* reason,
-///     which the test262 harness scores as a real failure rather
-///     than a by-design refusal.
-pub fn throwEvalUnsupported(realm: *Realm, disabled_msg: []const u8) NativeError {
-    if (realm.allow_eval) {
-        return throwEvalError(realm, "runtime code construction is enabled (--allow=eval) but not implemented in this build");
-    }
-    return throwSyntaxError(realm, disabled_msg);
 }
 
 /// Convenience: throw a real `ReferenceError(msg)` from a native.
@@ -2324,20 +2316,63 @@ pub const newEvalError = @import("builtins/error.zig").newEvalError;
 pub const PromiseState = @import("builtins/promise.zig").PromiseState;
 pub const allocatePromiseFor = @import("builtins/promise.zig").allocatePromiseFor;
 
-/// §19.2.1 eval(x). Cynic is strict-only and explicitly does NOT
-/// ship runtime code construction (per AGENTS.md — `eval()`,
-/// `new Function(string)`, etc. are out permanently). The binding
-/// must exist on globalThis though so `typeof eval === "function"`
-/// and `eval === null` (Sputnik S10.2.3_* uses both shapes) don't
-/// fall through to ReferenceError. Returns the argument unchanged
-/// for non-string operands per §19.2.1 step 1; throws SyntaxError
-/// on String operands so callers see a spec-flavored failure
-/// rather than silent success.
-fn globalEvalNotSupported(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
+/// §19.2.1 eval(x) — the global `eval` function object. The binding
+/// always exists on globalThis (so `typeof eval === "function"` and
+/// `eval === null` probes resolve), but its behaviour depends on the
+/// `--allow=eval` posture (`realm.allow_eval`):
+///
+///   • non-String argument → returned unchanged (§19.2.1 step 2),
+///     regardless of posture.
+///   • gate closed (default) → a String argument is the SES policy
+///     refusal: SyntaxError (AGENTS.md "eval and runtime code
+///     construction").
+///   • gate open (`--allow=eval`) → a String argument is evaluated.
+///
+/// This native is reached only for an **indirect** eval — the
+/// syntactic direct `eval(...)` form compiles to a dedicated
+/// `direct_eval` opcode that captures the caller's scope. §19.2.1.1
+/// EvalDeclarationInstantiation for an indirect eval uses the global
+/// environment as the variable + lexical environment, which is
+/// exactly what `evaluateEval` produces (free references resolve via
+/// `lda_global`; the per-call declarative env isolates top-level
+/// `let` / `const`). Cynic is strict-only, so this is always a strict
+/// eval (§19.2.1.3).
+fn globalEval(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = this_value;
     const arg = if (args.len > 0) args[0] else Value.undefined_;
+    // §19.2.1 step 2 — a non-String operand is returned unchanged.
     if (!arg.isString()) return arg;
-    // Gated by `--allow=eval` (`realm.allow_eval`): closed → policy
-    // SyntaxError; open → EvalError (enabled-but-unimplemented).
-    return throwEvalUnsupported(realm, "Cynic does not support eval() of source strings");
+    if (!realm.allow_eval) {
+        // Gate closed → SES policy refusal (unchanged default).
+        return throwSyntaxError(realm, "Cynic does not support eval() of source strings");
+    }
+    const s: *JSString = @ptrCast(@alignCast(arg.asString()));
+    return performIndirectEval(realm, s.flatBytes());
+}
+
+/// §19.2.1.1 — run `source` as indirect eval code (global scope) in
+/// `realm`. Shared by the global `eval` native and any other
+/// indirect-eval entry. Parse / compile failures surface as a
+/// SyntaxError; a thrown completion is re-raised on the realm; a
+/// normal completion is returned as the eval result value.
+pub fn performIndirectEval(realm: *Realm, source: []const u8) NativeError!Value {
+    const interp = @import("lantern/interpreter.zig");
+    // Retain a realm-lifetime copy: the chunk compiled here lands in
+    // `script_chunks` and its function templates borrow source slices
+    // for `Function.prototype.toString`, but `source` may be a
+    // transient heap JSString that GC can reclaim.
+    const stable = realm.retainEvalSource(source) catch return error.OutOfMemory;
+    const result = interp.evaluateEval(realm.allocator, realm, stable) catch |err| switch (err) {
+        error.OutOfMemory => return error.OutOfMemory,
+        // §19.2.1 step 11 — a SyntaxError from parsing the program.
+        error.ParseError, error.CompileError => return throwSyntaxError(realm, "eval: SyntaxError in evaluated source"),
+        error.InvalidOpcode => return error.OutOfMemory,
+    };
+    return switch (result) {
+        .value, .yielded => |v| v,
+        .thrown => |ex| {
+            realm.pending_exception = ex;
+            return error.NativeThrew;
+        },
+    };
 }

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -2372,7 +2372,11 @@ pub fn performIndirectEval(realm: *Realm, source: []const u8) NativeError!Value 
     // for `Function.prototype.toString`, but `source` may be a
     // transient heap JSString that GC can reclaim.
     const stable = realm.retainEvalSource(source) catch return error.OutOfMemory;
-    const result = interp.evaluateEval(realm.allocator, realm, stable) catch |err| switch (err) {
+    // §19.2.1.1 indirect eval is a strict eval (§19.2.1.3): top-level
+    // `var` / function bind in the eval's own variable environment, not
+    // the global env. (Distinct from `evaluateEval`, which ShadowRealm
+    // uses for Script evaluation where var → the realm's global env.)
+    const result = interp.evaluateIndirectEval(realm.allocator, realm, stable) catch |err| switch (err) {
         error.OutOfMemory => return error.OutOfMemory,
         // §19.2.1 step 11 — a SyntaxError from parsing the program.
         error.ParseError, error.CompileError => return throwSyntaxError(realm, "eval: SyntaxError in evaluated source"),

--- a/src/runtime/lantern/helpers.zig
+++ b/src/runtime/lantern/helpers.zig
@@ -426,3 +426,7 @@ pub fn makeRangeError(realm: *Realm, msg: []const u8) RunError!Value {
 pub fn makeSyntaxError(realm: *Realm, msg: []const u8) RunError!Value {
     return intrinsics_mod.newSyntaxError(realm, msg) catch return error.OutOfMemory;
 }
+
+pub fn makeEvalError(realm: *Realm, msg: []const u8) RunError!Value {
+    return intrinsics_mod.newEvalError(realm, msg) catch return error.OutOfMemory;
+}

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -55,6 +55,7 @@ const Op = @import("../../bytecode/op.zig").Op;
 const chunk_mod = @import("../../bytecode/chunk.zig");
 const Chunk = chunk_mod.Chunk;
 const Handler = chunk_mod.Handler;
+const scope_mod = @import("../../bytecode/scope.zig");
 const parser_mod = @import("../../parser/parser.zig");
 const compiler_mod = @import("../../bytecode/compiler.zig");
 const module_mod = @import("../module.zig");
@@ -483,6 +484,121 @@ pub fn evaluateEval(
     source: []const u8,
 ) EvaluateError!RunResult {
     return evaluateSource(allocator, realm, source, true);
+}
+
+/// §19.2.1 direct eval — the caller-frame context the `direct_eval`
+/// opcode hands to `evaluateDirectEval` so the eval'd code inherits
+/// the running execution context (§19.2.1 steps 6-13): the caller's
+/// `this`, `new.target`, home object, and — via `parent_env` — its
+/// lexical environment, so free identifiers resolve against the
+/// caller's locals.
+pub const DirectEvalContext = struct {
+    this_value: Value,
+    new_target: Value,
+    home_object: ?*JSObject,
+    home_function: ?*JSFunction,
+    running_realm: ?*Realm,
+    owning_module: ?*module_mod.ModuleRecord,
+    /// The caller's innermost lexical environment. The eval body's
+    /// own environment (its leading `make_environment`) is allocated
+    /// as a child of this, so `lda_env [depth]` from eval'd code
+    /// walks into the caller's env chain.
+    parent_env: ?*Environment,
+    is_derived_ctor: bool,
+    super_called_cell: ?*bool,
+};
+
+/// §19.2.1 PerformEval for a *direct* eval. Compiles `source` as eval
+/// code whose free references resolve against the caller's lexical
+/// environment (reconstructed from `snapshot`), then runs it in a
+/// fresh frame that inherits the caller's `this` / `new.target` / home
+/// and whose environment is parented to the caller's (`ctx.parent_env`).
+/// Cynic is strict-only, so this is always a strict eval (§19.2.1.3):
+/// the eval body's own `var` / `let` bind in its own environment and
+/// don't leak into the caller's scope.
+pub fn evaluateDirectEval(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    source: []const u8,
+    snapshot: *const chunk_mod.DirectEvalScope,
+    ctx: DirectEvalContext,
+) EvaluateError!RunResult {
+    var arena: std.heap.ArenaAllocator = .init(allocator);
+    defer arena.deinit();
+    const aa = arena.allocator();
+
+    // Retain a realm-lifetime copy of the source — the compiled chunk
+    // lands in `script_chunks` and its function templates borrow
+    // slices for `Function.prototype.toString`.
+    const stable = try realm.retainEvalSource(source);
+
+    const diag_mod = @import("../../diagnostic.zig");
+    var diags: diag_mod.Diagnostics = .empty;
+    const program = parser_mod.parseScript(aa, stable, &diags) catch return error.ParseError;
+    for (diags.items) |d| if (d.severity == .err) return error.ParseError;
+
+    // Rebuild the caller's visible env-slot bindings as a synthetic
+    // outer scope (parent = null). Each binding keeps its original
+    // env_depth / env_slot so `lda_env`'s depth arithmetic reaches the
+    // right runtime environment. Allocated on the parse arena — only
+    // needed during compilation, not at runtime.
+    var caller_scope: scope_mod.Scope = .{ .parent = null, .kind = .function };
+    for (snapshot.bindings) |b| {
+        caller_scope.bindings.append(aa, .{
+            .name = b.name,
+            .env_slot = b.env_slot,
+            .env_depth = b.env_depth,
+            .kind = b.kind,
+            .span = .{ .start = 0, .end = 0 },
+            .is_fn_expr_name = b.is_fn_expr_name,
+            .is_using = b.is_using,
+        }) catch return error.OutOfMemory;
+    }
+
+    const chunk_ptr = try realm.allocator.create(Chunk);
+    chunk_ptr.* = compiler_mod.compileDirectEvalAsChunk(
+        realm.allocator,
+        realm,
+        &program,
+        stable,
+        null,
+        &caller_scope,
+        // The eval body's env sits one level below the caller's
+        // innermost env at runtime. Saturating add guards the
+        // pathological 255-deep nesting case.
+        snapshot.caller_env_depth +| 1,
+    ) catch {
+        realm.allocator.destroy(chunk_ptr);
+        return error.CompileError;
+    };
+    try realm.script_chunks.append(realm.allocator, chunk_ptr);
+
+    var frames: std.ArrayListUnmanaged(CallFrame) = .empty;
+    defer {
+        for (frames.items) |*fr| if (fr.owns_registers) realm.frame_pool.release(allocator, fr.registers);
+        frames.deinit(allocator);
+    }
+    const main_regs = try realm.frame_pool.acquire(allocator, chunk_ptr.register_count);
+    @memset(main_regs, Value.undefined_);
+    try frames.append(allocator, .{
+        .chunk = chunk_ptr,
+        .ip = 0,
+        .accumulator = Value.undefined_,
+        .registers = main_regs,
+        // Pre-seed the caller's env so the eval body's leading
+        // `make_environment` chains its fresh env to the caller's.
+        .env = ctx.parent_env,
+        .this_value = ctx.this_value,
+        .new_target = ctx.new_target,
+        .home_object = ctx.home_object,
+        .home_function = ctx.home_function,
+        .running_realm = ctx.running_realm,
+        .owning_module = ctx.owning_module,
+        .is_derived_ctor = ctx.is_derived_ctor,
+        .super_called_cell = ctx.super_called_cell,
+        .argc = 0,
+    });
+    return runFrames(allocator, realm, &frames);
 }
 
 fn evaluateSource(
@@ -1724,6 +1840,117 @@ pub fn runFrames(
                 realm.intrinsics.function_prototype;
             acc = heap_mod.taggedFunction(fn_obj);
             continue :dispatch try decodeNext(code, &ip, &committed);
+        },
+        .direct_eval => {
+            // §19.2.1 direct eval. Operands: scope:u16, r_callee:u8,
+            // argc:u8. Args are at `r_callee+1 .. r_callee+argc`.
+            const scope_idx = readU16(code, ip);
+            const r_callee = code[ip + 2];
+            const argc = code[ip + 3];
+            ip += 4;
+
+            const callee_v = registers[r_callee];
+            const args_start = @as(usize, r_callee) + 1;
+            const args_slice = registers[args_start .. args_start + argc];
+
+            // §19.2.1.1 — the call is a direct eval only when the
+            // callee is this realm's %eval% intrinsic. Otherwise (a
+            // reassigned `globalThis.eval`, a cross-realm eval) it's
+            // an ordinary call.
+            const is_intrinsic_eval = blk: {
+                const fnobj = heap_mod.valueAsFunction(callee_v) orelse break :blk false;
+                break :blk realm.intrinsics.eval_function == fnobj;
+            };
+            if (!is_intrinsic_eval) {
+                const cresult = try callValue(allocator, realm, f.running_realm orelse realm, callee_v, Value.undefined_, args_slice);
+                switch (cresult) {
+                    .value, .yielded => |v| {
+                        acc = v;
+                        continue :dispatch try decodeNext(code, &ip, &committed);
+                    },
+                    .thrown => |ex| {
+                        f.ip = ip;
+                        f.accumulator = acc;
+                        committed = true;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) {
+                            return .{ .thrown = ex };
+                        }
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    },
+                }
+            }
+
+            // §19.2.1 step 2 — a non-String argument is returned
+            // unchanged (no source is evaluated).
+            const arg0 = if (argc > 0) registers[args_start] else Value.undefined_;
+            if (!arg0.isString()) {
+                acc = arg0;
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+
+            // Gate closed → SES policy refusal (SyntaxError), matching
+            // the indirect `eval` native and the default posture.
+            if (!realm.allow_eval) {
+                const ex = try makeSyntaxError(realm, "Cynic does not support eval() of source strings");
+                f.ip = ip;
+                f.accumulator = acc;
+                committed = true;
+                if (!try unwindThrow(allocator, realm, frames, ex)) {
+                    return .{ .thrown = ex };
+                }
+                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+            }
+
+            // Direct eval — compile against the caller's scope snapshot
+            // and run with the caller's `this` / env inherited. Flush
+            // ip/acc onto the frame first: `evaluateDirectEval`
+            // allocates + runs JS, so a GC during it must see the
+            // current frame state.
+            const src_str: *JSString = @ptrCast(@alignCast(arg0.asString()));
+            const snapshot = &local_chunk.direct_eval_scopes[scope_idx];
+            const ctx: DirectEvalContext = .{
+                .this_value = f.this_value,
+                .new_target = f.new_target,
+                .home_object = f.home_object,
+                .home_function = f.home_function,
+                .running_realm = f.running_realm,
+                .owning_module = f.owning_module,
+                .parent_env = f.env,
+                .is_derived_ctor = f.is_derived_ctor,
+                .super_called_cell = f.super_called_cell,
+            };
+            f.ip = ip;
+            f.accumulator = acc;
+            committed = true;
+            const eresult = evaluateDirectEval(allocator, realm, src_str.flatBytes(), snapshot, ctx) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.InvalidOpcode => return error.InvalidOpcode,
+                // §19.2.1 step 11 — a parse / compile failure is a
+                // SyntaxError raised in the caller.
+                error.ParseError, error.CompileError => {
+                    const ex = try makeSyntaxError(realm, "eval: SyntaxError in evaluated source");
+                    if (!try unwindThrow(allocator, realm, frames, ex)) {
+                        return .{ .thrown = ex };
+                    }
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                },
+            };
+            switch (eresult) {
+                .value, .yielded => |v| {
+                    // The eval ran in its own `runFrames` re-entry — no
+                    // frame was pushed onto this stack, so reload the
+                    // (unchanged) active frame and continue past the op.
+                    acc = v;
+                    f.accumulator = v;
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                },
+                .thrown => |ex| {
+                    if (!try unwindThrow(allocator, realm, frames, ex)) {
+                        return .{ .thrown = ex };
+                    }
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                },
+            }
         },
         .call => {
             const r_callee = code[ip];

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -465,26 +465,37 @@ pub fn evaluateScript(
     realm: *Realm,
     source: []const u8,
 ) EvaluateError!RunResult {
-    return evaluateSource(allocator, realm, source, false);
+    return evaluateSource(allocator, realm, source, false, false);
 }
 
-/// Evaluate `source` as eval code against `realm` (§3.8.3.7
-/// PerformShadowRealmEval; the indirect-`eval` path when `eval`
-/// ships). Like `evaluateScript`, but top-level lexical declarations
-/// (`let` / `const` / `class`) bind in a fresh per-call declarative
-/// environment rather than the realm's shared global env-record (see
-/// `compileEvalAsChunk`). Repeated calls against one realm are
-/// therefore independent: a later evaluation redeclaring a top-level
-/// `let` / `const` a prior evaluation used does not collide. Top-level
-/// `var` / function declarations still bind on the realm's global env
-/// and persist across calls. Free references resolve against the
-/// realm's globals.
+/// §3.8.3.7 PerformShadowRealmEval — evaluate `source` as **Script**
+/// code against `realm` (used by `ShadowRealm.prototype.evaluate`).
+/// Like `evaluateScript`, but top-level lexical declarations bind in a
+/// fresh per-call declarative environment so repeated calls don't
+/// collide. Top-level `var` / function declarations still bind on the
+/// shadow realm's global env and persist across `evaluate` calls
+/// (varEnv = [[GlobalEnv]]). NOT strict-eval var isolation — that's
+/// `evaluateIndirectEval`. Free references resolve against the realm's
+/// globals.
 pub fn evaluateEval(
     allocator: std.mem.Allocator,
     realm: *Realm,
     source: []const u8,
 ) EvaluateError!RunResult {
-    return evaluateSource(allocator, realm, source, true);
+    return evaluateSource(allocator, realm, source, true, false);
+}
+
+/// §19.2.1.1 — evaluate `source` as **indirect eval** code against
+/// `realm`. Like `evaluateEval`, but a strict eval (§19.2.1.3): the
+/// eval body gets its own variable environment, so top-level `var` /
+/// function declarations bind eval-locally and do NOT leak to the
+/// global env. Free references resolve against the realm's globals.
+pub fn evaluateIndirectEval(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    source: []const u8,
+) EvaluateError!RunResult {
+    return evaluateSource(allocator, realm, source, true, true);
 }
 
 /// §19.2.1 direct eval — the caller-frame context the `direct_eval`
@@ -607,6 +618,10 @@ fn evaluateSource(
     realm: *Realm,
     source: []const u8,
     eval_scope: bool,
+    /// §19.2.1.3 — when `eval_scope` is set, whether this is a strict
+    /// eval (var / function bind eval-locally) vs ShadowRealm-style
+    /// Script evaluation (var → global). Ignored when `!eval_scope`.
+    eval_local: bool,
 ) EvaluateError!RunResult {
     var arena: std.heap.ArenaAllocator = .init(allocator);
     defer arena.deinit();
@@ -631,7 +646,7 @@ fn evaluateSource(
     // across `script_chunks` array growth.
     const chunk_ptr = try realm.allocator.create(Chunk);
     chunk_ptr.* = (if (eval_scope)
-        compiler_mod.compileEvalAsChunk(realm.allocator, realm, &program, source, null)
+        compiler_mod.compileEvalAsChunk(realm.allocator, realm, &program, source, null, eval_local)
     else
         compiler_mod.compileScriptAsChunk(realm.allocator, realm, &program, source, null)) catch {
         realm.allocator.destroy(chunk_ptr);

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -85,6 +85,7 @@ pub const TruncateResult = helpers.TruncateResult;
 pub const makeTypeError = helpers.makeTypeError;
 pub const makeRangeError = helpers.makeRangeError;
 pub const makeSyntaxError = helpers.makeSyntaxError;
+pub const makeEvalError = helpers.makeEvalError;
 
 // Generator + async-generator machinery lives in `generator.zig`.
 // Re-export the public entry points so the dispatch loop and
@@ -1888,10 +1889,11 @@ pub fn runFrames(
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
 
-            // Gate closed → SES policy refusal (SyntaxError), matching
-            // the indirect `eval` native and the default posture.
+            // Gate closed → host refusal (EvalError, §19.2.1.2
+            // HostEnsureCanCompileStrings), matching the indirect
+            // `eval` native and the default posture.
             if (!realm.allow_eval) {
-                const ex = try makeSyntaxError(realm, "Cynic does not support eval() of source strings");
+                const ex = try makeEvalError(realm, intrinsics_mod.eval_disabled_msg);
                 f.ip = ip;
                 f.accumulator = acc;
                 committed = true;

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -806,6 +806,19 @@ pub const Realm = struct {
     /// be revisited with a per-script arena later if it
     /// matters.
     script_chunks: std.ArrayListUnmanaged(*@import("../bytecode/chunk.zig").Chunk) = .empty,
+    /// Source buffers retained for `--allow=eval` runtime code
+    /// construction. Two producers:
+    ///   • §19.2.1 eval(string) — a copy of the eval source (the
+    ///     user's argument may be a transient heap JSString that GC
+    ///     can reclaim, but the compiled chunk lives in `script_chunks`
+    ///     and its function templates borrow slices of the source for
+    ///     `Function.prototype.toString`).
+    ///   • §20.2.1.1.1 CreateDynamicFunction — the synthesized
+    ///     `(function anonymous(P){B})` wrapper.
+    /// Both must outlive the chunks that borrow them, so they're owned
+    /// here and freed at realm teardown alongside `script_chunks`.
+    /// Only populated under `--allow=eval`.
+    eval_sources: std.ArrayListUnmanaged([]const u8) = .empty,
     /// Cooperative interpreter step budget. Decremented once per
     /// opcode in `runFrames`; on reaching zero the dispatch loop
     /// raises a synthetic `RangeError("step budget exhausted")`
@@ -1047,6 +1060,12 @@ pub const Realm = struct {
             self.allocator.destroy(ch);
         }
         self.script_chunks.deinit(self.allocator);
+        // Free the retained `--allow=eval` source buffers (a chunk's
+        // function templates borrow slices for
+        // `Function.prototype.toString`; the chunks were torn down
+        // just above). See `eval_sources`.
+        for (self.eval_sources.items) |buf| self.allocator.free(buf);
+        self.eval_sources.deinit(self.allocator);
         self.frame_stacks.deinit(self.allocator);
         // Free the derived-ctor `super_called` cells handed out
         // across this realm's lifetime. JSFunctions holding cell
@@ -1099,6 +1118,20 @@ pub const Realm = struct {
 
     pub fn enqueueMicrotask(self: *Realm, callback: Value, arg: Value) !void {
         try self.microtask_queue.append(self.allocator, .{ .kind = .callback, .callback = callback, .arg = arg });
+    }
+
+    /// Copy `source` into a realm-owned buffer and return the copy.
+    /// Used by the `--allow=eval` paths so a chunk compiled from
+    /// transient source text (a user eval string, a synthesized
+    /// `Function` wrapper) can safely borrow slices for the lifetime
+    /// of the realm. Freed at teardown — see `eval_sources`.
+    pub fn retainEvalSource(self: *Realm, source: []const u8) ![]const u8 {
+        const copy = try self.allocator.dupe(u8, source);
+        self.eval_sources.append(self.allocator, copy) catch |err| {
+            self.allocator.free(copy);
+            return err;
+        };
+        return copy;
     }
 
     /// §9.10.4.1 AddToKeptObjects — pin `value` alive for the

--- a/test262-results.md
+++ b/test262-results.md
@@ -3,7 +3,7 @@
 **Cynic passes 98.83 % of its 50894-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
 
 - **40178 passing** — Cynic produced the spec-expected result.
-- **10120 expected fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
+- **10123 expected fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
 - **593 failing** — real engine failures with no policy bucket. Work to do.
 - **Out of total**, dropped before `corpus`: the upstream `harness/` and `staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary, plus shipped joint-iteration / ShadowRealm — those get their own dedicated scoreboard).
 
@@ -11,40 +11,22 @@
 
 | posture | passing | failing | expected fails | skip | total | pass% |
 |---|---:|---:|---:|---:|---:|---:|
-| **unhardened, `--allow=eval`** † | 44074 | 604 | 6213 | 3 | 50894 | 98.81 % |
-| **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6217 | 3 | 50894 | 98.82 % |
-| **hardened** (default — `cynic run`) | 40178 | 593 | 10120 | 3 | 50894 | 98.83 % |
+| **unhardened, `--allow=eval`** | 44617 | 920 | 5357 | 0 | 50894 | 98.19 % |
+| **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6220 | 0 | 50894 | 98.82 % |
+| **hardened** (default — `cynic run`) | 40178 | 593 | 10123 | 0 | 50894 | 98.83 % |
 
 > **pass%** = `(passing + expected fails) / total`.
 > A fixture that fails because of a Cynic design policy
 > (Annex B not shipped, strict-only, no Intl, eval-off, SES
-> throw) is an **expected fail** rather than a real
+> throw) is a **expected fail** rather than a real
 > engine bug. Plain **failing** is what's left over — real
 > engine work to do. **skip** is in-corpus fixtures Cynic
-> doesn't run (capability / host gaps — cross-realm,
-> eval-helper), excluded from the pass% numerator; the
-> columns decompose exactly as
-> `passing + failing + expected fails + skip = total`.
->
-> **† the `--allow=eval` row is a projection**, not a measured
-> sweep. The `--allow=eval` *flag* ships (`Realm.allow_eval` plus
-> the CLI verb), but the eval *engine* does not — the flag only
-> swaps the refusal class (SyntaxError → EvalError), so
-> eval-dependent fixtures still don't execute. This row therefore
-> projects the score for when the eval **engine** lands (see
-> `docs/ses-alignment.md` §Phase 4), not the current flag-only
-> state. At that point, turning eval on makes the eval-dependent
-> fixtures (today counted as expected fails) attempt to run; most
-> would pass, but that relabel stays inside the pass-counted
-> numerator, so it never moves pass%. The *only* score-affecting
-> change is the **4 indirect-eval Sputnik fixtures** — they fail
-> even with eval on (strict-only parses the eval'd source strict,
-> so PerformEval throws the wrong error class), so they move from
-> expected fail to real failing. The projected row is the
-> unhardened row with those 4 shifted: `failing` 600 → 604,
-> `expected fails` 6217 → 6213, pass% 98.82 → 98.81. (Re-applied
-> by hand after each `--write-results` sweep, which regenerates
-> this table to `n/a`.)
+> doesn't run (capability / host gaps), excluded from the
+> pass% numerator; the columns decompose exactly as
+> `passing + failing + expected fails + skip = total`. The
+> `--allow=eval` row is a measured sweep (`--phase=eval`):
+> the eval surface runs for real, so its failures are real
+> engine work, not expected fails.
 
 *SES witness fidelity*: **10 / 10** witnesses are SES expected fails (100.00 %). Curated set in `tools/test262/ses_witnesses.zig`; CI gates at 100 %. See `docs/handbook/ses-test262-policy.md`.
 
@@ -57,12 +39,12 @@ refer to the same parse → compile → run sweep.
 
 - **unhardened, `--allow=eval`** — unhardened plus the
   eval surface (`eval()`, `new Function(string)`, …) opted
-  in. **Projected, not measured** (†): the `--allow=eval`
-  flag ships, but the eval *engine* doesn't yet (see
-  `docs/ses-alignment.md` §Phase 4), so the flag only changes
-  the refusal class and this row stays derived from the
-  unhardened sweep — see the † note under the table. A real
-  opt-in sweep replaces it when the eval engine lands.
+  in. A **measured** sweep (`--phase=eval`,
+  `realm.allow_eval = true`): the eval surface runs for real,
+  so its remaining gaps count as plain `failing` (real work)
+  rather than eval-off `expected fails`. That's why this row
+  has more `failing` and fewer `expected fails` than the
+  unhardened row — the eval-off → eval-on split made visible.
 - **unhardened** — `cynic --unhardened` opt-out. Eval off
   (so eval-dependent fixtures fail and count as correctly
   handled fails), Annex B / Intl / noStrict failures too.
@@ -159,10 +141,12 @@ Bucketed on the first two path components (`built-ins/Set`,
   fails split** shifts — that's the real per-posture signal,
   heaviest in the SES-hot built-ins (`Array`, `Object`,
   `TypedArray`, `String`, …).
-- **+eval** is the `--allow=eval` projection; per area it
-  equals the unhardened row (the 4 indirect-eval fixtures that
-  distinguish them globally don't localize — see the
-  `--allow=eval` row in `## Current scores`).
+- **+eval** here is a per-area *approximation* — these rows
+  reuse the unhardened buckets, so they don't reflect the eval
+  surface running for real. The **measured** `--allow=eval`
+  totals (eval fixtures run, failures counted as real work)
+  are the `unhardened, --allow=eval` row in `## Current
+  scores`, sourced from the `--phase=eval` sweep.
 - The **`1+ fails` tiers** are the engine-work list — today
   mostly the SAB/Atomics surface plus the ~13-fixture
   cross-realm cluster.
@@ -227,9 +211,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 1206 | 2 | 15 | 0 | 1223 | 100 % |
 | · +eval | 1206 | 2 | 15 | 0 | 1223 | 100 % |
 | **`language/expressions`** | | | | | | |
-| · hardened | 10017 | 1 | 661 | 3 | 10682 | 100 % |
-| · unhardened | 10132 | 1 | 546 | 3 | 10682 | 100 % |
-| · +eval | 10132 | 1 | 546 | 3 | 10682 | 100 % |
+| · hardened | 10017 | 1 | 664 | 0 | 10682 | 100 % |
+| · unhardened | 10132 | 1 | 549 | 0 | 10682 | 100 % |
+| · +eval | 10132 | 1 | 549 | 0 | 10682 | 100 % |
 
 **0 fails — passing / all-policy (sorted by expected fails ↓)**
 
@@ -635,7 +619,6 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 1 | 0 | 0 | 0 | 1 | 100 % |
 | · unhardened | 1 | 0 | 0 | 0 | 1 | 100 % |
 | · +eval | 1 | 0 | 0 | 0 | 1 | 100 % |
-
 ## Pre-Stage-4 proposals shipped
 
 Per-feature scores for the TC39 proposals Cynic ships at
@@ -652,25 +635,25 @@ These fixtures are excluded from the top-line score.
 
 | posture | passing | failing | expected fails | skip | total | pass% |
 |---|---:|---:|---:|---:|---:|---:|
-| hardened | 70 | 0 | 8 | 3 | 81 | 96 % |
-| unhardened | 76 | 0 | 2 | 3 | 81 | 96 % |
+| hardened | 70 | 0 | 8 | 0 | 78 | 100 % |
+| unhardened | 76 | 0 | 2 | 0 | 78 | 100 % |
 
 ### `ShadowRealm`
 
 | posture | passing | failing | expected fails | skip | total | pass% |
 |---|---:|---:|---:|---:|---:|---:|
-| hardened | 43 | 0 | 21 | 3 | 67 | 96 % |
-| unhardened | 63 | 0 | 1 | 3 | 67 | 96 % |
-
+| hardened | 43 | 0 | 21 | 0 | 64 | 100 % |
+| unhardened | 63 | 0 | 1 | 0 | 64 | 100 % |
 
 ## History
 
-### 2026-06-02 — cynic `5a82671`, test262 `d0c1b4555b`
+### 2026-06-02 — cynic `8bf5d61`, test262 `d0c1b4555b`
 
 |         | passing | failing | expected fails | total | pass% | Δ pass | elapsed |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| **unhardened** | 44074 | 600 | 6217 | 50894 | 98.82 % | ±0 | 30.1 s |
-| **hardened** | 40178 | 593 | 10120 | 50894 | 98.83 % | ±0 | 30.1 s |
+| **unhardened** | 44074 | 600 | 6220 | 50894 | 98.82 % | +3 | 30.1 s |
+| **hardened** | 40178 | 593 | 10123 | 50894 | 98.83 % | +3 | 30.3 s |
+| **unhardened_allow_eval** | 44617 | 920 | 5357 | 50894 | 98.19 % | n/a | 30.1 s |
 
 ### 2026-06-01 — cynic `fed859f`, test262 `d0c1b4555b`
 

--- a/test262-results.md
+++ b/test262-results.md
@@ -2,8 +2,8 @@
 
 **Cynic passes 98.83 % of its 50894-fixture test262 corpus** under the default (hardened SES) posture (`cynic run`). The breakdown:
 
-- **40178 passing** — Cynic produced the spec-expected result.
-- **10123 expected fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
+- **39880 passing** — Cynic produced the spec-expected result.
+- **10421 expected fails** — failures that hit a Cynic design policy (Annex B not shipped, strict-only, no Intl, eval-off, SES throw) rather than an engine bug. Counted as spec-correct in `pass%` because Cynic's deliberate "no" is the right answer for the policy it ships.
 - **593 failing** — real engine failures with no policy bucket. Work to do.
 - **Out of total**, dropped before `corpus`: the upstream `harness/` and `staging/` paths, and every Stage ≤ 3 proposal (decorators, import-defer, source-phase-imports, import-bytes, immutable-arraybuffer, await-dictionary, plus shipped joint-iteration / ShadowRealm — those get their own dedicated scoreboard).
 
@@ -11,9 +11,9 @@
 
 | posture | passing | failing | expected fails | skip | total | pass% |
 |---|---:|---:|---:|---:|---:|---:|
-| **unhardened, `--allow=eval`** | 44617 | 920 | 5357 | 0 | 50894 | 98.19 % |
-| **unhardened** (`cynic --unhardened`) | 44074 | 600 | 6220 | 0 | 50894 | 98.82 % |
-| **hardened** (default — `cynic run`) | 40178 | 593 | 10123 | 0 | 50894 | 98.83 % |
+| **unhardened, `--allow=eval`** | 44593 | 912 | 5389 | 0 | 50894 | 98.21 % |
+| **unhardened** (`cynic --unhardened`) | 43776 | 600 | 6518 | 0 | 50894 | 98.82 % |
+| **hardened** (default — `cynic run`) | 39880 | 593 | 10421 | 0 | 50894 | 98.83 % |
 
 > **pass%** = `(passing + expected fails) / total`.
 > A fixture that fails because of a Cynic design policy
@@ -195,9 +195,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 57 | 1 | 0 | 0 | 58 | 98 % |
 | · +eval | 57 | 1 | 0 | 0 | 58 | 98 % |
 | **`built-ins/Function`** | | | | | | |
-| · hardened | 315 | 5 | 189 | 0 | 509 | 99 % |
-| · unhardened | 344 | 5 | 160 | 0 | 509 | 99 % |
-| · +eval | 344 | 5 | 160 | 0 | 509 | 99 % |
+| · hardened | 302 | 5 | 202 | 0 | 509 | 99 % |
+| · unhardened | 331 | 5 | 173 | 0 | 509 | 99 % |
+| · +eval | 331 | 5 | 173 | 0 | 509 | 99 % |
 | **`built-ins/Proxy`** | | | | | | |
 | · hardened | 290 | 3 | 18 | 0 | 311 | 99 % |
 | · unhardened | 296 | 4 | 11 | 0 | 311 | 99 % |
@@ -211,9 +211,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 1206 | 2 | 15 | 0 | 1223 | 100 % |
 | · +eval | 1206 | 2 | 15 | 0 | 1223 | 100 % |
 | **`language/expressions`** | | | | | | |
-| · hardened | 10017 | 1 | 664 | 0 | 10682 | 100 % |
-| · unhardened | 10132 | 1 | 549 | 0 | 10682 | 100 % |
-| · +eval | 10132 | 1 | 549 | 0 | 10682 | 100 % |
+| · hardened | 9935 | 1 | 746 | 0 | 10682 | 100 % |
+| · unhardened | 10050 | 1 | 631 | 0 | 10682 | 100 % |
+| · +eval | 10050 | 1 | 631 | 0 | 10682 | 100 % |
 
 **0 fails — passing / all-policy (sorted by expected fails ↓)**
 
@@ -231,6 +231,10 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 3885 | 0 | 703 | 0 | 4588 | 100 % |
 | · unhardened | 4588 | 0 | 0 | 0 | 4588 | 100 % |
 | · +eval | 4588 | 0 | 0 | 0 | 4588 | 100 % |
+| **`language/statements`** | | | | | | |
+| · hardened | 8641 | 0 | 682 | 0 | 9323 | 100 % |
+| · unhardened | 8730 | 0 | 593 | 0 | 9323 | 100 % |
+| · +eval | 8730 | 0 | 593 | 0 | 9323 | 100 % |
 | **`built-ins/Object`** | | | | | | |
 | · hardened | 2785 | 0 | 626 | 0 | 3411 | 100 % |
 | · unhardened | 3322 | 0 | 89 | 0 | 3411 | 100 % |
@@ -239,14 +243,10 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 2490 | 0 | 591 | 0 | 3081 | 100 % |
 | · unhardened | 3054 | 0 | 27 | 0 | 3081 | 100 % |
 | · +eval | 3054 | 0 | 27 | 0 | 3081 | 100 % |
-| **`language/statements`** | | | | | | |
-| · hardened | 8753 | 0 | 570 | 0 | 9323 | 100 % |
-| · unhardened | 8842 | 0 | 481 | 0 | 9323 | 100 % |
-| · +eval | 8842 | 0 | 481 | 0 | 9323 | 100 % |
 | **`language/eval-code`** | | | | | | |
-| · hardened | 73 | 0 | 274 | 0 | 347 | 100 % |
-| · unhardened | 73 | 0 | 274 | 0 | 347 | 100 % |
-| · +eval | 73 | 0 | 274 | 0 | 347 | 100 % |
+| · hardened | 12 | 0 | 335 | 0 | 347 | 100 % |
+| · unhardened | 12 | 0 | 335 | 0 | 347 | 100 % |
+| · +eval | 12 | 0 | 335 | 0 | 347 | 100 % |
 | **`intl402/NumberFormat`** | | | | | | |
 | · hardened | 0 | 0 | 253 | 0 | 253 | 100 % |
 | · unhardened | 0 | 0 | 253 | 0 | 253 | 100 % |
@@ -256,9 +256,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 0 | 0 | 248 | 0 | 248 | 100 % |
 | · +eval | 0 | 0 | 248 | 0 | 248 | 100 % |
 | **`annexB/built-ins`** | | | | | | |
-| · hardened | 3 | 0 | 238 | 0 | 241 | 100 % |
-| · unhardened | 3 | 0 | 238 | 0 | 241 | 100 % |
-| · +eval | 3 | 0 | 238 | 0 | 241 | 100 % |
+| · hardened | 2 | 0 | 239 | 0 | 241 | 100 % |
+| · unhardened | 2 | 0 | 239 | 0 | 241 | 100 % |
+| · +eval | 2 | 0 | 239 | 0 | 241 | 100 % |
 | **`built-ins/Date`** | | | | | | |
 | · hardened | 439 | 0 | 155 | 0 | 594 | 100 % |
 | · unhardened | 594 | 0 | 0 | 0 | 594 | 100 % |
@@ -276,9 +276,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 0 | 0 | 111 | 0 | 111 | 100 % |
 | · +eval | 0 | 0 | 111 | 0 | 111 | 100 % |
 | **`built-ins/RegExp`** | | | | | | |
-| · hardened | 1770 | 0 | 109 | 0 | 1879 | 100 % |
-| · unhardened | 1871 | 1 | 7 | 0 | 1879 | 100 % |
-| · +eval | 1871 | 1 | 7 | 0 | 1879 | 100 % |
+| · hardened | 1769 | 0 | 110 | 0 | 1879 | 100 % |
+| · unhardened | 1870 | 1 | 8 | 0 | 1879 | 100 % |
+| · +eval | 1870 | 1 | 8 | 0 | 1879 | 100 % |
 | **`built-ins/Promise`** | | | | | | |
 | · hardened | 533 | 0 | 107 | 0 | 640 | 100 % |
 | · unhardened | 637 | 0 | 3 | 0 | 640 | 100 % |
@@ -336,9 +336,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 152 | 0 | 1 | 0 | 153 | 100 % |
 | · +eval | 152 | 0 | 1 | 0 | 153 | 100 % |
 | **`language/arguments-object`** | | | | | | |
-| · hardened | 223 | 0 | 40 | 0 | 263 | 100 % |
-| · unhardened | 225 | 0 | 38 | 0 | 263 | 100 % |
-| · +eval | 225 | 0 | 38 | 0 | 263 | 100 % |
+| · hardened | 221 | 0 | 42 | 0 | 263 | 100 % |
+| · unhardened | 223 | 0 | 40 | 0 | 263 | 100 % |
+| · +eval | 223 | 0 | 40 | 0 | 263 | 100 % |
 | **`language/statementList`** | | | | | | |
 | · hardened | 40 | 0 | 40 | 0 | 80 | 100 % |
 | · unhardened | 40 | 0 | 40 | 0 | 80 | 100 % |
@@ -351,10 +351,18 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 58 | 0 | 36 | 0 | 94 | 100 % |
 | · unhardened | 94 | 0 | 0 | 0 | 94 | 100 % |
 | · +eval | 94 | 0 | 0 | 0 | 94 | 100 % |
+| **`language/literals`** | | | | | | |
+| · hardened | 502 | 0 | 32 | 0 | 534 | 100 % |
+| · unhardened | 502 | 0 | 32 | 0 | 534 | 100 % |
+| · +eval | 502 | 0 | 32 | 0 | 534 | 100 % |
 | **`built-ins/JSON`** | | | | | | |
 | · hardened | 136 | 0 | 29 | 0 | 165 | 100 % |
 | · unhardened | 164 | 1 | 0 | 0 | 165 | 99 % |
 | · +eval | 164 | 1 | 0 | 0 | 165 | 99 % |
+| **`language/directive-prologue`** | | | | | | |
+| · hardened | 33 | 0 | 29 | 0 | 62 | 100 % |
+| · unhardened | 33 | 0 | 29 | 0 | 62 | 100 % |
+| · +eval | 33 | 0 | 29 | 0 | 62 | 100 % |
 | **`built-ins/WeakMap`** | | | | | | |
 | · hardened | 114 | 0 | 27 | 0 | 141 | 100 % |
 | · unhardened | 141 | 0 | 0 | 0 | 141 | 100 % |
@@ -363,10 +371,6 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 73 | 0 | 25 | 0 | 98 | 100 % |
 | · unhardened | 96 | 0 | 2 | 0 | 98 | 100 % |
 | · +eval | 96 | 0 | 2 | 0 | 98 | 100 % |
-| **`language/directive-prologue`** | | | | | | |
-| · hardened | 37 | 0 | 25 | 0 | 62 | 100 % |
-| · unhardened | 37 | 0 | 25 | 0 | 62 | 100 % |
-| · +eval | 37 | 0 | 25 | 0 | 62 | 100 % |
 | **`built-ins/AsyncDisposableStack`** | | | | | | |
 | · hardened | 80 | 0 | 24 | 0 | 104 | 100 % |
 | · unhardened | 104 | 0 | 0 | 0 | 104 | 100 % |
@@ -408,9 +412,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 68 | 0 | 0 | 0 | 68 | 100 % |
 | · +eval | 68 | 0 | 0 | 0 | 68 | 100 % |
 | **`language/white-space`** | | | | | | |
-| · hardened | 52 | 0 | 15 | 0 | 67 | 100 % |
-| · unhardened | 52 | 0 | 15 | 0 | 67 | 100 % |
-| · +eval | 52 | 0 | 15 | 0 | 67 | 100 % |
+| · hardened | 51 | 0 | 16 | 0 | 67 | 100 % |
+| · unhardened | 51 | 0 | 16 | 0 | 67 | 100 % |
+| · +eval | 51 | 0 | 16 | 0 | 67 | 100 % |
 | **`intl402/String`** | | | | | | |
 | · hardened | 5 | 0 | 14 | 0 | 19 | 100 % |
 | · unhardened | 7 | 0 | 12 | 0 | 19 | 100 % |
@@ -419,10 +423,6 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 28 | 0 | 14 | 0 | 42 | 100 % |
 | · unhardened | 36 | 0 | 6 | 0 | 42 | 100 % |
 | · +eval | 36 | 0 | 6 | 0 | 42 | 100 % |
-| **`language/literals`** | | | | | | |
-| · hardened | 521 | 0 | 13 | 0 | 534 | 100 % |
-| · unhardened | 521 | 0 | 13 | 0 | 534 | 100 % |
-| · +eval | 521 | 0 | 13 | 0 | 534 | 100 % |
 | **`built-ins/RegExpStringIteratorPrototype`** | | | | | | |
 | · hardened | 5 | 0 | 12 | 0 | 17 | 100 % |
 | · unhardened | 17 | 0 | 0 | 0 | 17 | 100 % |
@@ -468,9 +468,9 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · unhardened | 29 | 0 | 0 | 0 | 29 | 100 % |
 | · +eval | 29 | 0 | 0 | 0 | 29 | 100 % |
 | **`language/comments`** | | | | | | |
-| · hardened | 45 | 0 | 7 | 0 | 52 | 100 % |
-| · unhardened | 45 | 0 | 7 | 0 | 52 | 100 % |
-| · +eval | 45 | 0 | 7 | 0 | 52 | 100 % |
+| · hardened | 44 | 0 | 8 | 0 | 52 | 100 % |
+| · unhardened | 44 | 0 | 8 | 0 | 52 | 100 % |
+| · +eval | 44 | 0 | 8 | 0 | 52 | 100 % |
 | **`language/future-reserved-words`** | | | | | | |
 | · hardened | 48 | 0 | 7 | 0 | 55 | 100 % |
 | · unhardened | 48 | 0 | 7 | 0 | 55 | 100 % |
@@ -499,6 +499,10 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 23 | 0 | 4 | 0 | 27 | 100 % |
 | · unhardened | 27 | 0 | 0 | 0 | 27 | 100 % |
 | · +eval | 27 | 0 | 0 | 0 | 27 | 100 % |
+| **`built-ins/eval`** | | | | | | |
+| · hardened | 6 | 0 | 4 | 0 | 10 | 100 % |
+| · unhardened | 9 | 0 | 1 | 0 | 10 | 100 % |
+| · +eval | 9 | 0 | 1 | 0 | 10 | 100 % |
 | **`built-ins/undefined`** | | | | | | |
 | · hardened | 4 | 0 | 4 | 0 | 8 | 100 % |
 | · unhardened | 4 | 0 | 4 | 0 | 8 | 100 % |
@@ -531,10 +535,6 @@ Bucketed on the first two path components (`built-ins/Set`,
 | · hardened | 28 | 0 | 3 | 0 | 31 | 100 % |
 | · unhardened | 31 | 0 | 0 | 0 | 31 | 100 % |
 | · +eval | 31 | 0 | 0 | 0 | 31 | 100 % |
-| **`built-ins/eval`** | | | | | | |
-| · hardened | 7 | 0 | 3 | 0 | 10 | 100 % |
-| · unhardened | 10 | 0 | 0 | 0 | 10 | 100 % |
-| · +eval | 10 | 0 | 0 | 0 | 10 | 100 % |
 | **`built-ins/Infinity`** | | | | | | |
 | · hardened | 4 | 0 | 2 | 0 | 6 | 100 % |
 | · unhardened | 4 | 0 | 2 | 0 | 6 | 100 % |
@@ -647,13 +647,13 @@ These fixtures are excluded from the top-line score.
 
 ## History
 
-### 2026-06-02 — cynic `8bf5d61`, test262 `d0c1b4555b`
+### 2026-06-02 — cynic `6a72b62`, test262 `d0c1b4555b`
 
 |         | passing | failing | expected fails | total | pass% | Δ pass | elapsed |
 |---|---:|---:|---:|---:|---:|---:|---:|
-| **unhardened** | 44074 | 600 | 6220 | 50894 | 98.82 % | +3 | 30.1 s |
-| **hardened** | 40178 | 593 | 10123 | 50894 | 98.83 % | +3 | 30.3 s |
-| **unhardened_allow_eval** | 44617 | 920 | 5357 | 50894 | 98.19 % | n/a | 30.1 s |
+| **unhardened** | 43776 | 600 | 6518 | 50894 | 98.82 % | +3 | 30.1 s |
+| **hardened** | 39880 | 593 | 10421 | 50894 | 98.83 % | +3 | 30.1 s |
+| **unhardened_allow_eval** | 44593 | 912 | 5389 | 50894 | 98.21 % | n/a | 30.1 s |
 
 ### 2026-06-01 — cynic `fed859f`, test262 `d0c1b4555b`
 

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -913,6 +913,14 @@ const Phase = union(enum) {
     /// life with the single `--unhardened` opt-out. Selected via
     /// `--phase=unhardened`.
     unhardened,
+    /// `--allow=eval` sweep. Runs the main-phase fixture set against
+    /// a realm with `realm.allow_eval = true` (and `hardened = false`,
+    /// matching the published `unhardened, --allow=eval` row). The
+    /// `.eval` policy classification is dropped in this phase, so the
+    /// ~2,100 eval-surface fixtures run for real and their failures
+    /// count as genuine failures — the live "what eval work remains"
+    /// signal. Selected via `--phase=eval`.
+    eval,
 
     const FeaturePhase = struct {
         flag: cynic.runtime.FeatureFlag,
@@ -926,13 +934,21 @@ const Phase = union(enum) {
     /// returns a singleton set with only its flag.
     fn realmFeatures(self: Phase) cynic.runtime.FeatureSet {
         return switch (self) {
-            .main, .unhardened => cynic.runtime.FeatureSet.initEmpty(),
+            .main, .unhardened, .eval => cynic.runtime.FeatureSet.initEmpty(),
             .feature => |f| blk: {
                 var s = cynic.runtime.FeatureSet.initEmpty();
                 s.insert(f.flag);
                 break :blk s;
             },
         };
+    }
+
+    /// Whether per-fixture realms open the `--allow=eval` gate
+    /// (§19.2.1 / §20.2.1.1.1). Only the `.eval` phase does; every
+    /// other phase keeps the default SES refusal so eval-surface
+    /// failures classify as `correctly_handled`.
+    fn realmAllowEval(self: Phase) bool {
+        return self == .eval;
     }
 
     /// Whether per-fixture realms run under the hardened SES
@@ -943,7 +959,10 @@ const Phase = union(enum) {
     /// correctly_handled classification) and unhardened (bare ECMA-262).
     fn realmHardened(self: Phase) bool {
         return switch (self) {
-            .unhardened => false,
+            // The eval sweep runs unhardened so it maps onto the
+            // published `unhardened, --allow=eval` row and the freeze
+            // doesn't confound the eval-surface signal.
+            .unhardened, .eval => false,
             .main => true,
             .feature => |f| f.hardened,
         };
@@ -956,7 +975,7 @@ const Phase = union(enum) {
     /// mask has the matching bit (regardless of posture).
     fn includesFixture(self: Phase, pre_stage4_mask: PreStage4Mask) bool {
         return switch (self) {
-            .main, .unhardened => pre_stage4_mask == 0,
+            .main, .unhardened, .eval => pre_stage4_mask == 0,
             .feature => |f| has: {
                 const idx: usize = @intFromEnum(f.flag);
                 const bit = @as(PreStage4Mask, 1) << @intCast(idx);
@@ -975,6 +994,7 @@ const Phase = union(enum) {
             .main => "main",
             .feature => |f| f.flag.name(),
             .unhardened => "unhardened",
+            .eval => "eval",
         };
     }
 };
@@ -1109,8 +1129,9 @@ pub fn main(init: std.process.Init) !void {
     // embedder would evaluate the feature in isolation.
     const tracked_count = @typeInfo(cynic.runtime.FeatureFlag).@"enum".fields.len;
     // Each tracked proposal contributes two sweeps (hardened +
-    // unhardened), plus the two headline phases (main, unhardened).
-    var phases_buf: [tracked_count * 2 + 2]Phase = undefined;
+    // unhardened), plus the three headline phases (main, unhardened,
+    // eval).
+    var phases_buf: [tracked_count * 2 + 3]Phase = undefined;
     var phases_len: usize = 0;
     if (opts.phase) |p| {
         phases_buf[0] = p;
@@ -1118,7 +1139,11 @@ pub fn main(init: std.process.Init) !void {
     } else if (opts.write_results) {
         phases_buf[0] = .main;
         phases_buf[1] = .unhardened;
-        phases_len = 2;
+        // §19.2.1 / §20.2.1.1.1 — the `--allow=eval` row: the eval
+        // surface runs for real so its failures are measured, not
+        // projected.
+        phases_buf[2] = .eval;
+        phases_len = 3;
         inline for (@typeInfo(cynic.runtime.FeatureFlag).@"enum".fields) |f| {
             const flag: cynic.runtime.FeatureFlag = @enumFromInt(f.value);
             phases_buf[phases_len] = .{ .feature = .{ .flag = flag, .hardened = true } };
@@ -1136,6 +1161,8 @@ pub fn main(init: std.process.Init) !void {
     defer if (main_result) |*r| r.deinit(gpa);
     var unhardened_result: ?PhaseResult = null;
     defer if (unhardened_result) |*r| r.deinit(gpa);
+    var eval_result: ?PhaseResult = null;
+    defer if (eval_result) |*r| r.deinit(gpa);
     var feature_results_hardened: [tracked_count]?PhaseResult = @splat(null);
     var feature_results_unhardened: [tracked_count]?PhaseResult = @splat(null);
     defer for (&feature_results_hardened) |*slot| if (slot.*) |*pr| pr.deinit(gpa);
@@ -1160,6 +1187,10 @@ pub fn main(init: std.process.Init) !void {
             .unhardened => {
                 if (unhardened_result) |*old| old.deinit(gpa);
                 unhardened_result = res;
+            },
+            .eval => {
+                if (eval_result) |*old| old.deinit(gpa);
+                eval_result = res;
             },
         }
     }
@@ -1219,6 +1250,15 @@ pub fn main(init: std.process.Init) !void {
         if (unhardened_result) |*ur| {
             const elapsed_for_row: ?u64 = if (is_full and ur.elapsed_ms > 0) @intCast(ur.elapsed_ms) else null;
             try writeResults(gpa, io, &ur.stats, &ur.buckets, null, &pre_stage4_hardened, &pre_stage4_unhardened, now_ts.toSeconds(), .unhardened, elapsed_for_row);
+        }
+        // §19.2.1 / §20.2.1.1.1 — `unhardened, --allow=eval` row from
+        // the measured eval sweep (the eval surface ran for real, so
+        // its failures are counted, not projected). Written last so
+        // the regenerated snapshot reflects all three measured rows.
+        if (eval_result) |*er| {
+            const elapsed_for_row: ?u64 = if (is_full and er.elapsed_ms > 0) @intCast(er.elapsed_ms) else null;
+            const empty_pre_stage4: PreStage4Stats = .{};
+            try writeResults(gpa, io, &er.stats, &er.buckets, null, &empty_pre_stage4, &empty_pre_stage4, now_ts.toSeconds(), .unhardened_allow_eval, elapsed_for_row);
         }
     }
 
@@ -2221,9 +2261,16 @@ fn classifyAndRun(
     // SES classification is still post-run (runtime error pattern)
     // and lives in the throw-handling block below.
     const path_policy: ?skip_rules.PolicyKind = skip_rules.pathPolicyKind(rel, fm.features, fm.flags.no_strict);
-    // The allow-eval row (when wired) would gate out `.eval` here.
-    // Today both real phases (`.main`, `.unhardened`) admit eval.
-    const sticky_policy: ?skip_rules.PolicyKind = path_policy;
+    // The `.eval` phase opens the `--allow=eval` gate, so the eval
+    // surface runs for real and an eval-policy failure is a genuine
+    // failure (the "what eval work remains" signal) rather than a
+    // by-design refusal. Drop the `.eval` classification in that phase
+    // only; every other policy (Annex B / Intl / no_strict) still
+    // applies, and the eval-off phases keep `.eval` → correctly_handled.
+    const sticky_policy: ?skip_rules.PolicyKind = if (phase.realmAllowEval() and path_policy == .eval)
+        null
+    else
+        path_policy;
     const fail_reject_or_ch: RunResult = if (sticky_policy != null)
         .{ .kind = .fail_correctly_handled }
     else
@@ -2300,6 +2347,10 @@ fn classifyAndRun(
     // even when they regress under the hardened-default main
     // sweep.
     realm.hardened = phase.realmHardened();
+    // The `eval` phase opens the `--allow=eval` gate so the eval
+    // surface (§19.2.1 / §20.2.1.1.1) runs for real; every other
+    // phase keeps the default refusal.
+    realm.allow_eval = phase.realmAllowEval();
     realm.installBuiltins() catch return fail_reject_or_ch;
     // test262 fixtures use `__collectGarbage` / `__clearKeptObjects`
     // / `__drainMicrotasks` for deterministic triggering — debug
@@ -3803,14 +3854,18 @@ fn writeFileBody(
         \\
     );
     // Three rows in user-visible order: the `--allow=eval` opt-in
-    // first (always `n/a` — `--allow=eval` doesn't exist as a runtime
-    // flag yet; the row is reserved so the layout is stable when it
-    // ships), then the unhardened baseline (`--unhardened` opt-out),
+    // first, then the unhardened baseline (`--unhardened` opt-out),
     // then hardened (the default Cynic posture, `cynic run`). Same
     // engine path, different policy mask: unhardened counts annex_b +
-    // no_strict + intl402 + eval as expected fails; hardened
-    // adds SES on top.
-    try writeAllowEvalPlaceholderRow(gpa, out);
+    // no_strict + intl402 + eval as expected fails; hardened adds SES
+    // on top; `--allow=eval` lifts the eval-off policy so the eval
+    // surface is measured for real. The eval row is now sourced from a
+    // measured sweep (`--phase=eval`); it falls back to the reserved
+    // `n/a` placeholder only until the first such sweep has run.
+    if (latestRow(rows, .unhardened_allow_eval)) |r|
+        try writeMiniRow(gpa, out, r)
+    else
+        try writeAllowEvalPlaceholderRow(gpa, out);
     inline for (.{ Mode.unhardened, Mode.hardened }) |m| {
         if (latestRow(rows, m)) |r| try writeMiniRow(gpa, out, r);
     }
@@ -3825,7 +3880,9 @@ fn writeFileBody(
         \\> doesn't run (capability / host gaps), excluded from the
         \\> pass% numerator; the columns decompose exactly as
         \\> `passing + failing + expected fails + skip = total`. The
-        \\> `--allow=eval` row is always `n/a` until that opt-in ships.
+        \\> `--allow=eval` row is a measured sweep (`--phase=eval`):
+        \\> the eval surface runs for real, so its failures are real
+        \\> engine work, not expected fails.
         \\
         \\
     );
@@ -3875,10 +3932,12 @@ fn writeFileBody(
         \\
         \\- **unhardened, `--allow=eval`** — unhardened plus the
         \\  eval surface (`eval()`, `new Function(string)`, …) opted
-        \\  in. **Always `n/a`**: `--allow=eval` isn't shipped (see
-        \\  `docs/ses-alignment.md`), so no sweep populates this row.
-        \\  The row is reserved so the layout stays stable when the
-        \\  opt-in lands (eval fails would then become passes).
+        \\  in. A **measured** sweep (`--phase=eval`,
+        \\  `realm.allow_eval = true`): the eval surface runs for real,
+        \\  so its remaining gaps count as plain `failing` (real work)
+        \\  rather than eval-off `expected fails`. That's why this row
+        \\  has more `failing` and fewer `expected fails` than the
+        \\  unhardened row — the eval-off → eval-on split made visible.
         \\- **unhardened** — `cynic --unhardened` opt-out. Eval off
         \\  (so eval-dependent fixtures fail and count as correctly
         \\  handled fails), Annex B / Intl / noStrict failures too.
@@ -4041,8 +4100,8 @@ fn writeFileBody(
 
 /// Posture label for the `## Current scores` table. Renders each
 /// Mode in user-facing terms so a reader who doesn't know Cynic's
-/// mode naming sees what matters — which one ships, which is the
-/// opt-out, which is the placeholder waiting on `--allow=eval`.
+/// mode naming sees what matters — which one ships by default, which
+/// is the SES opt-out, which is the `--allow=eval` opt-in.
 fn postureLabel(m: Mode) []const u8 {
     return switch (m) {
         .hardened => "**hardened** (default — `cynic run`)",
@@ -4051,12 +4110,11 @@ fn postureLabel(m: Mode) []const u8 {
     };
 }
 
-/// Emit the `--allow=eval` posture row. This row is **always** all
-/// `n/a`: `--allow=eval` isn't a shipped runtime flag (see
-/// `docs/ses-alignment.md`), so no sweep ever populates it. The row
-/// exists only to keep the `## Current scores` layout stable for when
-/// the opt-in lands. No `Mode.unhardened_allow_eval` history row is
-/// ever written, so there's nothing to read back — it's hardcoded here.
+/// Emit a placeholder (all-`n/a`) `--allow=eval` row. Used ONLY as a
+/// fallback before the first measured `--phase=eval` sweep has written
+/// a `Mode.unhardened_allow_eval` history row — once one exists, the
+/// `## Current scores` snapshot renders the measured row instead (see
+/// `writeFileBody`). Keeps the table layout stable on a fresh file.
 fn writeAllowEvalPlaceholderRow(
     gpa: std.mem.Allocator,
     out: *std.ArrayListUnmanaged(u8),
@@ -4183,10 +4241,12 @@ fn writeScoreboard(
         \\  fails split** shifts — that's the real per-posture signal,
         \\  heaviest in the SES-hot built-ins (`Array`, `Object`,
         \\  `TypedArray`, `String`, …).
-        \\- **+eval** is the `--allow=eval` projection; per area it
-        \\  equals the unhardened row (the 4 indirect-eval fixtures that
-        \\  distinguish them globally don't localize — see the
-        \\  `--allow=eval` row in `## Current scores`).
+        \\- **+eval** here is a per-area *approximation* — these rows
+        \\  reuse the unhardened buckets, so they don't reflect the eval
+        \\  surface running for real. The **measured** `--allow=eval`
+        \\  totals (eval fixtures run, failures counted as real work)
+        \\  are the `unhardened, --allow=eval` row in `## Current
+        \\  scores`, sourced from the `--phase=eval` sweep.
         \\- The **`1+ fails` tiers** are the engine-work list — today
         \\  mostly the SAB/Atomics surface plus the ~13-fixture
         \\  cross-realm cluster.
@@ -4658,6 +4718,8 @@ fn parseArgs(gpa: std.mem.Allocator, args: std.process.Args) !Options {
                 opts.phase = .main;
             } else if (std.mem.eql(u8, spec, "unhardened")) {
                 opts.phase = .unhardened;
+            } else if (std.mem.eql(u8, spec, "eval")) {
+                opts.phase = .eval;
             } else if (std.mem.startsWith(u8, spec, "feature:")) {
                 // `feature:<name>` defaults to the hardened
                 // (as-shipped) sweep; append `:unhardened` /
@@ -4676,7 +4738,7 @@ fn parseArgs(gpa: std.mem.Allocator, args: std.process.Args) !Options {
                 };
                 opts.phase = .{ .feature = .{ .flag = flag, .hardened = hardened } };
             } else {
-                std.debug.print("error: --phase expects 'main', 'unhardened', or 'feature:<name>', got '{s}'\n", .{spec});
+                std.debug.print("error: --phase expects 'main', 'unhardened', 'eval', or 'feature:<name>', got '{s}'\n", .{spec});
                 std.process.exit(1);
             }
         }

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -1116,6 +1116,21 @@ pub const eval_dependent_exact_paths = [_][]const u8{
     "built-ins/Function/proto-from-ctor-realm-prototype.js",
     "built-ins/GeneratorFunction/proto-from-ctor-realm.js",
     "built-ins/GeneratorFunction/proto-from-ctor-realm-prototype.js",
+    // Eval-dependent negatives: each calls the dynamic-function family
+    // or indirect eval and expects a SyntaxError from the *evaluated*
+    // source (`import.meta` outside a Module goal; `using` / `await
+    // using` at the top level of eval; `var arguments` in a strict
+    // indirect eval). On an eval-disabled engine §19.2.1.2
+    // HostEnsureCanCompileStrings refuses BEFORE parsing, so the host
+    // EvalError is thrown instead of the expected SyntaxError — they
+    // can only pass with `--allow=eval`. (Node + browser CSP behave
+    // the same: EvalError when code-gen from strings is off.)
+    "language/expressions/import.meta/syntax/goal-async-function-params-or-body.js",
+    "language/expressions/import.meta/syntax/goal-async-generator-params-or-body.js",
+    "language/expressions/import.meta/syntax/goal-generator-params-or-body.js",
+    "language/statements/await-using/syntax/await-using-not-allowed-at-top-level-of-eval.js",
+    "language/statements/using/syntax/using-not-allowed-at-top-level-of-eval.js",
+    "language/statements/variable/12.2.1-22-s.js",
 };
 
 // ════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Implements runtime code construction behind the `--allow=eval` gate
(orthogonal to `--unhardened`). Gate closed → refuse; gate open → run.
Five commits: the eval engine, then two refinements (host-refusal error
type; strict-eval `var` isolation), each with a results regen.

### The eval engine
- **`eval(x)` — §19.2.1.** Indirect (`(0,eval)(s)`, `globalThis.eval(s)`)
  runs as global-scope code. Direct (`eval(...)` syntactic form) is
  detected at compile time → a new `direct_eval` opcode that snapshots
  the caller's env-slot bindings; the runtime rebuilds a synthetic outer
  scope and runs in a frame parented to the caller's env, inheriting
  `this` / `new.target` / home. Non-string arg returned unchanged;
  runtime re-checks the callee is `%eval%` (reassigned `globalThis.eval`
  → ordinary call).
- **`Function` / `GeneratorFunction` / `AsyncFunction` /
  `AsyncGeneratorFunction` string ctors — §20.2.1.1.1
  CreateDynamicFunction**, via a parenthesized-function-expression
  wrapper run through the eval pipeline (scope = global env).

### Host-refusal error type (§19.2.1.2)
Gate-closed `eval` / `Function(string)` / direct eval throw **`EvalError`**
(matching Node `--disallow-code-generation-from-strings` + browser CSP),
not SyntaxError. The spec leaves the type host-defined. A genuine parse
failure *after* the gate opens stays a SyntaxError — refusal and parse
outcome are distinct.

### Strict-eval `var` isolation (§19.2.1.3)
Cynic is strict-only, so every eval is a strict eval: top-level `var` /
function in eval'd code bind in the eval's own variable environment, not
the global env (indirect) or the caller's scope (direct). Implemented
via a compiler `eval_local` mode reusing the non-global module-binding
path. `ShadowRealm.prototype.evaluate` stays Script evaluation
(var → the shadow realm's global env) and is unaffected.

## test262

| posture | passing | failing | expected fails | total | pass% |
|---|---:|---:|---:|---:|---:|
| unhardened, `--allow=eval` | 44593 | 912 | 5389 | 50894 | 98.21 % |
| unhardened | 43776 | 600 | 6518 | 50894 | 98.82 % |
| hardened | 39880 | 593 | 10421 | 50894 | 98.83 % |

The eval surface (~2,100 fixtures) runs in every phase: eval-off
classifies eval failures as correctly-handled; `--phase=eval`
(unhardened + `realm.allow_eval`) runs them for real, failures counted
as work. **No regression**: `failing` unchanged (593 / 600); the
var-isolation fix dropped eval-on failing 920 → 912.

**Heads-up on the eval-off rows:** ~298 fixtures shifted
`passing` → `expected fails`. These are eval-surface negatives like
`assert.throws(SyntaxError, () => eval("bad"))` that previously passed
*by coincidence* (the gate-closed SyntaxError matched the assertion).
Under the EvalError host refusal they classify as eval-dependent
(correctly-handled) — the same outcome they'd have on a production
eval-disabled engine. `pass%` is unchanged; this is a more honest split,
not a regression. (If you'd prefer the higher engine-true `passing`
count, the EvalError commit can be dropped to restore the SyntaxError
refusal.)

## Verification
- `zig build` clean; `zig build test` green (full suite)
- Unit coverage in `src/runtime/eval_test.zig` (indirect/direct/dynamic-fn,
  posture, EvalError-vs-SyntaxError, var isolation); `eval_policy_test.zig`
  updated
- Full `--write-results` sweep; crash/hang audit over all 50,894 fixtures
  exits 0; GC-stress at `--gc-threshold=1` on the eval paths clean
- ShadowRealm fixtures unaffected (0 failing)
- Docs: `docs/ses-alignment.md` "eval engine" section; `AGENTS.md` eval /
  `--allow=eval` / `--phase` updates
