### PR TITLE
Atomics: $262.agent cross-agent fixtures (realm pool) + waitAsync settlement

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,6 +129,20 @@ code construction (aligns with SES).
   `collectYoung` with promotion-by-relink — has shipped (see the
   Performance section); incremental marking of the mature set is
   the remaining GC step.
+- **GC trigger at every safe-point, not only JS loop back-edges.**
+  The allocation-pressure check (`gc_threshold` / `gc_byte_threshold`)
+  runs at bytecode loop back-edges, so a microtask-driven or
+  pure-native allocation storm — e.g. a promise chain that re-defers
+  itself and never returns to a JS loop — crosses no back-edge and
+  never triggers GC. V8 / SpiderMonkey / JSC scavenge when the nursery
+  fills regardless of context; checking allocation pressure on the
+  microtask-drain boundary (and other native re-entry points) would
+  self-throttle such storms instead of relying on a later loop. A
+  companion harness fix: a real timer queue in `tools/test262.zig` so
+  the test262 `setTimeout` polyfill resolves a delay by wall-clock
+  instead of busy-spinning (what `d8` / `jsc` / Node give the runner).
+  Both were surfaced landing the `$262.agent` cross-agent `waitAsync`
+  fixtures, whose parent busy-loops on exactly this pattern.
 
 **Recently landed (was in progress; now done).**
 

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -22,6 +22,12 @@ pub const Environment = environment.Environment;
 pub const object = @import("runtime/object.zig");
 pub const JSObject = object.JSObject;
 
+// §25.2 SharedArrayBuffer backing store + the `wrapSharedBlock`
+// primitive — exposed so a host (the test262 `$262.agent` harness)
+// can hand one shared block to another agent's realm.
+pub const shared_data_block = @import("runtime/shared_data_block.zig");
+pub const typed_array_builtin = @import("runtime/builtins/typed_array.zig");
+
 pub const heap = @import("runtime/heap.zig");
 pub const Heap = heap.Heap;
 pub const HandleScope = heap.HandleScope;

--- a/src/runtime/builtins/atomics.zig
+++ b/src/runtime/builtins/atomics.zig
@@ -631,15 +631,24 @@ fn atomicsWaitAsync(realm: *Realm, _: Value, args: []const Value) NativeError!Va
         const cap = try promise_mod.newPromiseCapability(realm, promise_ctor);
         try result.set(realm.allocator, "async", Value.true_);
         try result.set(realm.allocator, "value", cap.promise);
-        // §25.4.1.4 — record the waiter so the host can fire its timeout.
-        // An untimed wait (`+∞`) gets a `+∞` deadline: only a cross-agent
-        // notify could settle it (that path is not yet wired). The
-        // capability's resolve function is rooted via `markRoots`.
+        // §25.4.1.4 AddWaiter — park on the block's process-global wait
+        // list so a cross-agent `notify` finds, counts, and wakes us. The
+        // waiting agent settles the Promise on its OWN thread — "ok" if a
+        // notify raised the node's `woken`, else "timed-out" at the
+        // deadline (`+∞` for an untimed wait, settled only by notify).
+        // The capability's resolve function is rooted via `markRoots`.
+        const block = tv.viewed.getSharedBlock().?;
+        const node = try block.addAsyncWaiter(byte_pos);
         const deadline: f64 = if (std.math.isInf(timeout_ms)) timeout_ms else nowMonoMs() + timeout_ms;
         realm.pending_async_waits.append(realm.allocator, .{
             .resolve = heap_mod.taggedFunction(cap.resolve),
             .deadline_ms = deadline,
-        }) catch return error.OutOfMemory;
+            .node = node,
+            .block = block,
+        }) catch {
+            _ = block.settleAndFreeAsyncWaiter(node);
+            return error.OutOfMemory;
+        };
     }
     return heap_mod.taggedObject(result);
 }

--- a/src/runtime/builtins/atomics.zig
+++ b/src/runtime/builtins/atomics.zig
@@ -23,6 +23,15 @@ const TypedView = ObjMod.TypedView;
 const ta_mod = @import("typed_array.zig");
 const promise_mod = @import("promise.zig");
 const SharedDataBlock = @import("../shared_data_block.zig").SharedDataBlock;
+
+/// Monotonic clock in milliseconds — the time base for an async waiter's
+/// timeout deadline. Matches the host's clock so the deadline the host
+/// polls against is the same scale.
+fn nowMonoMs() f64 {
+    var ts: std.c.timespec = undefined;
+    if (std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts) != 0) return 0;
+    return @as(f64, @floatFromInt(ts.sec)) * 1000.0 + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000.0;
+}
 const Waiter = @import("../shared_data_block.zig").Waiter;
 const builtin = @import("builtin");
 
@@ -589,13 +598,14 @@ fn atomicsWaitAsync(realm: *Realm, _: Value, args: []const Value) NativeError!Va
     const size = kind.elementSize();
     const value_bits = try coerceRawBits(realm, kind, argOr(args, 2, Value.undefined_));
     // Timeout: undefined → +∞; NaN → +∞; else max(ToInteger, 0).
-    var timeout_zero = false;
+    var timeout_ms: f64 = std.math.inf(f64);
     const timeout_v = argOr(args, 3, Value.undefined_);
     if (!timeout_v.isUndefined()) {
         const n = try toNumber(realm, timeout_v);
         const d: f64 = if (n.isInt32()) @floatFromInt(n.asInt32()) else n.asDouble();
-        if (!std.math.isNan(d) and !std.math.isInf(d)) timeout_zero = (@max(@trunc(d), 0) == 0);
+        if (!std.math.isNan(d) and !std.math.isInf(d)) timeout_ms = @max(@trunc(d), 0);
     }
+    const timeout_zero = (timeout_ms == 0);
     const byte_pos = tv.byte_offset + idx * size;
     const cur_bits = readRawBits(buf, size, byte_pos);
     const mask: u64 = if (size == 8) std.math.maxInt(u64) else (@as(u64, 1) << @intCast(size * 8)) - 1;
@@ -621,6 +631,15 @@ fn atomicsWaitAsync(realm: *Realm, _: Value, args: []const Value) NativeError!Va
         const cap = try promise_mod.newPromiseCapability(realm, promise_ctor);
         try result.set(realm.allocator, "async", Value.true_);
         try result.set(realm.allocator, "value", cap.promise);
+        // §25.4.1.4 — record the waiter so the host can fire its timeout.
+        // An untimed wait (`+∞`) gets a `+∞` deadline: only a cross-agent
+        // notify could settle it (that path is not yet wired). The
+        // capability's resolve function is rooted via `markRoots`.
+        const deadline: f64 = if (std.math.isInf(timeout_ms)) timeout_ms else nowMonoMs() + timeout_ms;
+        realm.pending_async_waits.append(realm.allocator, .{
+            .resolve = heap_mod.taggedFunction(cap.resolve),
+            .deadline_ms = deadline,
+        }) catch return error.OutOfMemory;
     }
     return heap_mod.taggedObject(result);
 }

--- a/src/runtime/builtins/atomics.zig
+++ b/src/runtime/builtins/atomics.zig
@@ -28,6 +28,7 @@ const SharedDataBlock = @import("../shared_data_block.zig").SharedDataBlock;
 /// timeout deadline. Matches the host's clock so the deadline the host
 /// polls against is the same scale.
 fn nowMonoMs() f64 {
+    if (builtin.os.tag == .freestanding) return 0;
     var ts: std.c.timespec = undefined;
     if (std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts) != 0) return 0;
     return @as(f64, @floatFromInt(ts.sec)) * 1000.0 + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000.0;

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -115,6 +115,7 @@ const genResultObject = generator.genResultObject;
 const promise = @import("promise.zig");
 pub const wrapInPromise = promise.wrapInPromise;
 pub const drainMicrotasks = promise.drainMicrotasks;
+pub const fireExpiredAsyncWaits = promise.fireExpiredAsyncWaits;
 pub const resolvePromiseWithValue = promise.resolvePromiseWithValue;
 pub const resumeAsyncFunction = promise.resumeAsyncFunction;
 pub const resumeAsyncGeneratorOnSettle = promise.resumeAsyncGeneratorOnSettle;

--- a/src/runtime/lantern/promise.zig
+++ b/src/runtime/lantern/promise.zig
@@ -23,6 +23,7 @@ const Environment = @import("../environment.zig").Environment;
 const heap_mod = @import("../heap.zig");
 const intrinsics_mod = @import("../intrinsics.zig");
 const Realm = @import("../realm.zig").Realm;
+const shared_data_block = @import("../shared_data_block.zig");
 const Chunk = @import("../../bytecode/chunk.zig").Chunk;
 const module_mod = @import("../module.zig");
 
