### PR TITLE
promise/set: fix withResolvers capability gate and GetSetRecord negative size

### DIFF
--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -1895,9 +1895,15 @@ fn validateSetLike(realm: *Realm, op: []const u8, value: Value) NativeError!SetL
         const msg = std.fmt.bufPrint(&buf, "Set.prototype.{s}: argument is not set-like (size is NaN)", .{op}) catch op;
         return throwTypeError(realm, msg);
     }
-    const size_usize: usize = if (size_d < 0)
-        0
-    else if (std.math.isInf(size_d))
+    // §24.2.1.2 GetSetRecord step 3.f — a negative `size` is a
+    // RangeError, not a silently-clamped zero. (Step 3.e already
+    // rejected NaN as a TypeError above.)
+    if (size_d < 0) {
+        var buf: [128]u8 = undefined;
+        const msg = std.fmt.bufPrint(&buf, "Set.prototype.{s}: argument is not set-like (size is negative)", .{op}) catch op;
+        return intrinsics.throwRangeError(realm, msg);
+    }
+    const size_usize: usize = if (std.math.isInf(size_d))
         std.math.maxInt(usize)
     else
         @intFromFloat(@trunc(size_d));

--- a/src/runtime/builtins/promise.zig
+++ b/src/runtime/builtins/promise.zig
@@ -2071,35 +2071,33 @@ fn promiseTry(realm: *Realm, this_value: Value, args: []const Value) NativeError
 /// path.
 fn promiseWithResolvers(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     _ = args;
+    // §27.2.4.6 step 1 — Let C be the this value.
     const ctor = try thisAsPromiseCtor(realm, this_value, "withResolvers");
-    const promise_v = allocatePromiseFor(realm, ctor, .pending, Value.undefined_) catch return error.OutOfMemory;
+    // §27.2.4.6 step 2 — Let promiseCapability be ? NewPromiseCapability(C).
+    // Route through the shared helper rather than inlining a
+    // %Promise%-only construction: NewPromiseCapability runs
+    // Construct(C, «executor») and enforces §27.2.1.5 steps 7-8
+    // (resolve/reject must be callable). A constructor that never
+    // invokes its executor — e.g. `Promise.withResolvers.call(function(){})`
+    // — leaves them undefined and must throw a TypeError; a Promise
+    // subclass runs its real constructor through this path too.
+    const cap = try newPromiseCapability(realm, ctor);
+    // `cap` lives only in this native frame (the GC does not scan it),
+    // so root the promise + resolving functions across the result-object
+    // allocation and property writes below.
+    const wr_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer wr_sc.close();
+    wr_sc.push(cap.promise) catch return error.OutOfMemory;
+    wr_sc.push(heap_mod.taggedFunction(cap.resolve)) catch return error.OutOfMemory;
+    wr_sc.push(heap_mod.taggedFunction(cap.reject)) catch return error.OutOfMemory;
 
-    // Per §27.2.1.5 NewPromiseCapability, the Resolve and Reject
-    // functions have name = "" and are not constructors. The
-    // 1-arg `length` matches spec (single (resolution) / (reason)
-    // parameter).
-    const resolve_impl = realm.heap.allocateFunctionNative(realm, promiseResolveImpl, 1, "") catch return error.OutOfMemory;
-    resolve_impl.proto = realm.intrinsics.function_prototype;
-    resolve_impl.has_construct = false;
-    const resolve_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
-    resolve_fn.proto = realm.intrinsics.function_prototype;
-    resolve_fn.has_construct = false;
-    realm.heap.setBoundTarget(resolve_fn, resolve_impl);
-    realm.heap.setBoundThis(resolve_fn, promise_v);
-
-    const reject_impl = realm.heap.allocateFunctionNative(realm, promiseRejectImpl, 1, "") catch return error.OutOfMemory;
-    reject_impl.proto = realm.intrinsics.function_prototype;
-    reject_impl.has_construct = false;
-    const reject_fn = realm.heap.allocateFunctionNative(realm, boundResolveTrampoline, 1, "") catch return error.OutOfMemory;
-    reject_fn.proto = realm.intrinsics.function_prototype;
-    reject_fn.has_construct = false;
-    realm.heap.setBoundTarget(reject_fn, reject_impl);
-    realm.heap.setBoundThis(reject_fn, promise_v);
-
+    // §27.2.4.6 steps 3-7 — wrap { promise, resolve, reject } in an
+    // ordinary object created from %Object.prototype%.
     const obj = realm.heap.allocateObject() catch return error.OutOfMemory;
+    wr_sc.push(heap_mod.taggedObject(obj)) catch return error.OutOfMemory;
     realm.heap.setObjectPrototype(obj, realm.intrinsics.object_prototype);
-    obj.set(realm.allocator, "promise", promise_v) catch return error.OutOfMemory;
-    obj.set(realm.allocator, "resolve", heap_mod.taggedFunction(resolve_fn)) catch return error.OutOfMemory;
-    obj.set(realm.allocator, "reject", heap_mod.taggedFunction(reject_fn)) catch return error.OutOfMemory;
+    obj.set(realm.allocator, "promise", cap.promise) catch return error.OutOfMemory;
+    obj.set(realm.allocator, "resolve", heap_mod.taggedFunction(cap.resolve)) catch return error.OutOfMemory;
+    obj.set(realm.allocator, "reject", heap_mod.taggedFunction(cap.reject)) catch return error.OutOfMemory;
     return heap_mod.taggedObject(obj);
 }

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -4602,6 +4602,33 @@ test "later: Promise.withResolvers().reject(e) settles promise to rejected" {
     , "caught:nope");
 }
 