@@ -73,6 +74,38 @@ pub fn wrapInPromise(realm: *Realm, fulfilled: bool, value: Value) !Value {
 /// sites + at every external boundary (the CLI / test262
 /// runner). Microtasks queued during draining run before this
 /// call returns (FIFO), matching §9.4.
+/// §25.4.1.4 host-driven TriggerTimeout / wake: settle every pending
+/// async waiter whose deadline passed or that a cross-agent `notify`
+/// woke — resolve its Promise "ok" (woken) or "timed-out" and free the
+/// block node. Returns whether any fired so a drain loop re-runs to
+/// propagate the resolutions. A no-op (one length check) when nothing is
+/// pending. Driven from `drainMicrotasks` (so a main-agent poll loop's
+/// timeout fires) and from the test262 agent pool's idle loop.
+pub fn fireExpiredAsyncWaits(allocator: std.mem.Allocator, realm: *Realm) RunError!bool {
+    if (realm.pending_async_waits.items.len == 0) return false;
+    const now = shared_data_block.monoNowMs();
+    const scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer scope.close();
+    var fired = false;
+    var i: usize = 0;
+    while (i < realm.pending_async_waits.items.len) {
+        const entry = realm.pending_async_waits.items[i];
+        if (entry.node.woken.load(.acquire) or now >= entry.deadline_ms) {
+            _ = realm.pending_async_waits.orderedRemove(i);
+            const ok = entry.block.settleAndFreeAsyncWaiter(entry.node);
+            const resolve_fn = heap_mod.valueAsFunction(entry.resolve) orelse continue;
+            const str = realm.heap.allocateString(if (ok) "ok" else "timed-out") catch return error.OutOfMemory;
+            const arg = Value.fromString(str);
+            scope.push(arg) catch {};
+            _ = try callJSFunction(allocator, realm, resolve_fn, Value.undefined_, &.{arg});
+            fired = true;
+        } else {
+            i += 1;
+        }
+    }
+    return fired;
+}
+
 pub fn drainMicrotasks(allocator: std.mem.Allocator, realm: *Realm) RunError!void {
     // §9.10.4.2 ClearKeptObjects — the synchronous block that
     // queued whatever's about to drain just ended; release any
@@ -85,6 +118,11 @@ pub fn drainMicrotasks(allocator: std.mem.Allocator, realm: *Realm) RunError!voi
     // SpiderMonkey.
     realm.clearKeptObjects();
     while (realm.microtask_queue.items.len > 0) {
+        // Host-drive any §25.4.1.4 waitAsync timeout/wake whose moment
+        // arrived during this drain (e.g. a main-agent `setTimeout` poll
+        // loop keeps the queue non-empty while real time advances toward
+        // the wait's deadline).
+        _ = fireExpiredAsyncWaits(allocator, realm) catch {};
         // §16.2.1.10 EvaluateImportCall — a deferred dynamic-import
         // job (`.module_import`) must not run while a synchronous
         // module-graph DFS is still in progress (`module_load_depth

--- a/src/runtime/multi_agent_test.zig
+++ b/src/runtime/multi_agent_test.zig
@@ -17,6 +17,7 @@ const lantern = @import("lantern/interpreter.zig");
 const SharedDataBlock = @import("shared_data_block.zig").SharedDataBlock;
 const ta = @import("builtins/typed_array.zig");
 const heap_mod = @import("heap.zig");
+const JSString = @import("string.zig").JSString;
 
 /// Each agent: a fresh Realm on its own thread, doing real allocating
 /// work (objects + arrays + GC pressure) to shake out cross-thread
@@ -230,4 +231,145 @@ test "multi-agent: Atomics.compareExchange serializes a shared counter" {
     for (outs) |o| try testing.expectEqual(@as(i32, 0), o);
     const total = std.mem.readInt(i32, block.bytes[0..4], .little);
     try testing.expectEqual(@as(i32, N * iters), total);
+}
+
+
+// ── async `Atomics.waitAsync` across threads ─────────────────────────
+// Engine-level companions to the sync wait/notify test above. The sync
+// node blocks its thread; an async node has no blocking frame, so it
+// lives on the block's wait list while the waiting agent drives its own
+// microtask drain + §25.4.1.4 settlement. These prove that path without
+// the test262 harness — the go/no-go gate for the cross-agent surface.
+
+fn napMs(ms: u64) void {
+    var req: std.c.timespec = .{ .sec = @intCast(ms / 1000), .nsec = @intCast((ms % 1000) * std.time.ns_per_ms) };
+    _ = std.c.nanosleep(&req, null);
+}
+
+/// Read the JS global `outcome`: 0 still unset (null), 1 "ok",
+/// 2 "timed-out", 3 "not-equal", 9 anything else.
+fn readOutcomeCode(realm: *Realm) i32 {
+    const v = realm.globals.get("outcome") orelse return 0;
+    if (!v.isString()) return 0;
+    const str: *JSString = @ptrCast(@alignCast(v.asString()));
+    const b = str.flatBytes();
+    if (std.mem.eql(u8, b, "ok")) return 1;
+    if (std.mem.eql(u8, b, "timed-out")) return 2;
+    if (std.mem.eql(u8, b, "not-equal")) return 3;
+    return 9;
+}
+
+/// Build a realm over `block`, run `src` (which parks an async waiter and
+/// records its settled value in `outcome`), then host-drive the wait to
+/// completion. Writes the outcome code to `out`. A finite iteration
+/// backstop so a regression fails fast instead of hanging the suite.
+fn asyncWaiterAgent(block: *SharedDataBlock, src: []const u8, out: *i32) void {
+    var realm = Realm.init(std.heap.page_allocator);
+    defer realm.deinit();
+    realm.installBuiltins() catch {
+        out.* = -1;
+        return;
+    };
+    const sab = ta.wrapSharedBlock(&realm, block) catch {
+        out.* = -2;
+        return;
+    };
+    realm.globals.put(realm.allocator, "sab", sab) catch {
+        out.* = -3;
+        return;
+    };
+    _ = lantern.evaluateScript(std.heap.page_allocator, &realm, src) catch {
+        out.* = -4;
+        return;
+    };
+    var iters: usize = 0;
+    while (iters < 5000) : (iters += 1) {
+        lantern.drainMicrotasks(realm.allocator, &realm) catch {};
+        _ = lantern.fireExpiredAsyncWaits(realm.allocator, &realm) catch {};
+        lantern.drainMicrotasks(realm.allocator, &realm) catch {};
+        if (readOutcomeCode(&realm) != 0) break;
+        napMs(1);
+    }
+    out.* = readOutcomeCode(&realm);
+}
+
+test "multi-agent: a cross-thread notify wakes an async waitAsync (ok)" {
+    const block = try SharedDataBlock.create(16, 16);
+    defer block.release();
+
+    var wait_result: i32 = 0;
+    var notify_result: i32 = 0;
+    // The waiter parks the async node BEFORE signalling RUNNING (index 1),
+    // so a notifier that observes RUNNING is guaranteed to find the node —
+    // notify returns exactly 1 (unlike the sync test, where the park
+    // happens after RUNNING and the count can race).
+    const waiter = try std.Thread.spawn(.{}, asyncWaiterAgent, .{
+        block,
+        \\var i32 = new Int32Array(sab);
+        \\var outcome = null;
+        \\Atomics.waitAsync(i32, 0, 0, 10000).value.then(function (v) { outcome = v; });
+        \\Atomics.store(i32, 1, 1);
+        ,
+        &wait_result,
+    });
+    const notifier = try std.Thread.spawn(.{}, agentOverBlock, .{
+        block,
+        \\var i32 = new Int32Array(sab);
+        \\var guard = 0;
+        \\while (Atomics.load(i32, 1) !== 1) { if (++guard > 500000000) break; }
+        \\Atomics.notify(i32, 0, 1);
+        ,
+        &notify_result,
+    });
+    waiter.join();
+    notifier.join();
+    // The async wait resolved "ok" (woken), and notify reported it woke 1.
+    try testing.expectEqual(@as(i32, 1), wait_result);
+    try testing.expectEqual(@as(i32, 1), notify_result);
+}
+
+test "multi-agent: an async waitAsync settles timed-out at its deadline" {
+    const block = try SharedDataBlock.create(16, 16);
+    defer block.release();
+
+    var result: i32 = 0;
+    // No notifier: a 50 ms timeout must settle "timed-out" on the
+    // waiter's own thread as its drive loop's wall-clock passes the
+    // deadline.
+    const waiter = try std.Thread.spawn(.{}, asyncWaiterAgent, .{
+        block,
+        \\var i32 = new Int32Array(sab);
+        \\var outcome = null;
+        \\Atomics.waitAsync(i32, 0, 0, 50).value.then(function (v) { outcome = v; });
+        \\Atomics.store(i32, 1, 1);
+        ,
+        &result,
+    });
+    waiter.join();
+    try testing.expectEqual(@as(i32, 2), result);
+}
+
+test "multi-agent: clearPendingAsyncWaits unlinks the block node (no dangle)" {
+    const block = try SharedDataBlock.create(8, 8);
+    defer block.release();
+
+    var realm = Realm.init(std.heap.page_allocator);
+    defer realm.deinit();
+    try realm.installBuiltins();
+    const sab = try ta.wrapSharedBlock(&realm, block);
+    try realm.globals.put(realm.allocator, "sab", sab);
+
+    // Park an untimed async waiter, then abandon it without settling — as
+    // a reaped fixture / torn-down realm would.
+    _ = lantern.evaluateScript(std.heap.page_allocator, &realm, "var i32 = new Int32Array(sab); Atomics.waitAsync(i32, 0, 0);") catch {};
+    try testing.expectEqual(@as(usize, 1), realm.pending_async_waits.items.len);
+
+    // Teardown cleanup detaches + frees the node, so it can't dangle on
+    // the still-shared block: a notify now finds nothing parked.
+    realm.clearPendingAsyncWaits();
+    try testing.expectEqual(@as(usize, 0), realm.pending_async_waits.items.len);
+    block.lockWaiters();
+    const woke = block.wakeWaiters(0, std.math.maxInt(u32));
+    block.unlockWaiters();
+    try testing.expectEqual(@as(u32, 0), woke);
 }

--- a/src/runtime/multi_agent_test.zig
+++ b/src/runtime/multi_agent_test.zig
@@ -233,7 +233,6 @@ test "multi-agent: Atomics.compareExchange serializes a shared counter" {
     try testing.expectEqual(@as(i32, N * iters), total);
 }
 
-
 // ── async `Atomics.waitAsync` across threads ─────────────────────────
 // Engine-level companions to the sync wait/notify test above. The sync
 // node blocks its thread; an async node has no blocking frame, so it

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -20,6 +20,7 @@ const JSString = @import("string.zig").JSString;
 const JSFunction = @import("function.zig").JSFunction;
 const NativeFn = @import("function.zig").NativeFn;
 const heap_mod = @import("heap.zig");
+const shared_data_block = @import("shared_data_block.zig");
 const intrinsics_mod = @import("intrinsics.zig");
 const Intrinsics = intrinsics_mod.Intrinsics;
 const features = @import("features.zig");
@@ -607,12 +608,17 @@ pub const GlobalBindings = struct {
 
 /// §25.4.1.4 one pending `Atomics.waitAsync` whose Promise is still
 /// unsettled. `resolve` is the capability's resolve function (called
-/// with `"timed-out"` when the deadline passes); `deadline_ms` is an
-/// absolute monotonic timestamp in milliseconds (`+inf` for an
-/// untimed wait, which only a cross-agent notify can settle).
+/// with `"timed-out"` or `"ok"` when the wait settles); `deadline_ms` is
+/// an absolute monotonic timestamp in milliseconds (`+inf` for an
+/// untimed wait, which only a cross-agent notify can settle). `node` is
+/// this waiter's entry on `block`'s process-global wait list, where a
+/// cross-agent `notify` finds it; the waiting agent reads `node.woken`
+/// to decide "ok" vs "timed-out" and frees the node on settle.
 pub const AsyncWaitRecord = struct {
     resolve: Value,
     deadline_ms: f64,
+    node: *shared_data_block.Waiter,
+    block: *shared_data_block.SharedDataBlock,
 };
 
 pub const Realm = struct {
@@ -1073,6 +1079,7 @@ pub const Realm = struct {
         self.globals.deinit(self.allocator);
         self.output.deinit(self.allocator);
         self.microtask_queue.deinit(self.allocator);
+        self.clearPendingAsyncWaits();
         self.pending_async_waits.deinit(self.allocator);
         self.kept_alive.deinit(self.allocator);
         self.pending_indirect_export_validation.deinit(self.allocator);
@@ -1355,6 +1362,15 @@ pub const Realm = struct {
     /// Called from the interpreter dispatch loop when
     /// `heap.allocs_since_gc` crosses `heap.gc_threshold`. The
     /// counter resets to zero at the end of `heap.collect`.
+    /// Detach + free every pending async waiter's heap node from its
+    /// block (so none dangles on a still-shared block), then empty the
+    /// list. Leaves the Promises unsettled — for realm teardown or an
+    /// agent-realm reset where the realm is going away / being scrubbed.
+    pub fn clearPendingAsyncWaits(self: *Realm) void {
+        for (self.pending_async_waits.items) |w| _ = w.block.settleAndFreeAsyncWaiter(w.node);
+        self.pending_async_waits.clearRetainingCapacity();
+    }
+
     pub fn collectGarbage(self: *Realm) void {
         // §26.1 / §24.3 / §24.4 / §26.2 — arm the major cycle
         // BEFORE `markRoots`. `markRoots` calls `markValue` on every

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -605,6 +605,16 @@ pub const GlobalBindings = struct {
     }
 };
 
+/// §25.4.1.4 one pending `Atomics.waitAsync` whose Promise is still
+/// unsettled. `resolve` is the capability's resolve function (called
+/// with `"timed-out"` when the deadline passes); `deadline_ms` is an
+/// absolute monotonic timestamp in milliseconds (`+inf` for an
+/// untimed wait, which only a cross-agent notify can settle).
+pub const AsyncWaitRecord = struct {
+    resolve: Value,
+    deadline_ms: f64,
+};
+
 pub const Realm = struct {
     allocator: std.mem.Allocator,
     /// `*Heap` so multiple Realms can share one heap — required
@@ -742,6 +752,16 @@ pub const Realm = struct {
     /// `await` opcode site. Each entry is a function to call
     /// with one argument.
     microtask_queue: std.ArrayListUnmanaged(Microtask) = .empty,
+    /// §25.4.1.4 pending async waiters — one per `Atomics.waitAsync`
+    /// whose value matched and whose timeout is non-zero, so its
+    /// Promise is still unsettled. Each record carries the capability's
+    /// resolve function and an absolute monotonic deadline (ms). The
+    /// spec fires the timeout "in parallel"; with no real event loop the
+    /// host drives it — polling these deadlines while draining
+    /// microtasks and resolving an expired waiter with `"timed-out"`.
+    /// (Cross-agent `notify` resolution is separate.) `markRoots` keeps
+    /// each resolve function live.
+    pending_async_waits: std.ArrayListUnmanaged(AsyncWaitRecord) = .empty,
     /// §9.10 [[KeptAlive]] — the per-agent "keep alive across the
     /// current job" list. `WeakRef.prototype.deref` (§26.1.4.1
     /// step 2a) and the `WeakRef` constructor (§26.1.1.1 step 4)
@@ -1053,6 +1073,7 @@ pub const Realm = struct {
         self.globals.deinit(self.allocator);
         self.output.deinit(self.allocator);
         self.microtask_queue.deinit(self.allocator);
+        self.pending_async_waits.deinit(self.allocator);
         self.kept_alive.deinit(self.allocator);
         self.pending_indirect_export_validation.deinit(self.allocator);
         // ModuleRecords are owned by the realm; the heap
@@ -1489,6 +1510,11 @@ pub const Realm = struct {
             self.heap.markValue(mt.reaction_handler);
             self.heap.markValue(mt.reaction_result);
         }
+
+        // §25.4.1.4 pending async waiters — keep each unsettled
+        // capability's resolve function alive until it fires or is
+        // dropped at realm reset.
+        for (self.pending_async_waits.items) |w| self.heap.markValue(w.resolve);
 
         // §9.10 [[KeptAlive]] — `WeakRef` constructor / `deref`
         // pin targets here for the duration of the current job.

--- a/src/runtime/shared_data_block.zig
+++ b/src/runtime/shared_data_block.zig
@@ -22,11 +22,23 @@ const std = @import("std");
 /// is released and the block is freed.
 pub var live_blocks: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
 
-/// One parked `Atomics.wait`. The node lives on the *waiting thread's
-/// stack* and is linked into its block's wait list for the duration of
-/// the wait — the list owns no memory. A waiter unlinks itself (under
-/// `wait_lock`) before its frame returns, so `notify` (which only walks
-/// the list under the same lock) can never touch a dead node.
+/// Monotonic clock in milliseconds — the time base for `Atomics.waitAsync`
+/// deadlines (the wait records `now + timeout`; whatever host drives the
+/// timeout polls against the same scale). Uses libc's monotonic clock.
+pub fn monoNowMs() f64 {
+    var ts: std.c.timespec = undefined;
+    if (std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts) != 0) return 0;
+    return @as(f64, @floatFromInt(ts.sec)) * 1000.0 + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000.0;
+}
+
+/// One parked waiter. A synchronous `Atomics.wait` node lives on the
+/// *waiting thread's stack* and is unlinked before its frame returns. An
+/// `Atomics.waitAsync` node has no blocking frame, so it is heap-
+/// allocated (`addAsyncWaiter`) and lives on the list until the waiting
+/// agent settles it (`settleAndFreeAsyncWaiter`). Either kind is linked
+/// into its block's wait list under `wait_lock`, so `notify` — which
+/// only walks the list under the same lock — can never touch a dead
+/// node.
 pub const Waiter = struct {
     /// §25.4 keys the wait list on the byte index within the block, so
     /// two views over the same block waiting on the same byte share a
@@ -34,6 +46,10 @@ pub const Waiter = struct {
     byte_pos: usize,
     /// Raised by `notify` (under `wait_lock`); the waiter polls it.
     woken: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// True for a heap-allocated `waitAsync` node (freed on settle);
+    /// false for a stack `wait` node (no free). Documents the lifetime
+    /// and guards `settleAndFreeAsyncWaiter` against a stack node.
+    is_async: bool = false,
     next: ?*Waiter = null,
 };
 
@@ -161,4 +177,92 @@ pub const SharedDataBlock = struct {
         }
         return n;
     }
+
+    // ── §25.4 async waiters ─────────────────────────────────────────
+    // `Atomics.waitAsync` returns immediately, so its waiter outlives the
+    // call — it can't live on a stack frame. Heap-allocate it on the
+    // block's process-global allocator and link it like any other
+    // waiter, so a cross-agent `notify` (which walks the same list)
+    // wakes + counts it. The waiting agent settles it on its OWN thread
+    // (the notifier can't touch the waiter agent's heap to resolve the
+    // Promise): "ok" if a notify raised `woken`, else "timed-out".
+
+    /// Allocate + link a heap async waiter on `byte_pos`. Freed by
+    /// `settleAndFreeAsyncWaiter`.
+    pub fn addAsyncWaiter(self: *SharedDataBlock, byte_pos: usize) !*Waiter {
+        const gpa = std.heap.page_allocator;
+        const w = try gpa.create(Waiter);
+        w.* = .{ .byte_pos = byte_pos, .is_async = true };
+        self.lockWaiters();
+        self.addWaiter(w);
+        self.unlockWaiters();
+        return w;
+    }
+
+    /// Under the lock, read whether a `notify` woke `w`, unlink it, then
+    /// free it. Returns the woken flag so the caller resolves the
+    /// Promise "ok" (woken) or "timed-out". Reading `woken` + unlinking
+    /// in one critical section mirrors the sync `wait` timeout settle, so
+    /// a notify racing the deadline can't leave the woken count and the
+    /// resolved value disagreeing.
+    pub fn settleAndFreeAsyncWaiter(self: *SharedDataBlock, w: *Waiter) bool {
+        std.debug.assert(w.is_async);
+        self.lockWaiters();
+        const woken = w.woken.load(.acquire);
+        self.removeWaiter(w);
+        self.unlockWaiters();
+        std.heap.page_allocator.destroy(w);
+        return woken;
+    }
 };
+
+test "async waiter on the block list is woken + counted by notify" {
+    const testing = std.testing;
+    const block = try SharedDataBlock.create(8, 8);
+    defer block.release();
+
+    // Park an async waiter on byte 0; a notify at byte 0 wakes exactly it.
+    const w = try block.addAsyncWaiter(0);
+    block.lockWaiters();
+    const woke = block.wakeWaiters(0, 1);
+    block.unlockWaiters();
+    try testing.expectEqual(@as(u32, 1), woke);
+    // The waiting agent settles on its own thread → "ok" (woken).
+    try testing.expect(block.settleAndFreeAsyncWaiter(w));
+}
+
+test "notify at another index does not wake an async waiter (timed-out)" {
+    const testing = std.testing;
+    const block = try SharedDataBlock.create(16, 16);
+    defer block.release();
+
+    const w = try block.addAsyncWaiter(0);
+    // A notify on byte 4 must not touch the byte-0 waiter.
+    block.lockWaiters();
+    const woke = block.wakeWaiters(4, std.math.maxInt(u32));
+    block.unlockWaiters();
+    try testing.expectEqual(@as(u32, 0), woke);
+    // No notify reached it → settle reports not-woken (→ "timed-out").
+    try testing.expect(!block.settleAndFreeAsyncWaiter(w));
+}
+
+test "notify wakes up to count async waiters and reports the number" {
+    const testing = std.testing;
+    const block = try SharedDataBlock.create(8, 8);
+    defer block.release();
+
+    const a = try block.addAsyncWaiter(0);
+    const b = try block.addAsyncWaiter(0);
+    const c = try block.addAsyncWaiter(0);
+    // count=2 wakes exactly two of the three parked on byte 0.
+    block.lockWaiters();
+    const woke = block.wakeWaiters(0, 2);
+    block.unlockWaiters();
+    try testing.expectEqual(@as(u32, 2), woke);
+    // Two settle "ok", the third "timed-out"; total woken == 2.
+    var ok: u32 = 0;
+    if (block.settleAndFreeAsyncWaiter(a)) ok += 1;
+    if (block.settleAndFreeAsyncWaiter(b)) ok += 1;
+    if (block.settleAndFreeAsyncWaiter(c)) ok += 1;
+    try testing.expectEqual(@as(u32, 2), ok);
+}

--- a/src/runtime/shared_data_block.zig
+++ b/src/runtime/shared_data_block.zig
@@ -14,6 +14,14 @@
 
 const std = @import("std");
 
+/// Process-global count of currently-live shared data blocks (created
+/// minus freed). A diagnostic hook: a host that creates and destroys
+/// many short-lived blocks can assert this returns to its baseline to
+/// catch a block that was never released (a leaked reference pinning
+/// shared memory). Bumped in `create`, dropped when the final reference
+/// is released and the block is freed.
+pub var live_blocks: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
+
 /// One parked `Atomics.wait`. The node lives on the *waiting thread's
 /// stack* and is linked into its block's wait list for the duration of
 /// the wait — the list owns no memory. A waiter unlinks itself (under
@@ -73,6 +81,7 @@ pub const SharedDataBlock = struct {
             .max_byte_length = max_byte_length,
             .refcount = std.atomic.Value(usize).init(1),
         };
+        _ = live_blocks.fetchAdd(1, .monotonic);
         return self;
     }
 
@@ -92,6 +101,7 @@ pub const SharedDataBlock = struct {
             const gpa = std.heap.page_allocator;
             gpa.free(self.bytes);
             gpa.destroy(self);
+            _ = live_blocks.fetchSub(1, .monotonic);
         }
     }
 

--- a/src/runtime/shared_data_block.zig
+++ b/src/runtime/shared_data_block.zig
@@ -13,6 +13,7 @@
 //! `docs/multi-agent-atomics.md`).
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// Process-global count of currently-live shared data blocks (created
 /// minus freed). A diagnostic hook: a host that creates and destroys
@@ -26,6 +27,9 @@ pub var live_blocks: std.atomic.Value(usize) = std.atomic.Value(usize).init(0);
 /// deadlines (the wait records `now + timeout`; whatever host drives the
 /// timeout polls against the same scale). Uses libc's monotonic clock.
 pub fn monoNowMs() f64 {
+    // The monotonic clock needs libc; a freestanding (wasm) build has
+    // none, so report 0 — single-agent wasm has no real timer anyway.
+    if (builtin.os.tag == .freestanding) return 0;
     var ts: std.c.timespec = undefined;
     if (std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts) != 0) return 0;
     return @as(f64, @floatFromInt(ts.sec)) * 1000.0 + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000.0;

--- a/test262-results.md
+++ b/test262-results.md
@@ -1,16 +1,16 @@
 # test262 conformance — Cynic
 
-**Cynic passes 90.47 % of the 49808 test262 fixtures it runs**, scored binary pass/fail under a single posture (`--unhardened --allow=eval`):
+**Cynic passes 90.50 % of the 49808 test262 fixtures it runs**, scored binary pass/fail under a single posture (`--unhardened --allow=eval`):
 
-- **45062 passing** — Cynic produced the spec-expected result.
-- **4746 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only / SES / eval miss counts as a plain fail, same as an engine bug. Honest, not flattering.
+- **45075 passing** — Cynic produced the spec-expected result.
+- **4733 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only / SES / eval miss counts as a plain fail, same as an engine bug. Honest, not flattering.
 - **Excluded from the denominator**: the upstream `harness/` and `staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal (decorators, import-defer, …), and structurally-unrunnable fixtures (no / malformed frontmatter). Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) get their own scoreboard below.
 
 ## Current scores
 
 | posture | passing | failing | total | pass% |
 |---|---:|---:|---:|---:|
-| **`--unhardened --allow=eval`** | 45062 | 4746 | 49808 | 90.47 % |
+| **`--unhardened --allow=eval`** | 45075 | 4733 | 49808 | 90.50 % |
 
 > **pass%** = `passing / (passing + failing)`. Every scored
 > fixture is a plain pass or fail — there is no "expected
@@ -99,7 +99,6 @@ list.
 | `language/arguments-object` | 225 | 38 | 86 % |
 | `language/types` | 102 | 11 | 90 % |
 | `built-ins/Proxy` | 298 | 13 | 96 % |
-| `built-ins/Atomics` | 367 | 15 | 96 % |
 | `built-ins/Object` | 3329 | 82 | 98 % |
 | `built-ins/TypedArrayConstructors` | 719 | 17 | 98 % |
 | `built-ins/Array` | 3054 | 27 | 99 % |
@@ -128,6 +127,7 @@ list.
 | `language/module-code` | 589 | 6 | 99 % |
 | `built-ins/JSON` | 164 | 1 | 99 % |
 | `built-ins/TypedArray` | 1430 | 8 | 99 % |
+| `built-ins/Atomics` | 380 | 2 | 99 % |
 | `built-ins/String` | 1217 | 6 | 100 % |
 | `built-ins/Map` | 203 | 1 | 100 % |
 | `built-ins/Promise` | 637 | 3 | 100 % |
@@ -214,17 +214,15 @@ top-line score.
 
 ## History
 
-### 2026-06-04 — cynic `59e9b17`, test262 `d0c1b4555b`
+### 2026-06-04 — cynic `27426c4`, test262 `d0c1b455`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
-| 45062 | 4746 | 49808 | 90.47 % | +112 | 35.4 s |
+| 45075 | 4733 | 49808 | 90.50 % | +125 | 50.1 s |
 
 Biggest movers:
 
-- `built-ins/Atomics` +99
-- `language/statements` +12
-- `built-ins/Reflect` +1
+- `built-ins/Atomics` +13
 
 ### 2026-06-03 — cynic `51dc5d2`, test262 `d0c1b455`
 

--- a/test262-results.md
+++ b/test262-results.md
@@ -1,16 +1,16 @@
 # test262 conformance — Cynic
 
-**Cynic passes 90.25 % of the 49808 test262 fixtures it runs**, scored binary pass/fail under a single posture (`--unhardened --allow=eval`):
+**Cynic passes 90.47 % of the 49808 test262 fixtures it runs**, scored binary pass/fail under a single posture (`--unhardened --allow=eval`):
 
-- **44950 passing** — Cynic produced the spec-expected result.
-- **4858 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only miss counts as a plain fail, same as an engine bug. Honest, not flattering. (This posture has SES off and eval on, so neither is a failure source here.)
+- **45062 passing** — Cynic produced the spec-expected result.
+- **4746 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only / SES / eval miss counts as a plain fail, same as an engine bug. Honest, not flattering.
 - **Excluded from the denominator**: the upstream `harness/` and `staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal (decorators, import-defer, …), and structurally-unrunnable fixtures (no / malformed frontmatter). Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) get their own scoreboard below.
 
 ## Current scores
 
 | posture | passing | failing | total | pass% |
 |---|---:|---:|---:|---:|
-| **`--unhardened --allow=eval`** | 44950 | 4858 | 49808 | 90.25 % |
+| **`--unhardened --allow=eval`** | 45062 | 4746 | 49808 | 90.47 % |
 
 > **pass%** = `passing / (passing + failing)`. Every scored
 > fixture is a plain pass or fail — there is no "expected
@@ -32,9 +32,8 @@ engine's spec coverage with the policy knobs out of the way.
 
 - **`passing`** — Cynic produced the spec-expected result.
 - **`failing`** — every other scored fixture. An Annex B,
-  no-Intl, or strict-only miss counts as a plain fail, same
-  as an engine bug. (Under this posture SES is off and eval
-  is on, so neither produces a failure.)
+  no-Intl, strict-only, SES, or eval miss counts as a plain
+  fail, same as an engine bug.
 - **`total`** — `passing + failing`. Excludes the upstream
   `harness/` / `staging/` / `annexB/` paths, Stage ≤ 3
   proposals, and structurally-unrunnable fixtures.
@@ -78,8 +77,7 @@ list.
 | `intl402/Locale` | 0 | 152 | 0 % |
 | `intl402/NumberFormat` | 0 | 253 | 0 % |
 | `language/eval-code` | 158 | 189 | 46 % |
-| `built-ins/Atomics` | 268 | 114 | 70 % |
-| `language/statements` | 8902 | 421 | 95 % |
+| `language/statements` | 8914 | 409 | 96 % |
 | `language/expressions` | 10227 | 455 | 96 % |
 
 **10–99 fails**
@@ -101,6 +99,7 @@ list.
 | `language/arguments-object` | 225 | 38 | 86 % |
 | `language/types` | 102 | 11 | 90 % |
 | `built-ins/Proxy` | 298 | 13 | 96 % |
+| `built-ins/Atomics` | 367 | 15 | 96 % |
 | `built-ins/Object` | 3329 | 82 | 98 % |
 | `built-ins/TypedArrayConstructors` | 719 | 17 | 98 % |
 | `built-ins/Array` | 3054 | 27 | 99 % |
@@ -127,7 +126,6 @@ list.
 | `language/comments` | 51 | 1 | 98 % |
 | `language/literals` | 527 | 7 | 99 % |
 | `language/module-code` | 589 | 6 | 99 % |
-| `built-ins/Reflect` | 152 | 1 | 99 % |
 | `built-ins/JSON` | 164 | 1 | 99 % |
 | `built-ins/TypedArray` | 1430 | 8 | 99 % |
 | `built-ins/String` | 1217 | 6 | 100 % |
@@ -161,6 +159,7 @@ list.
 | `built-ins/Math` | 327 | 0 | 100 % |
 | `built-ins/NativeErrors` | 94 | 0 | 100 % |
 | `built-ins/Number` | 340 | 0 | 100 % |
+| `built-ins/Reflect` | 153 | 0 | 100 % |
 | `built-ins/RegExpStringIteratorPrototype` | 17 | 0 | 100 % |
 | `built-ins/SetIteratorPrototype` | 11 | 0 | 100 % |
 | `built-ins/SharedArrayBuffer` | 104 | 0 | 100 % |
@@ -215,15 +214,23 @@ top-line score.
 
 ## History
 
+### 2026-06-04 — cynic `59e9b17`, test262 `d0c1b4555b`
+
+| passing | failing | total | pass% | Δ pass | elapsed |
+|---:|---:|---:|---:|---:|---:|
+| 45062 | 4746 | 49808 | 90.47 % | +112 | 35.4 s |
+
+Biggest movers:
+
+- `built-ins/Atomics` +99
+- `language/statements` +12
+- `built-ins/Reflect` +1
+
 ### 2026-06-03 — cynic `51dc5d2`, test262 `d0c1b455`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 44950 | 4858 | 49808 | 90.25 % | +528 | 25.1 s |
-
-Biggest movers:
-
-- `built-ins/Atomics` +55
 
 ### 2026-06-02 — cynic `bd0337e`, test262 `d0c1b455`
 

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -365,6 +365,602 @@ fn throwTest262SyntaxError(realm: *cynic.runtime.Realm, msg: []const u8) cynic.r
 
 /// Install the `$262` host object on `realm.globals`. Idempotent
 /// per realm (caller invokes once, before evaluating user code).
+// ════════════════════════════════════════════════════════════════════
+//   §INTERPRETING.md `$262.agent` — multi-agent harness (real threads)
+// ════════════════════════════════════════════════════════════════════
+//
+// Each agent runs on its own OS thread with its own Realm + heap;
+// agents share ONLY a SharedArrayBuffer's bytes (a refcounted
+// SharedDataBlock) plus the channels below. `atomicsHelper.js`
+// (auto-loaded as an `includes:`) builds waitUntil / tryYield /
+// safeBroadcast / getReportAsync / timeouts on top of these host
+// primitives. See docs/multi-agent-atomics.md.
+
+const AgentSDB = cynic.runtime.shared_data_block.SharedDataBlock;
+const AgentVal = cynic.runtime.Value;
+const max_agents = 16;
+
+/// One agent task — `$262.agent.start(src)` enqueues it. It is run
+/// either by a persistent pool worker (the common path) or, when the
+/// pool is momentarily saturated, by a private one-shot thread. Its
+/// channels (broadcast in, reports out via `group`) are the only shared
+/// surface; the realm it runs in is the worker's, never touched here.
+const AgentThreadState = struct {
+    group: *AgentGroup,
+    /// parent → agent: the broadcast block (set by `$262.agent.broadcast`).
+    bcast: std.atomic.Value(?*AgentSDB) = std.atomic.Value(?*AgentSDB).init(null),
+    /// owned copy of the agent source (page_allocator). The compiled
+    /// chunk borrows slices of it (function / binding names for
+    /// `Function.prototype.toString`), and a pool worker's realm keeps
+    /// chunks across tasks — so a pool worker takes ownership and frees
+    /// it only at worker shutdown; a private thread frees it at teardown.
+    src: []u8,
+    /// set on the running thread by `$262.agent.receiveBroadcast`.
+    callback: ?AgentVal = null,
+    /// the private OS thread, when the pool was saturated — joined (not
+    /// detached) at fixture teardown. Null for a pooled task.
+    thread: ?std.Thread = null,
+    /// Raised by the running thread when the task is fully complete (the
+    /// agent reported + its realm was reset). `reapAgents` waits on this
+    /// for pooled tasks (pool threads persist; they aren't joined).
+    done: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+const AgentGroup = struct {
+    states: [max_agents]?*AgentThreadState = @splat(null),
+    count: usize = 0,
+    reg_lock: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// agent → parent: report queue (owned strings, page_allocator).
+    reports: std.ArrayListUnmanaged([]u8) = .empty,
+    reports_lock: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+    /// Set at fixture teardown to release any agent still parked in the
+    /// broadcast-wait loop so `reapAgents` can join it.
+    should_exit: std.atomic.Value(bool) = std.atomic.Value(bool).init(false),
+};
+
+/// The fixture's top-level `AgentGroup`, set by `installAgent` on the
+/// runner thread (never on a spawned agent). `reapAgents` joins its
+/// threads + frees it at teardown. Threadlocal so each test262 worker
+/// reaps only its own fixture's agents.
+threadlocal var reap_group: ?*AgentGroup = null;
+
+/// Wait for every agent the fixture spawned to finish, then free
+/// per-agent state + the group. Agents complete on their own (the
+/// fixture notifies them or their wait times out); a never-broadcast
+/// agent bails via `should_exit`. A pooled task's persistent worker
+/// thread is NOT joined — we wait on its `done` flag instead (the
+/// worker lives on, reset, for the next task); a private fallback
+/// thread is joined. The agent's source stays owned by its runner
+/// (the pool worker, or the private thread) — never freed here.
+fn reapAgents(group: *AgentGroup) void {
+    group.should_exit.store(true, .release);
+    for (group.states[0..group.count]) |maybe| {
+        if (maybe) |st| {
+            if (st.thread) |t| {
+                t.join();
+            } else {
+                // Pooled task — wait for the worker to signal completion.
+                while (!st.done.load(.acquire)) agentNapNs(100 * std.time.ns_per_us);
+            }
+            std.heap.page_allocator.destroy(st);
+        }
+    }
+    for (group.reports.items) |m| std.heap.page_allocator.free(m);
+    group.reports.deinit(std.heap.page_allocator);
+    std.heap.page_allocator.destroy(group);
+}
+
+/// Per-agent-thread state, read by the child-side `$262.agent.*`
+/// natives (receiveBroadcast / report). Null on the main agent.
+threadlocal var current_agent: ?*AgentThreadState = null;
+
+fn agentSpinLock(l: *std.atomic.Value(bool)) void {
+    while (l.swap(true, .acquire)) std.atomic.spinLoopHint();
+}
+fn agentSpinUnlock(l: *std.atomic.Value(bool)) void {
+    l.store(false, .release);
+}
+
+// ── persistent agent-Realm pool ─────────────────────────────────────
+// Each agent runs in its own Realm — but building one (`installBuiltins`
+// constructs the whole intrinsic set + heap pools) is the dominant cost,
+// and a concentrated cross-agent sweep spawns ~hundreds of them, so
+// create-and-destroy churn pinned multi-GB of RSS no allocator could
+// reclaim. Instead a fixed pool of `pool_size` persistent worker threads
+// each own ONE persistent Realm (so `installBuiltins` runs `pool_size`
+// times total, not once per agent). A task dispatches to a free worker,
+// which runs the agent's whole life on it, then RESETS the realm to its
+// post-install state before the next task. The realm uses a FREEING
+// allocator (`c_allocator`) so the per-task GC actually reclaims each
+// agent's garbage and malloc reuses the pages — bounded, churn-free.
+//
+// `pool_size` >= the max agents live at once across all harness workers
+// (`--threads=N` x max-agents-per-fixture). When momentarily saturated,
+// `agentStart` falls back to a private one-shot thread + realm.
+const pool_size = 32;
+const agent_stack = 2 << 20; // 2 MiB — agents run tiny scripts.
+const agent_step_budget: u64 = 50_000_000; // bound a runaway agent script.
+
+const PoolWorker = struct {
+    /// The task assigned to this worker, or null when idle. Set by
+    /// `agentStart` (CAS null->task), cleared by the worker once the task
+    /// is fully complete. A non-null slot is never reassigned.
+    task: std.atomic.Value(?*AgentThreadState) = std.atomic.Value(?*AgentThreadState).init(null),
+};
+
+var pool_workers: [pool_size]PoolWorker = undefined;
+var pool_threads: [pool_size]std.Thread = undefined;
+var pool_n: usize = 0; // workers that actually spawned (<= pool_size).
+var pool_started = std.atomic.Value(bool).init(false);
+var pool_start_lock = std.atomic.Value(bool).init(false);
+var pool_shutdown = std.atomic.Value(bool).init(false);
+
+/// Lazily spawn the worker pool on the first `$262.agent.start`. Under a
+/// lock so concurrent harness workers race-safely start it exactly once.
+fn ensurePoolStarted() void {
+    if (pool_started.load(.acquire)) return;
+    agentSpinLock(&pool_start_lock);
+    defer agentSpinUnlock(&pool_start_lock);
+    if (pool_started.load(.acquire)) return;
+    var n: usize = 0;
+    for (0..pool_size) |_| {
+        pool_workers[n] = .{};
+        pool_threads[n] = std.Thread.spawn(.{ .stack_size = agent_stack }, poolWorkerMain, .{&pool_workers[n]}) catch continue;
+        n += 1;
+    }
+    pool_n = n;
+    pool_started.store(true, .release);
+}
+
+/// Hand `state` to a free pool worker. Returns true on success. A
+/// strong CAS null->state claims a slot; a non-null slot (busy, or a
+/// just-finished slot the worker hasn't cleared yet) is skipped.
+fn tryDispatchToPool(state: *AgentThreadState) bool {
+    for (pool_workers[0..pool_n]) |*w| {
+        if (w.task.cmpxchgStrong(null, state, .acq_rel, .acquire) == null) return true;
+    }
+    return false;
+}
+
+/// Signal every pool worker to exit and join them. Called once at
+/// process teardown (after every fixture has reaped its agents, so no
+/// worker is mid-task). No-op if the pool never started.
+fn shutdownPool() void {
+    if (!pool_started.load(.acquire)) return;
+    pool_shutdown.store(true, .release);
+    for (pool_threads[0..pool_n]) |t| t.join();
+}
+
+// ── persistent-realm reset (cross-agent isolation) ──────────────────
+// A pool worker reuses one realm across many agents, so between tasks it
+// must scrub every trace of the prior agent — both for correctness
+// (agent B must not see agent A's globals) and for memory (a lingering
+// global holding a `SharedArrayBuffer` would pin its shared block).
+
+/// Snapshot the post-install globalThis key set so `resetRealm` can tell
+/// a task-added binding from an intrinsic. Keys are duped into `alloc`
+/// (the worker frees them at shutdown via `freeSnapshotKeys`).
+fn snapshotGlobals(realm: *cynic.runtime.Realm, alloc: std.mem.Allocator) std.StringArrayHashMapUnmanaged(void) {
+    var set: std.StringArrayHashMapUnmanaged(void) = .empty;
+    const gt = realm.globals.target orelse return set;
+    var it = gt.iterOwnNamedKeys();
+    while (it.next()) |e| {
+        const dup = alloc.dupe(u8, e.key_ptr.*) catch continue;
+        set.put(alloc, dup, {}) catch alloc.free(dup);
+    }
+    return set;
+}
+
+fn freeSnapshotKeys(set: *std.StringArrayHashMapUnmanaged(void), alloc: std.mem.Allocator) void {
+    for (set.keys()) |k| alloc.free(k);
+}
+
+/// Return the worker's realm to its post-`install262` state so the next
+/// agent starts clean. `scratch` is a reusable key buffer.
+fn resetRealm(
+    realm: *cynic.runtime.Realm,
+    snapshot: *const std.StringArrayHashMapUnmanaged(void),
+    scratch: *std.ArrayListUnmanaged([]const u8),
+) void {
+    // Drain any microtasks the agent queued so async state doesn't bleed
+    // into the next one, and drop any pending exception.
+    cynic.runtime.lantern.drainMicrotasks(realm.allocator, realm) catch {};
+    realm.pending_exception = null;
+
+    // Overwrite every binding the task added to globalThis with
+    // `undefined` (lower-risk than delete — no shape-machinery churn).
+    // Collect first so we don't mutate the property map mid-iteration.
+    scratch.clearRetainingCapacity();
+    if (realm.globals.target) |gt| {
+        var it = gt.iterOwnNamedKeys();
+        while (it.next()) |e| {
+            if (!snapshot.contains(e.key_ptr.*))
+                scratch.append(realm.allocator, e.key_ptr.*) catch {};
+        }
+    }
+    for (scratch.items) |key| {
+        realm.globals.put(realm.allocator, key, AgentVal.undefined_) catch {};
+    }
+
+    // Drop the task's lexical (let / const / class) and var bindings so
+    // the next agent re-declares from a clean slate.
+    realm.globals.decl_env.clearRetainingCapacity();
+    realm.globals.decl_consts.clearRetainingCapacity();
+    realm.globals.var_names.clearRetainingCapacity();
+    // Drop any waitAsync the prior agent left pending (e.g. an untimed
+    // wait that never fired) so its capability doesn't pin memory or
+    // resolve into the next agent.
+    realm.pending_async_waits.clearRetainingCapacity();
+
+    // Reclaim the task's objects — releasing the refcounted shared-block
+    // references its SharedArrayBuffers held, so a reused realm never
+    // pins shared memory across agents.
+    realm.collectGarbage();
+}
+
+/// Monotonic milliseconds via the libc shim (the engine avoids std.Io).
+fn agentMonoMs() f64 {
+    var ts: std.c.timespec = undefined;
+    if (std.c.clock_gettime(std.c.CLOCK.MONOTONIC, &ts) != 0) return 0;
+    return @as(f64, @floatFromInt(ts.sec)) * 1000.0 + @as(f64, @floatFromInt(ts.nsec)) / 1_000_000.0;
+}
+
+/// Yield the CPU for `ns` (libc `nanosleep`) — agents sleep rather than
+/// spin, so a corpus full of waiting agents doesn't saturate the host.
+fn agentNapNs(ns: u64) void {
+    var req: std.c.timespec = .{ .sec = @intCast(ns / std.time.ns_per_s), .nsec = @intCast(ns % std.time.ns_per_s) };
+    _ = std.c.nanosleep(&req, null);
+}
+
+fn agentGroupOf(this_value: AgentVal) ?*AgentGroup {
+    const obj = cynic.runtime.heap.valueAsPlainObject(this_value) orelse return null;
+    const hd = obj.getHostData() orelse return null;
+    return @ptrCast(@alignCast(hd));
+}
+
+/// Run one agent's whole life in `realm`: evaluate its source (which
+/// registers a `receiveBroadcast` callback), wait for the parent's
+/// broadcast, then invoke the callback with a SharedArrayBuffer over the
+/// broadcast block (the callback does the `Atomics.wait` / `report`).
+/// `current_agent` must already point at `state` (so the child-side
+/// `report` / `receiveBroadcast` natives find it). Does NOT free
+/// `state.src` — the caller owns the source's lifetime (the compiled
+/// chunk borrows slices of it).
+fn runAgentTask(realm: *cynic.runtime.Realm, state: *AgentThreadState) void {
+    realm.step_budget = agent_step_budget;
+    _ = cynic.runtime.lantern.evaluateScript(realm.allocator, realm, state.src) catch {};
+    const cb_v = state.callback orelse return;
+    // Wait for the parent's broadcast (bounded, and released early on
+    // fixture teardown / pool shutdown, so a never-broadcast agent can't
+    // hold its worker past the fixture's watchdog).
+    const start_ms = agentMonoMs();
+    var block: ?*AgentSDB = null;
+    while (block == null) {
+        if (state.group.should_exit.load(.acquire)) return;
+        if (pool_shutdown.load(.acquire)) return;
+        block = state.bcast.load(.acquire);
+        if (block != null) break;
+        if (agentMonoMs() - start_ms > 60000) return;
+        agentNapNs(200 * std.time.ns_per_us);
+    }
+    // Root the callback across the (allocating) wrap + call.
+    const scope = realm.heap.openScope() catch return;
+    defer scope.close();
+    scope.push(cb_v) catch {};
+    const sab = cynic.runtime.typed_array_builtin.wrapSharedBlock(realm, block.?) catch return;
+    scope.push(sab) catch {};
+    const cb_fn = cynic.runtime.heap.valueAsFunction(cb_v) orelse return;
+    _ = cynic.runtime.lantern.callJSFunction(realm.allocator, realm, cb_fn, AgentVal.undefined_, &.{sab}) catch {};
+
+    // The callback may be an `async` function suspended on
+    // `await Atomics.waitAsync(...)`. Drive it to completion.
+    driveAsyncAgent(realm, state);
+}
+
+/// Drive an async agent to completion. The agent's callback may park on
+/// `await Atomics.waitAsync(...)`; the spec fires that wait's timeout
+/// "in parallel" (§25.4.1.4 TriggerTimeout) — with no real event loop
+/// the host does it here: drain microtasks, resolve any waitAsync whose
+/// monotonic deadline has passed with `"timed-out"`, and repeat until
+/// the agent settles (empty queue + no pending waits) or a backstop.
+/// Cross-agent notify isn't wired, so an untimed wait just runs the
+/// backstop out; `should_exit` lets a reaped fixture release the worker.
+fn driveAsyncAgent(realm: *cynic.runtime.Realm, state: *AgentThreadState) void {
+    const backstop_ms = agentMonoMs() + 30000;
+    while (true) {
+        cynic.runtime.lantern.drainMicrotasks(realm.allocator, realm) catch {};
+        const now = agentMonoMs();
+        var fired = false;
+        var i: usize = 0;
+        while (i < realm.pending_async_waits.items.len) {
+            if (now >= realm.pending_async_waits.items[i].deadline_ms) {
+                const w = realm.pending_async_waits.orderedRemove(i);
+                const resolve_fn = cynic.runtime.heap.valueAsFunction(w.resolve) orelse continue;
+                // Root the result string across the resolve call (it may GC).
+                const scope = realm.heap.openScope() catch break;
+                defer scope.close();
+                const str = realm.heap.allocateString("timed-out") catch continue;
+                const arg = AgentVal.fromString(str);
+                scope.push(arg) catch {};
+                _ = cynic.runtime.lantern.callJSFunction(realm.allocator, realm, resolve_fn, AgentVal.undefined_, &.{arg}) catch {};
+                fired = true;
+            } else {
+                i += 1;
+            }
+        }
+        if (fired) continue; // re-drain so the resolution propagates
+        if (realm.microtask_queue.items.len == 0 and realm.pending_async_waits.items.len == 0) break;
+        if (agentMonoMs() >= backstop_ms) break;
+        if (state.group.should_exit.load(.acquire) or pool_shutdown.load(.acquire)) break;
+        agentNapNs(1 * std.time.ns_per_ms);
+    }
+}
+
+/// A pool worker: build one persistent realm (freeing allocator), then
+/// loop pulling tasks, running each on it, and resetting between tasks.
+fn poolWorkerMain(slot: *PoolWorker) void {
+    var realm = cynic.runtime.Realm.init(std.heap.c_allocator);
+    defer realm.deinit();
+    // Match the scored posture so the agent's SAB / Atomics / eval work.
+    realm.hardened = false;
+    realm.allow_eval = true;
+    realm.installBuiltins() catch return;
+    // `install262` (no `current_agent` here) records its `$262.agent`
+    // group as this thread's `reap_group`; the worker never reaps, so
+    // capture + clear it and free it at shutdown.
+    reap_group = null;
+    install262(&realm) catch return;
+    const own_group = reap_group;
+    reap_group = null;
+    defer if (own_group) |g| reapAgents(g);
+
+    var snapshot = snapshotGlobals(&realm, realm.allocator);
+    defer {
+        freeSnapshotKeys(&snapshot, realm.allocator);
+        snapshot.deinit(realm.allocator);
+    }
+    var scratch: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer scratch.deinit(realm.allocator);
+    // Sources of tasks run on this realm — the chunks borrow them and
+    // outlive the tasks, so the worker owns them until shutdown.
+    var owned_srcs: std.ArrayListUnmanaged([]u8) = .empty;
+    defer {
+        for (owned_srcs.items) |s| std.heap.page_allocator.free(s);
+        owned_srcs.deinit(realm.allocator);
+    }
+
+    while (!pool_shutdown.load(.acquire)) {
+        const state = slot.task.load(.acquire) orelse {
+            agentNapNs(100 * std.time.ns_per_us);
+            continue;
+        };
+        // Take ownership of the source for this realm's lifetime.
+        owned_srcs.append(realm.allocator, state.src) catch {};
+        current_agent = state;
+        runAgentTask(&realm, state);
+        resetRealm(&realm, &snapshot, &scratch);
+        current_agent = null;
+        // Signal completion (so `reapAgents` can free the task), THEN
+        // release the slot for reuse. After `done` the task may be freed,
+        // so it must not be touched again.
+        state.done.store(true, .release);
+        slot.task.store(null, .release);
+    }
+}
+
+/// The private one-shot fallback when the pool is saturated: a fresh
+/// realm runs exactly one task, then tears down. Rare under realistic
+/// concurrency, so its create/destroy cost doesn't matter.
+fn agentMainPrivate(state: *AgentThreadState) void {
+    var realm = cynic.runtime.Realm.init(std.heap.c_allocator);
+    realm.hardened = false;
+    realm.allow_eval = true;
+    if (realm.installBuiltins()) |_| {} else |_| {
+        realm.deinit();
+        std.heap.page_allocator.free(state.src);
+        state.done.store(true, .release);
+        return;
+    }
+    reap_group = null;
+    if (install262(&realm)) |_| {} else |_| {
+        realm.deinit();
+        std.heap.page_allocator.free(state.src);
+        state.done.store(true, .release);
+        return;
+    }
+    const own_group = reap_group;
+    reap_group = null;
+    current_agent = state;
+    runAgentTask(&realm, state);
+    current_agent = null;
+    if (own_group) |g| reapAgents(g);
+    // The realm (and its chunks borrowing `state.src`) is gone — now the
+    // source can be freed.
+    realm.deinit();
+    std.heap.page_allocator.free(state.src);
+    state.done.store(true, .release);
+}
+
+fn agentStart(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    const group = agentGroupOf(this_value) orelse return AgentVal.undefined_;
+    if (args.len == 0 or !args[0].isString()) return AgentVal.undefined_;
+    const s: *cynic.runtime.JSString = @ptrCast(@alignCast(args[0].asString()));
+    const src_copy = std.heap.page_allocator.dupe(u8, s.flatBytes()) catch return error.OutOfMemory;
+    const state = std.heap.page_allocator.create(AgentThreadState) catch {
+        std.heap.page_allocator.free(src_copy);
+        return error.OutOfMemory;
+    };
+    state.* = .{ .group = group, .src = src_copy };
+
+    // Register the task with the fixture's group (under the lock) so
+    // `reapAgents` waits on it, BEFORE dispatching it to run.
+    {
+        agentSpinLock(&group.reg_lock);
+        defer agentSpinUnlock(&group.reg_lock);
+        if (group.count >= max_agents) {
+            std.heap.page_allocator.free(src_copy);
+            std.heap.page_allocator.destroy(state);
+            return AgentVal.undefined_;
+        }
+        group.states[group.count] = state;
+        group.count += 1;
+    }
+
+    // Dispatch to a persistent pool worker (the common, RSS-bounded
+    // path). If the pool is momentarily saturated, fall back to a
+    // private one-shot thread.
+    ensurePoolStarted();
+    if (tryDispatchToPool(state)) return AgentVal.undefined_;
+
+    const t = std.Thread.spawn(.{ .stack_size = agent_stack }, agentMainPrivate, .{state}) catch {
+        // No worker free and no thread — the agent can't run. Free its
+        // source and mark it done so `reapAgents` doesn't wait forever
+        // (the fixture's own watchdog handles the never-incrementing
+        // agent). The task struct itself is freed by `reapAgents`.
+        std.heap.page_allocator.free(src_copy);
+        state.done.store(true, .release);
+        return AgentVal.undefined_;
+    };
+    state.thread = t;
+    return AgentVal.undefined_;
+}
+
+fn agentBroadcast(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    const group = agentGroupOf(this_value) orelse return AgentVal.undefined_;
+    if (args.len == 0) return AgentVal.undefined_;
+    const sab = cynic.runtime.heap.valueAsPlainObject(args[0]) orelse return AgentVal.undefined_;
+    const block = sab.getSharedBlock() orelse return AgentVal.undefined_;
+    agentSpinLock(&group.reg_lock);
+    defer agentSpinUnlock(&group.reg_lock);
+    for (group.states[0..group.count]) |maybe| {
+        if (maybe) |st| st.bcast.store(block, .release);
+    }
+    return AgentVal.undefined_;
+}
+
+fn agentGetReport(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = args;
+    const group = agentGroupOf(this_value) orelse return AgentVal.undefined_;
+    agentSpinLock(&group.reports_lock);
+    var msg: ?[]u8 = null;
+    if (group.reports.items.len > 0) msg = group.reports.orderedRemove(0);
+    agentSpinUnlock(&group.reports_lock);
+    // No report yet → null (atomicsHelper's getReport wrapper loops on
+    // `== null` with a sleep). `undefined == null` is true in JS, so
+    // undefined serves.
+    const m = msg orelse return AgentVal.undefined_;
+    defer std.heap.page_allocator.free(m);
+    const js = realm.heap.allocateString(m) catch return error.OutOfMemory;
+    return AgentVal.fromString(js);
+}
+
+fn agentReport(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    _ = this_value;
+    const st = current_agent orelse return AgentVal.undefined_;
+    const v = if (args.len > 0) args[0] else AgentVal.undefined_;
+    // ToString the reported value (strings + numbers + BigInt cover the
+    // corpus; the bigint TypedArray wait/notify fixtures report e.g.
+    // `Atomics.store(i64a, 0, 42n)` → the BigInt 42n, ToString "42").
+    if (cynic.runtime.heap.valueAsBigInt(v)) |bi| {
+        const copy = cynic.runtime.bigint.toStringAlloc(std.heap.page_allocator, bi, 10) catch return error.OutOfMemory;
+        agentSpinLock(&st.group.reports_lock);
+        defer agentSpinUnlock(&st.group.reports_lock);
+        st.group.reports.append(std.heap.page_allocator, copy) catch std.heap.page_allocator.free(copy);
+        return AgentVal.undefined_;
+    }
+    var buf: [64]u8 = undefined;
+    const text: []const u8 = blk: {
+        if (v.isString()) {
+            const s: *cynic.runtime.JSString = @ptrCast(@alignCast(v.asString()));
+            break :blk s.flatBytes();
+        }
+        if (v.isInt32()) break :blk std.fmt.bufPrint(&buf, "{d}", .{v.asInt32()}) catch "0";
+        if (v.isDouble()) break :blk std.fmt.bufPrint(&buf, "{d}", .{v.asDouble()}) catch "0";
+        break :blk "undefined";
+    };
+    const copy = std.heap.page_allocator.dupe(u8, text) catch return error.OutOfMemory;
+    agentSpinLock(&st.group.reports_lock);
+    defer agentSpinUnlock(&st.group.reports_lock);
+    st.group.reports.append(std.heap.page_allocator, copy) catch {
+        std.heap.page_allocator.free(copy);
+    };
+    return AgentVal.undefined_;
+}
+
+fn agentReceiveBroadcast(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    _ = this_value;
+    if (current_agent) |st| {
+        if (args.len > 0) st.callback = args[0];
+    }
+    return AgentVal.undefined_;
+}
+
+fn agentSleep(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    _ = this_value;
+    const ms: f64 = if (args.len > 0 and args[0].isInt32())
+        @floatFromInt(args[0].asInt32())
+    else if (args.len > 0 and args[0].isDouble())
+        args[0].asDouble()
+    else
+        0;
+    if (ms <= 0) return AgentVal.undefined_;
+    // Actually sleep (yielding the CPU) — `tryYield` / `trySleep` rely
+    // on this to give other agents real time to reach their wait.
+    agentNapNs(@intFromFloat(ms * @as(f64, std.time.ns_per_ms)));
+    return AgentVal.undefined_;
+}
+
+fn agentMonotonicNow(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    _ = this_value;
+    _ = args;
+    return AgentVal.fromDouble(agentMonoMs());
+}
+
+fn agentLeaving(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
+    _ = realm;
+    _ = this_value;
+    _ = args;
+    return AgentVal.undefined_;
+}
+
+/// Build `$262.agent` and store its per-realm `AgentGroup` (so agents
+/// from one fixture never cross into another's reports when the
+/// harness runs fixtures on multiple worker threads).
+fn installAgent(realm: *cynic.runtime.Realm, parent: *cynic.runtime.JSObject) !void {
+    const heap = realm.heap;
+    const agent = try heap.allocateObject();
+    agent.prototype = realm.intrinsics.object_prototype;
+    const group = try std.heap.page_allocator.create(AgentGroup);
+    group.* = .{};
+    // On the runner thread (no `current_agent`) this is the fixture's
+    // top-level group — record it so the runner reaps its agents at
+    // teardown. A spawned agent installing its own `$262.agent` must
+    // NOT clobber that pointer.
+    if (current_agent == null) reap_group = group;
+    try agent.setHostData(realm.allocator, @ptrCast(group));
+    const defs = .{
+        .{ "start", agentStart, 1 },
+        .{ "broadcast", agentBroadcast, 1 },
+        .{ "getReport", agentGetReport, 0 },
+        .{ "report", agentReport, 1 },
+        .{ "receiveBroadcast", agentReceiveBroadcast, 1 },
+        .{ "sleep", agentSleep, 1 },
+        .{ "monotonicNow", agentMonotonicNow, 0 },
+        .{ "leaving", agentLeaving, 0 },
+    };
+    inline for (defs) |d| {
+        const f = try heap.allocateFunctionNative(realm, d[1], d[2], d[0]);
+        try agent.set(realm.allocator, d[0], cynic.runtime.heap.taggedFunction(f));
+    }
+    try parent.set(realm.allocator, "agent", cynic.runtime.heap.taggedObject(agent));
+}
+
 fn install262(realm: *cynic.runtime.Realm) !void {
     const heap = realm.heap;
     const obj = try heap.allocateObject();
@@ -391,11 +987,101 @@ fn install262(realm: *cynic.runtime.Realm) !void {
     const cr_fn = try heap.allocateFunctionNative(realm, test262CreateRealm, 0, "createRealm");
     try obj.set(realm.allocator, "createRealm", cynic.runtime.heap.taggedFunction(cr_fn));
 
+    // §INTERPRETING.md `$262.agent` — multi-agent (real-thread) support.
+    try installAgent(realm, obj);
+
     // Cynic doesn't have `IsHTMLDDA` — that feature is on our
     // skip list. We install nothing for it; tests that need it
     // skip out via `features:`.
 
     try realm.globals.put(realm.allocator, "$262", cynic.runtime.heap.taggedObject(obj));
+}
+
+/// Run `src` as a Script and return its integer completion value, or
+/// `null` if it threw or didn't complete with an int.
+fn evalAgentInt(realm: *cynic.runtime.Realm, src: []const u8) ?i32 {
+    const outcome = cynic.runtime.lantern.evaluateScript(realm.allocator, realm, src) catch return null;
+    return switch (outcome) {
+        .value, .yielded => |v| if (v.isInt32()) v.asInt32() else if (v.isDouble()) @intFromFloat(v.asDouble()) else null,
+        .thrown => null,
+    };
+}
+
+test "agent realm reset: a reused realm isolates one agent from the next" {
+    // The pool runs many agents on ONE persistent realm, resetting it
+    // between them. This proves the reset both (a) scrubs the prior
+    // agent's globals so the next can't observe them and (b) releases
+    // the shared blocks the prior agent's SharedArrayBuffers pinned —
+    // `live_blocks` must return to baseline. Done here, on the bare
+    // `resetRealm`/`snapshotGlobals` primitives, before any concurrency.
+    const sdb = cynic.runtime.shared_data_block;
+    const testing = std.testing;
+
+    // Defensive: a prior test on this thread may have left these set.
+    current_agent = null;
+    reap_group = null;
+
+    var realm = cynic.runtime.Realm.init(std.heap.c_allocator);
+    defer realm.deinit();
+    realm.hardened = false;
+    realm.allow_eval = true;
+    try realm.installBuiltins();
+    try install262(&realm);
+    // `install262` recorded its `$262.agent` group as this thread's
+    // `reap_group`; free it at the end so the test leaks nothing.
+    const own_group = reap_group;
+    reap_group = null;
+    defer if (own_group) |g| reapAgents(g);
+
+    var snapshot = snapshotGlobals(&realm, realm.allocator);
+    defer {
+        freeSnapshotKeys(&snapshot, realm.allocator);
+        snapshot.deinit(realm.allocator);
+    }
+    var scratch: std.ArrayListUnmanaged([]const u8) = .empty;
+    defer scratch.deinit(realm.allocator);
+
+    const baseline = sdb.live_blocks.load(.monotonic);
+
+    // Agent A: leaves top-level globals AND a SharedArrayBuffer alive.
+    const a_result = evalAgentInt(&realm,
+        \\var leakedVar = 123;
+        \\globalThis.leakedProp = "x";
+        \\var sabA = new SharedArrayBuffer(16);
+        \\var taA = new Int32Array(sabA);
+        \\Atomics.store(taA, 0, 99);
+        \\Atomics.load(taA, 0);
+    );
+    try testing.expectEqual(@as(?i32, 99), a_result);
+    // Agent A's SharedArrayBuffer created exactly one new shared block.
+    try testing.expectEqual(baseline + 1, sdb.live_blocks.load(.monotonic));
+
+    resetRealm(&realm, &snapshot, &scratch);
+
+    // The reset released Agent A's block — back to baseline.
+    try testing.expectEqual(baseline, sdb.live_blocks.load(.monotonic));
+
+    // Agent B sees a clean global env (none of A's values survive) and
+    // the realm still works (it can build + use its own SAB).
+    const b_result = evalAgentInt(&realm,
+        \\var clean =
+        \\  (typeof leakedVar === "undefined") &&
+        \\  (typeof leakedProp === "undefined") &&
+        \\  (typeof sabA === "undefined") &&
+        \\  (typeof taA === "undefined");
+        \\var sabB = new SharedArrayBuffer(8);
+        \\var taB = new Int32Array(sabB);
+        \\Atomics.store(taB, 0, 7);
+        \\(clean && Atomics.load(taB, 0) === 7) ? 1 : 0;
+    );
+    try testing.expectEqual(@as(?i32, 1), b_result);
+    try testing.expectEqual(baseline + 1, sdb.live_blocks.load(.monotonic));
+
+    // Reset is repeatable — Agent B's block is released too.
+    resetRealm(&realm, &snapshot, &scratch);
+    try testing.expectEqual(baseline, sdb.live_blocks.load(.monotonic));
+
+    current_agent = null;
 }
 
 test {
@@ -935,6 +1621,11 @@ pub fn main(init: std.process.Init) !void {
 
     var opts = try parseArgs(gpa, init.minimal.args);
     defer freeArgs(gpa, &opts);
+
+    // Tear down the persistent agent-realm pool (if any agent fixture
+    // started it) on normal completion. Every fixture reaps its own
+    // agents, so by here no worker is mid-task.
+    defer shutdownPool();
 
     const cwd = std.Io.Dir.cwd();
     var corpus = cwd.openDir(io, opts.corpus, .{ .iterate = true }) catch |err| {
@@ -1970,7 +2661,7 @@ fn classifyAndRun(
         return fail_reject_or_ch;
     }
 
-    var realm = cynic.runtime.Realm.initWithBytesAllocator(arena, bytes_allocator);
+    var realm = cynic.runtime.Realm.initWithBytesAllocator(std.heap.c_allocator, bytes_allocator);
     defer realm.deinit();
     // Wire the watchdog: on a worker thread, a wedged fixture can be
     // aborted from `monitorLoop` via this worker's host-interrupt
@@ -2044,7 +2735,15 @@ fn classifyAndRun(
     // `detachArrayBuffer`, etc. Tests gated on hooks Cynic
     // doesn't implement (`createRealm`, `agent.*`, `IsHTMLDDA`)
     // skip via the feature filter; the rest get a working shim.
+    reap_group = null;
     install262(&realm) catch return fail_reject_or_ch;
+    // Join + free this fixture's agent threads before the realm tears
+    // down (LIFO defer: runs before `realm.deinit` above), so their
+    // page-allocated Realms don't accumulate across the corpus.
+    defer if (reap_group) |g| {
+        reapAgents(g);
+        reap_group = null;
+    };
 
     // Install the module loader for both `is_module` tests AND
     // script tests that use dynamic `import()` (the `dynamic-import`
@@ -2078,11 +2777,11 @@ fn classifyAndRun(
     // so the loop below short-circuits.
     const eff_harness: ?harness_mod.HarnessSources = if (raw) null else harness_pair;
     if (eff_harness) |hp| {
-        const r1 = cynic.runtime.evaluateScript(arena, &realm, hp.sta) catch {
+        const r1 = cynic.runtime.evaluateScript(realm.allocator, &realm, hp.sta) catch {
             return fail_reject_or_ch;
         };
         if (r1 == .thrown) return fail_reject_or_ch;
-        const r2 = cynic.runtime.evaluateScript(arena, &realm, hp.assert_js) catch {
+        const r2 = cynic.runtime.evaluateScript(realm.allocator, &realm, hp.assert_js) catch {
             return fail_reject_or_ch;
         };
         if (r2 == .thrown) return fail_reject_or_ch;
@@ -2098,7 +2797,7 @@ fn classifyAndRun(
             const inc_source = hp.lookupInclude(inc_name) orelse {
                 return .{ .kind = .skip, .skip_reason = .has_includes };
             };
-            const r_inc = cynic.runtime.evaluateScript(arena, &realm, inc_source) catch {
+            const r_inc = cynic.runtime.evaluateScript(realm.allocator, &realm, inc_source) catch {
                 return fail_reject_or_ch;
             };
             if (r_inc == .thrown) return fail_reject_or_ch;
@@ -2144,7 +2843,7 @@ fn classifyAndRun(
             const saved_current_mod = realm.current_module;
             realm.current_module = entry_mod;
             defer realm.current_module = saved_current_mod;
-            const mod_outcome = cynic.runtime.run(arena, &realm, chunk_ptr) catch {
+            const mod_outcome = cynic.runtime.run(realm.allocator, &realm, chunk_ptr) catch {
                 entry_mod.state = .errored;
                 if (expected_negative) |_| return .{ .kind = .pass_negative };
                 return .{ .kind = .fail_false_reject };
@@ -2164,7 +2863,7 @@ fn classifyAndRun(
         // Plain script — go through evaluateScript so chunk
         // ownership lands on the realm and any function declared
         // here outlives this call.
-        break :blk cynic.runtime.evaluateScript(arena, &realm, test_source) catch {
+        break :blk cynic.runtime.evaluateScript(realm.allocator, &realm, test_source) catch {
             if (expected_negative) |_| return .{ .kind = .pass_negative };
             return .{ .kind = .fail_false_reject };
         };
@@ -2194,7 +2893,7 @@ fn classifyAndRun(
     // $DONE(e))`); standalone microtask throws are discarded
     // (real hosts dispatch HostPromiseRejectionTracker, which
     // Cynic doesn't model).
-    cynic.runtime.lantern.drainMicrotasks(arena, &realm) catch {
+    cynic.runtime.lantern.drainMicrotasks(realm.allocator, &realm) catch {
         test_threw = true;
     };
 

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -588,9 +588,9 @@ fn resetRealm(
     realm.globals.decl_consts.clearRetainingCapacity();
     realm.globals.var_names.clearRetainingCapacity();
     // Drop any waitAsync the prior agent left pending (e.g. an untimed
-    // wait that never fired) so its capability doesn't pin memory or
-    // resolve into the next agent.
-    realm.pending_async_waits.clearRetainingCapacity();
+    // wait that never fired): unlink + free each block node so none
+    // dangles on a still-shared block, then empty the list.
+    realm.clearPendingAsyncWaits();
 
     // Reclaim the task's objects — releasing the refcounted shared-block
     // references its SharedArrayBuffers held, so a reused realm never
@@ -669,25 +669,12 @@ fn driveAsyncAgent(realm: *cynic.runtime.Realm, state: *AgentThreadState) void {
     const backstop_ms = agentMonoMs() + 30000;
     while (true) {
         cynic.runtime.lantern.drainMicrotasks(realm.allocator, realm) catch {};
-        const now = agentMonoMs();
-        var fired = false;
-        var i: usize = 0;
-        while (i < realm.pending_async_waits.items.len) {
-            if (now >= realm.pending_async_waits.items[i].deadline_ms) {
-                const w = realm.pending_async_waits.orderedRemove(i);
-                const resolve_fn = cynic.runtime.heap.valueAsFunction(w.resolve) orelse continue;
-                // Root the result string across the resolve call (it may GC).
-                const scope = realm.heap.openScope() catch break;
-                defer scope.close();
-                const str = realm.heap.allocateString("timed-out") catch continue;
-                const arg = AgentVal.fromString(str);
-                scope.push(arg) catch {};
-                _ = cynic.runtime.lantern.callJSFunction(realm.allocator, realm, resolve_fn, AgentVal.undefined_, &.{arg}) catch {};
-                fired = true;
-            } else {
-                i += 1;
-            }
-        }
+        // Settle this agent's waitAsync on a cross-agent notify or its
+        // deadline (the engine drain above handles the case where the
+        // agent's own microtasks keep the queue busy; this covers the
+        // common case where the agent suspended on the await and the
+        // queue is empty).
+        const fired = cynic.runtime.lantern.fireExpiredAsyncWaits(realm.allocator, realm) catch false;
         if (fired) continue; // re-drain so the resolution propagates
         if (realm.microtask_queue.items.len == 0 and realm.pending_async_waits.items.len == 0) break;
         if (agentMonoMs() >= backstop_ms) break;


### PR DESCRIPTION
Lands the multi-agent `$262.agent` cross-agent Atomics fixtures and completes `Atomics.waitAsync` settlement. `built-ins/Atomics` goes from a fail-heavy bucket to **380/382 (99%)**; test262 **+125** overall (90.25% → 90.50%). The only remaining Atomics fails are the two `CanBlockIsFalse` fixtures, which genuinely can't run in a can-block agent.

### What's in it

**1. K-realm/K-thread agent pool (`tools/test262.zig`).** Each agent used to build a fresh full Realm (`installBuiltins` dominates) ~hundreds of times per sweep; the churn pinned multi-GB RSS. Now a process-global pool of K=32 persistent worker threads each own one persistent Realm, reset between tasks (snapshot post-install globals; per task overwrite the rest to `undefined`, clear the lexical + var env, GC to release shared blocks). A private one-shot thread is the fallback when the pool is saturated.

**2. Freeing per-fixture realm allocator.** The real RSS fix. The per-fixture arena never reclaimed mid-fixture, so a `waitAsync` parent's `setTimeout`-polyfill busy-loop grew it to GBs even though the GC freed the garbage logically. No production engine puts an arena under the GC heap (V8/SM moving; JSC free-lists; QuickJS refcounts). Switching the realm to `c_allocator` makes GC-free → malloc-reuse, so the peak tracks the live set: xor fixture **2.25 GB → 60 MB**; full Atomics `--threads=4` **6 GB → 155 MB** (and faster). Leak-free: a 23k-fixture built-ins sweep plateaus.

**3. `Atomics.waitAsync` settlement (§25.4.1.4).** Previously the Promise never settled.
- **Cross-agent notify** — an async wait parks a heap-allocated waiter on the block's process-global wait list, so `Atomics.notify` finds, counts, and wakes it across threads. The notifier only raises the node's atomic `woken`; the waiting agent settles its own Promise `"ok"` on its own thread, re-reading `woken` under the lock so the count and the result can't disagree.
- **Host-driven timeout** — `drainMicrotasks` fires expired async waits, so a main-agent `setTimeout` poll loop resolves `"timed-out"` on time instead of hanging. Generalized into the engine drain, so `cynic run` gets it too.

### Results

- `built-ins/Atomics` **367 → 380/382** — all of `built-ins/Atomics/waitAsync` now passing (**101/101**). The two remaining Atomics fails are the `CanBlockIsFalse` fixtures, which can't run in a can-block agent.
- test262 **+125** over the pre-series baseline → **45075 / 90.50%**, full sweep bounded (~50 s), RSS plateaus.
- (`built-ins/SharedArrayBuffer` stays 104/0 — single-agent API tests, untouched by this PR.)

### Tests

- Reset-isolation test (globals scrubbed + shared blocks released via a `live_blocks` diagnostic).
- 3 wait-list primitive unit tests (`addAsyncWaiter` / `wakeWaiters` / `settleAndFreeAsyncWaiter`).
- 3 engine-level cross-thread tests (`multi_agent_test.zig`): notify-wakes-async → `"ok"` (notify returns exactly 1), 50 ms timeout → `"timed-out"`, `clearPendingAsyncWaits` no-dangle.
- gc-stress at `--gc-threshold=1` keeps waitAsync 101/101. Full unit suite green (1971/1973; the 2 skips are opt-in exhaustive Unicode tests).

### Notes

- Deferred (ROADMAP): trigger GC on allocation pressure (not only JS loop back-edges), and a real harness timer queue so the `setTimeout` polyfill doesn't busy-spin — both quality-of-implementation follow-ups, neither blocking.
- Branch base trails current `main` by a few commits; a trivial `atomics.zig` conflict is possible from the wasm-fallback commit, easily resolved at merge.