+test "Promise.withResolvers.call(function(){}) throws TypeError — executor never set resolvers (§27.2.1.5)" {
+    // §27.2.1.5 NewPromiseCapability steps 7-8 — a constructor whose
+    // executor is never invoked leaves [[Resolve]]/[[Reject]] undefined,
+    // so withResolvers (§27.2.4.6 step 2) must throw a TypeError.
+    try expectScriptStringWithBuiltins(
+        \\try { Promise.withResolvers.call(function () {}); "NO-THROW"; }
+        \\catch (e) { e.constructor.name; }
+    , "TypeError");
+}
+
+test "Promise.withResolvers.call(C) honors a constructor that invokes its executor" {
+    try expectScriptStringWithBuiltins(
+        \\const w = Promise.withResolvers.call(function (ex) { ex(function () {}, function () {}); });
+        \\typeof w.resolve + "," + typeof w.reject;
+    , "function,function");
+}
+
+test "Promise subclass withResolvers() runs the subclass constructor" {
+    // §27.2.4.6 step 2 routes through NewPromiseCapability(C), so the
+    // subclass constructor runs and the bundled promise is its instance.
+    try expectScriptStringWithBuiltins(
+        \\class P extends Promise {}
+        \\const w = P.withResolvers();
+        \\String(w.promise instanceof P) + "," + typeof w.resolve;
+    , "true,function");
+}
+
 // ── §24.2.4.x Set ES2025 methods ──────────────────────────────────────────
 
 test "later: Set.prototype.union returns the merged set" {
@@ -4610,6 +4637,15 @@ test "later: Set.prototype.union returns the merged set" {
         \\const b = new Set([2, 3]);
         \\Array.from(a.union(b)).sort().join(",");
     , "1,2,3");
+}
+
+test "Set.prototype.union rejects a set-like with negative size as RangeError (§24.2.1.2 step 3.f)" {
+    // §24.2.1.2 GetSetRecord step 3.f — a negative `.size` is a
+    // RangeError, distinct from the NaN-size TypeError of step 3.e.
+    try expectScriptStringWithBuiltins(
+        \\const bad = { size: -1, has() { return false; }, keys() { return [].values(); } };
+        \\try { new Set([1]).union(bad); "NO-THROW"; } catch (e) { e.constructor.name; }
+    , "RangeError");
 }
 
 test "later: Set.prototype.intersection returns elements present in both" {


### PR DESCRIPTION
Fixes #15. Fixes #16.

Two ES2025 conformance gaps surfaced by differential testing — both mode-independent (unrelated to strict/sloppy).

## #16 — `Promise.withResolvers` skips the executor-resolver gate (§27.2.4.6 / §27.2.1.5)
`promiseWithResolvers` inlined a `%Promise%`-only construction (`allocatePromiseFor` + hand-built resolvers) that never ran `Construct(C, «executor»)`. So a constructor whose executor is never invoked — `Promise.withResolvers.call(function(){})` — returned a broken capability instead of throwing `TypeError`, and a Promise **subclass**'s own constructor never ran either.

**Fix:** route through the shared `newPromiseCapability(C)` (§27.2.4.6 step 2), which performs the `Construct` and enforces §27.2.1.5 steps 7-8 (`[[Resolve]]`/`[[Reject]]` must be callable). The capability is rooted across the result-object allocation.

## #15 — Set methods accept a Set-like with negative `size` (§24.2.1.2 step 3.f)
`validateSetLike` silently clamped a negative `.size` to `0`, so `new Set([1]).union({ size: -1, … })` proceeded.

**Fix:** throw `RangeError` for a negative size, after the existing step-3.e NaN→TypeError check.

## Tests & verification
- 4 regression unit tests (3 `withResolvers` incl. the subclass-constructor case + a precise `TypeError`/`function` assertion; 1 negative-size `RangeError`).
- `zig build test`: green.
- test262: `built-ins/Promise/withResolvers` 6/6; `built-ins/Promise` 637/640 and `built-ins/Set` 393/394 — the only failures in either bucket are the pre-existing strict-only sloppy-`this` divergences (the #6 by-design class), none touched by these changes.

> Branched from `main` HEAD. Neither bug is covered by an existing test262 fixture, so both are candidates for `docs/test262-upstream-gaps.md` (follow-up).
