### PR TITLE
IC frontier: drop hash from JS call path, fuse method calls, cache globals + free-function callees

### DIFF
--- a/docs/inline-caches.md
+++ b/docs/inline-caches.md
@@ -67,6 +67,44 @@ All on `origin/main`:
   prototype-inherited reads (`arr.push`, `instance.m`,
   `String.prototype.constructor`) — the dominant real-world
   case the own-data IC missed.
+- `fdf3940` — Fused `call_property` opcode for the simple
+  `obj.method(args)` shape. Replaces a 4-op `ldar + lda_property
+  + star + call_method` sequence (15 bytes operand, 4 dispatches)
+  with one `[k:u16] [r_recv:u8] [argc:u8] [ic_load:u16]
+  [ic_call:u16]` dispatch (8 bytes operand). Shares the proto-load
+  `ICCell` with `lda_property` and the call IC with `call_method`.
+  Slow path: a factored `slowLookupForCallProperty` helper mirrors
+  `lda_property`'s 11-arm receiver-type matrix (plain / proxy /
+  module-namespace / chainHasProxy / accessor /
+  function-poison-pill / string / number / bool / bigint /
+  symbol). Compiler gates the fused emission on the simple shape
+  (plain ident key, no `#private`, no optional, no `super`, not
+  in tail position); every other shape falls back to the legacy
+  emission unchanged. Hermes ships exactly this (`CallBuiltin` /
+  `CallPropertyN`); Ignition ships `CallProperty0/1/2`.
+  **`method_call` p50 -3.1 % (~22.7 → ~22.0 ms).**
+- `e2c5b59` — `lda_global` / `lda_global_or_undef` IC. Cache
+  `(globalThis_shape, slot, decl_revision)` at each callsite.
+  Wire format grows to `[k:u16] [ic:u16]`. Fast path: shape
+  compare on `gr.globals.target` + `decl_revision` snapshot
+  match → `gt.slots[cell.slot]`. Slow path: factored
+  `slowLdaGlobal` helper (decl_env first per §9.1.1.4 — does NOT
+  fill the cell so a top-level `let X = …` keeps shadowing the
+  cached object-env slot — then shape lookup, then accessor /
+  bootstrap-fallback). `GlobalBindings.decl_revision` is a new
+  counter on the realm's globals struct, bumped exactly once per
+  fresh `installScriptLexBinding` (`!found_existing` branch);
+  `putDecl` reassignments don't bump because they don't change
+  which env a free-identifier lookup resolves through. The
+  slow-path-factoring is load-bearing: an earlier inlined-handler
+  version added ~85 lines per opcode to the dispatch loop and
+  i-cache pressure regressed unrelated fixtures (e.g.
+  `class_instantiate` +12 % despite zero `lda_global` in its hot
+  loop); pulling the slow path out collapsed that footprint.
+  **Bench wins (p50 / min vs pre-IC baseline, --runs=30):**
+  `prop_access` -9.6 % / -7.3 %, `prop_write` -7.8 % / -4.5 %,
+  `array_iter` -8.4 % / -4.3 %, `string_concat` -12.8 % / -4.7 %,
+  `object_alloc` -5.8 % / -3.2 %, `method_call` -5.7 % / -4.2 %.
 
 ## Architecture decisions
 
@@ -94,55 +132,53 @@ All on `origin/main`:
   []CallICCell`** are mutable side-tables on the otherwise-immutable
   chunk. Both are zeroed at chunk finalisation. GC weak-clears the
   call-IC's callee pointer and the proto-load IC's proto pointer.
+- **`ICCell` is dual-use.** Same struct serves three opcodes — its
+  fields are reinterpreted by the consumer:
+    * `lda_property` / `sta_property` own-data mode: `proto == null`,
+      `slot` indexes `recv.slots`, `bag_index` is the `sta_property`
+      hot path's cached `properties` array index.
+    * `lda_property` proto-load mode: `proto != null` + `proto_shape`
+      + `proto_rev` (snapshot of `realm.proto_revision_counter`).
+    * `lda_global` / `lda_global_or_undef`: `proto == null`, `shape`
+      is the global object's shape, `proto_rev` is repurposed to
+      record `GlobalBindings.decl_revision`. A future `lda_global`
+      proto-walk variant would set `proto` like `lda_property`.
+- **Factor the slow path when the dispatch loop grows.** The lda_global
+  IC ran into 5-15 % regressions on unrelated micros (e.g.
+  `class_instantiate` +12 % despite zero `lda_global` in its hot
+  loop) when its ~85 lines of slow path lived inline in the giant
+  `switch :dispatch`. Pulling the slow path into a function
+  (`slowLdaGlobal`) and keeping each handler at ~25 lines collapsed
+  the i-cache footprint and turned the regressions into 5-13 % wins
+  across the IC-exercising fixtures. Same lesson holds for any future
+  IC: keep the per-op handler tight; helper-call the slow paths.
 
 ## Remaining IC frontier
 
 Stack-ranked by expected impact, biggest first.
 
-### Tier 1 — biggest single remaining win
+### Tier 1 — biggest single remaining wins
 
-**Fused `call_property` opcode.** Combines
-`lda_property + star + call_method` into a single dispatch.
-Compiler detects `Call(MemberExpr(obj, name), args)` in the AST
-and emits `call_property [k:u16] [r_recv:u8] [argc:u8] [ic:u16]`
-instead of the three-op sequence. Cell reuses the existing
-proto-load `ICCell` — fast path: receiver-shape compare → load
-callee via own or proto slot → call directly.
-
-Hermes ships exactly this; Ignition ships a near-equivalent
-(`CallProperty0`/`CallProperty1`). Two implementation paths:
-
-- **Clean: factor `lookupProperty` out of `lda_property`.** The
-  current 250-line handler interleaves IC fill, proxy [[Get]],
-  module-namespace [[Get]], `chainHasProxy` walk, accessor
-  dispatch, AND primitive-receiver auto-box paths. Extract the
-  slow-path lookup into a helper that returns
-  `enum { value: Value, handled, uncaught: Value }` so both
-  `lda_property` and `call_property` share semantics. Invasive
-  but clean.
-- **Pragmatic: duplicate the slow path inline.** Copy-paste ~250
-  lines; drift risk on every future `lda_property` change.
-
-Expected: meaningful single-digit % across method-heavy
-fixtures; bigger on tight monomorphic call loops.
-
-### Tier 2 — medium
-
-**Global-property IC** (`lda_global`). `globalThis` is one shared
-object; every script touches it repeatedly (`console.log`,
-`Object`, `Array`, …). Cache `(globalThis_shape, slot)` per
-`lda_global` site. Same machinery as `lda_property` against a
-fixed receiver.
-
-**`call` opcode IC** (free-function calls — `f(x)` not
-`obj.f(x)`). Same call-IC cell pattern as `call_method`: cache
-the last plain callee pointer, skip exotic-callee dispatch.
-Useful for direct calls to closure-captured functions and locals.
+**Free-function `call` opcode IC.** Mirror `call_method`'s
+`CallICCell` pattern on the bare `call` op for `f(x)` (closure-
+captured functions, helper functions, callbacks). Cache the last
+plain callee pointer; cell hit skips the proxy / revocable /
+bound / `valueAsFunction` exotic dispatch. ~50 lines, parallels
+existing code closely. Helps FP-style and parser / traversal
+code.
 
 **`new_call` IC.** Caches `(ctor_fn, proto)` so the fast path
 skips `valueAsFunction` + `OrdinaryCreateFromConstructor`'s
 prototype lookup. Constructor-heavy code (`new ClassName(…)`
-loops) benefits.
+loops — object pools, `new URL()`, `new Date()`) benefits.
+Moderate complexity (~80 lines).
+
+### Tier 2 — medium
+
+**Computed-property IC** (`obj[k]` where `k` is a hot constant
+string). Cache `(shape, key_intern, slot)`. Requires string
+interning first; unlocked once *the flip* (below) makes
+shape-mode reads independent of `properties`.
 
 ### Tier 3 — niche
 
@@ -153,10 +189,6 @@ we care about.
 
 **`hasOwn` / `in` ICs.** Cache shape-presence for
 `Object.hasOwn(obj, "x")` and `"x" in obj`. Niche.
-
-**Computed-property IC** (`obj[k]` where `k` is a hot constant
-string). Cache `(shape, key_intern, slot)`. Requires string
-interning first.
 
 ## The flip — retire `properties` for shaped objects
 
@@ -216,6 +248,8 @@ makes the JIT-tier work tractable. Phased plan + invariants in
 - `bench-results.md` records per-commit deltas.
 - Cross-engine comparison via `tools/bench-cross.sh` per
   [docs/benchmarking.md](benchmarking.md).
-- test262 runtime gate every new IC chunk — `fail` must not
-  regress from the established baseline (currently 9 fail,
-  all pre-existing RegExp property-escapes).
+- test262 runtime gate every new IC chunk — pass / fail counts must
+  match the row recorded in
+  [test262-results.md](../test262-results.md). Each landed IC in
+  the *Shipped* list above kept the count byte-for-byte stable;
+  any future IC must do the same.

--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -700,6 +700,27 @@ pub const Builder = struct {
         try self.emitU16(try self.allocIC());
     }
 
+    /// Emit `lda_global` plus its key constant index and a freshly
+    /// allocated IC slot. Encoding: `[op] [k:u16] [ic:u16]`. The IC
+    /// caches `(globalThis_shape, slot, decl_revision)` so repeated
+    /// `Math` / `Object` / `Array` / `print` reads collapse from a
+    /// `decl_env.get` + `globalThis.lookupOwn` hash pair to a shape
+    /// compare + slot load.
+    pub fn emitLdaGlobal(self: *Builder, span: Span, k: u16) !void {
+        try self.emitOp(.lda_global, span);
+        try self.emitU16(k);
+        try self.emitU16(try self.allocIC());
+    }
+
+    /// Emit `lda_global_or_undef` plus its key constant index and a
+    /// freshly allocated IC slot. Same cache shape as
+    /// `lda_global` — the miss path is the only difference.
+    pub fn emitLdaGlobalOrUndef(self: *Builder, span: Span, k: u16) !void {
+        try self.emitOp(.lda_global_or_undef, span);
+        try self.emitU16(k);
+        try self.emitU16(try self.allocIC());
+    }
+
     /// Emit `sta_property` plus its key constant index, receiver
     /// register, and a freshly allocated IC slot. Encoding:
     /// `[op] [k:u16] [r_obj:u8] [ic:u16]`.

--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -737,6 +737,27 @@ pub const Builder = struct {
         try self.emitU16(try self.allocCallIC());
     }
 
+    /// Emit `call_property` — the fused property-load + method-call
+    /// op. Reserves BOTH an IC slot (for the property lookup, same
+    /// table `lda_property` uses) AND a call-IC slot (for the loaded
+    /// callee, same table `call_method` uses). Encoding:
+    /// `[op] [k:u16] [r_recv:u8] [argc:u8] [ic_load:u16] [ic_call:u16]`.
+    /// Args live at `r_recv + 1.. r_recv + 1 + argc`.
+    pub fn emitCallProperty(
+        self: *Builder,
+        span: Span,
+        k: u16,
+        r_recv: u8,
+        argc: u8,
+    ) !void {
+        try self.emitOp(.call_property, span);
+        try self.emitU16(k);
+        try self.emitU8(r_recv);
+        try self.emitU8(argc);
+        try self.emitU16(try self.allocIC());
+        try self.emitU16(try self.allocCallIC());
+    }
+
     /// Append `v` to the constant pool, returning its index.
     /// Identical doubles, ints, etc. are not deduplicated — the
     /// optimizer (M5+) can do that. Keep simple here.

--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -758,6 +758,24 @@ pub const Builder = struct {
         try self.emitU16(try self.allocCallIC());
     }
 
+    /// Emit `call` plus its callee / argc operands and a freshly
+    /// allocated call-IC slot. Encoding:
+    /// `[op] [r_callee:u8] [argc:u8] [ic:u16]`. Mirrors
+    /// `emitCallMethod`'s allocation pattern; targets the free-
+    /// function call site `f(args)` (not `obj.f(args)`), with the
+    /// same cached-callee fast path as `call_method`.
+    pub fn emitCall(
+        self: *Builder,
+        span: Span,
+        r_callee: u8,
+        argc: u8,
+    ) !void {
+        try self.emitOp(.call, span);
+        try self.emitU8(r_callee);
+        try self.emitU8(argc);
+        try self.emitU16(try self.allocCallIC());
+    }
+
     /// Emit `call_property` — the fused property-load + method-call
     /// op. Reserves BOTH an IC slot (for the property lookup, same
     /// table `lda_property` uses) AND a call-IC slot (for the loaded

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -644,8 +644,7 @@ pub const Compiler = struct {
                 try self.builder.emitU32(binding.global_lex_slot);
             } else {
                 const k = try self.internString(binding.name);
-                try self.builder.emitOp(.lda_global, span);
-                try self.builder.emitU16(k);
+                try self.builder.emitLdaGlobal(span, k);
             }
         } else {
             const depth = self.env_depth - binding.env_depth;
@@ -1030,8 +1029,7 @@ pub const Compiler = struct {
         // Look up `RegExp` from globals at runtime; emit
         // `new RegExp(pattern, flags)` via the literal call path.
         const k_regexp = try self.internString("RegExp");
-        try self.builder.emitOp(.lda_global, span);
-        try self.builder.emitU16(k_regexp);
+        try self.builder.emitLdaGlobal(span, k_regexp);
         const r_ctor = try self.reserveTemp();
         defer self.releaseTemp();
         try self.builder.emitOp(.star, span);
@@ -1291,8 +1289,7 @@ pub const Compiler = struct {
             try self.builder.emitOp(.iter_close, y.span);
             try self.builder.emitU8(r_iter);
             try self.builder.emitU8(0);
-            try self.builder.emitOp(.lda_global, y.span);
-            try self.builder.emitU16(k_type_error);
+            try self.builder.emitLdaGlobal(y.span, k_type_error);
             try self.builder.emitOp(.star, y.span);
             try self.builder.emitU8(r_callee);
             try self.builder.emitOp(.new_call, y.span);
@@ -1527,8 +1524,7 @@ pub const Compiler = struct {
         try self.builder.emitU8(r_iter);
         try self.builder.emitU8(0); // mode = normal
         // `new TypeError()` — lda_global TypeError → r_callee, new_call.
-        try self.builder.emitOp(.lda_global, y.span);
-        try self.builder.emitU16(k_type_error);
+        try self.builder.emitLdaGlobal(y.span, k_type_error);
         try self.builder.emitOp(.star, y.span);
         try self.builder.emitU8(r_callee);
         try self.builder.emitOp(.new_call, y.span);
@@ -4476,8 +4472,7 @@ pub const Compiler = struct {
         // Call Reflect.construct(callee, args). It allocates the
         // new instance and binds `this` correctly per §10.2.2.
         const k_reflect = try self.internString("Reflect");
-        try self.builder.emitOp(.lda_global, n.span);
-        try self.builder.emitU16(k_reflect);
+        try self.builder.emitLdaGlobal(n.span, k_reflect);
         const k_construct = try self.internString("construct");
         try self.builder.emitLdaProperty(n.span, k_construct);
         const r_construct = try self.reserveTemp();
@@ -4519,8 +4514,7 @@ pub const Compiler = struct {
             // `Realm.installBuiltins`. Resolution failure at
             // runtime raises a ReferenceError.
             const k = try self.internString(name);
-            try self.builder.emitOp(.lda_global, span);
-            try self.builder.emitU16(k);
+            try self.builder.emitLdaGlobal(span, k);
             return;
         };
         try self.emitLoadBinding(binding, span);
@@ -4838,8 +4832,7 @@ pub const Compiler = struct {
                     const k_ref_error = try self.internString("ReferenceError");
                     const r_callee = try self.reserveTemp();
                     defer self.releaseTemp();
-                    try self.builder.emitOp(.lda_global, u.span);
-                    try self.builder.emitU16(k_ref_error);
+                    try self.builder.emitLdaGlobal(u.span, k_ref_error);
                     try self.builder.emitOp(.star, u.span);
                     try self.builder.emitU8(r_callee);
                     try self.builder.emitOp(.new_call, u.span);
@@ -4917,8 +4910,7 @@ pub const Compiler = struct {
                 const scope = self.scope orelse return error.UnresolvedReference;
                 if (scope.resolve(name) == null and !std.mem.eql(u8, name, "undefined")) {
                     const k = try self.internString(name);
-                    try self.builder.emitOp(.lda_global_or_undef, span);
-                    try self.builder.emitU16(k);
+                    try self.builder.emitLdaGlobalOrUndef(span, k);
                     try self.builder.emitOp(.typeof_, u.span);
                     return;
                 }
@@ -8651,8 +8643,7 @@ pub const Compiler = struct {
     /// no message is uninformative.
     fn emitGlobalDeclThrow(self: *Compiler, name: []const u8, span: Span) CompileError!void {
         const k_type_error = try self.internString("TypeError");
-        try self.builder.emitOp(.lda_global, span);
-        try self.builder.emitU16(k_type_error);
+        try self.builder.emitLdaGlobal(span, k_type_error);
         const r_callee = try self.reserveTemp();
         defer self.releaseTemp();
         try self.builder.emitOp(.star, span);

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -3964,6 +3964,57 @@ pub const Compiler = struct {
         m: ast.expression.MemberExpr,
         emit_tail: bool,
     ) CompileError!void {
+        // Fused-emission gate: `obj.method(args)` where the property
+        // is a plain identifier, not a private name (`#x`), no
+        // optional chain on either side, and not in tail position.
+        // The qualifying shape compiles to one `call_property` op
+        // (8-byte operand) instead of the four-op
+        // `ldar + lda_property + star + call_method` sequence
+        // (15-byte operand) — saves 3 dispatches + 5 wire bytes per
+        // site. Every other shape (private, computed, optional,
+        // tail, super) falls through to the legacy emission below
+        // and behavior is unchanged.
+        const fused_ident: ?u16 = blk: {
+            if (emit_tail) break :blk null;
+            if (m.optional or c.optional) break :blk null;
+            switch (m.property) {
+                .ident => |span| {
+                    const key_slice = self.source[span.start..span.end];
+                    if (key_slice.len > 0 and key_slice[0] == '#') break :blk null;
+                    const decoded = try self.decodeIdentifierName(key_slice);
+                    break :blk try self.internString(decoded);
+                },
+                .computed => break :blk null,
+            }
+        };
+
+        if (fused_ident) |k| {
+            // Receiver into r_recv. Args contiguous from r_recv + 1
+            // — no intervening r_callee slot, since `call_property`
+            // loads the callee inline and never spills it to a
+            // register.
+            try self.compileExpression(m.object);
+            const r_recv = try self.reserveTemp();
+            try self.builder.emitOp(.star, c.span);
+            try self.builder.emitU8(r_recv);
+
+            var reserved: u8 = 0;
+            for (c.arguments) |*arg| {
+                try self.compileExpression(arg);
+                const r = try self.reserveTemp();
+                reserved += 1;
+                try self.builder.emitOp(.star, c.span);
+                try self.builder.emitU8(r);
+            }
+
+            try self.builder.emitCallProperty(c.span, k, r_recv, @intCast(c.arguments.len));
+
+            var j: u8 = 0;
+            while (j < reserved) : (j += 1) self.releaseTemp();
+            self.releaseTemp(); // r_recv
+            return;
+        }
+
         // Receiver into r_recv. `m.optional` flag (`a?.b`)
         // short-circuits to undefined when `a` is null/undefined.
         try self.compileExpression(m.object);

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -2219,9 +2219,13 @@ pub const Compiler = struct {
             try self.builder.emitU8(r_arg);
         }
 
-        try self.builder.emitOp(if (emit_tail) .tail_call else .call, tt.span);
-        try self.builder.emitU8(r_callee);
-        try self.builder.emitU8(@intCast(1 + lit.expressions.len));
+        if (emit_tail) {
+            try self.builder.emitOp(.tail_call, tt.span);
+            try self.builder.emitU8(r_callee);
+            try self.builder.emitU8(@intCast(1 + lit.expressions.len));
+        } else {
+            try self.builder.emitCall(tt.span, r_callee, @intCast(1 + lit.expressions.len));
+        }
 
         var k: u8 = 0;
         while (k < reserved) : (k += 1) self.releaseTemp();
@@ -3749,9 +3753,13 @@ pub const Compiler = struct {
         // tail position, emit `tail_call` so the interpreter reuses
         // the current frame instead of pushing one. Spread calls
         // and super calls don't take this path (handled above).
-        try self.builder.emitOp(if (emit_tail) .tail_call else .call, c.span);
-        try self.builder.emitU8(r_callee);
-        try self.builder.emitU8(@intCast(c.arguments.len));
+        if (emit_tail) {
+            try self.builder.emitOp(.tail_call, c.span);
+            try self.builder.emitU8(r_callee);
+            try self.builder.emitU8(@intCast(c.arguments.len));
+        } else {
+            try self.builder.emitCall(c.span, r_callee, @intCast(c.arguments.len));
+        }
 
         var j: u8 = 0;
         while (j < reserved) : (j += 1) self.releaseTemp();
@@ -4492,9 +4500,7 @@ pub const Compiler = struct {
         defer self.releaseTemp();
         try self.builder.emitOp(.star, n.span);
         try self.builder.emitU8(r_a2);
-        try self.builder.emitOp(.call, n.span);
-        try self.builder.emitU8(r_construct);
-        try self.builder.emitU8(2);
+        try self.builder.emitCall(n.span, r_construct, 2);
     }
 
     fn compileIdentRef(self: *Compiler, span: Span) CompileError!void {

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -182,11 +182,15 @@ pub const Op = enum(u8) {
     /// body compile to `throw_assign_const` so user-visible writes
     /// throw a TypeError per §8.1.1.1.4 SetMutableBinding step 9.b.
     make_named_function_expr,
-    /// `[op] [r_callee:u8] [argc:u8]` — invoke the function in
-    /// register `r_callee` with `argc` arguments drawn from the
+    /// `[op] [r_callee:u8] [argc:u8] [ic:u16]` — invoke the function
+    /// in register `r_callee` with `argc` arguments drawn from the
     /// consecutive registers `r_callee+1.. r_callee+argc`. The
     /// return value lands in the caller's accumulator after the
-    /// callee's `Return`.
+    /// callee's `Return`. The `ic` operand indexes
+    /// `Chunk.inline_call_caches` — a hit on the cached callee
+    /// pointer skips the proxy / revocable / bound / `valueAsFunction`
+    /// dispatch chain and calls the function directly. Same cell
+    /// shape as `call_method`'s call IC.
     call,
     /// `[op] [r_recv:u8] [r_callee:u8] [argc:u8] [ic:u16]` — method
     /// call. Identical to `Call` except `this` is bound to the value
@@ -1185,13 +1189,13 @@ pub const Op = enum(u8) {
             .sta_global_strict,
             => 3, // k:u16 + r:u8
             .make_class => 4, // k:u16 + r_keys_base:u8 + inner_class_slot:u8
-            .call,
             .new_call,
             .super_call,
             .tail_call,
             .lda_env,
             .sta_env,
             => 2, // u8 + u8
+            .call => 4, // r_callee:u8 + argc:u8 + ic:u16
             .tail_call_method => 3, // r_recv:u8 + r_callee:u8 + argc:u8
             .direct_eval => 4, // scope:u16 + r_callee:u8 + argc:u8
             .sta_private, .super_set, .def_property => 3, // k:u16 + r_obj:u8
@@ -1403,6 +1407,10 @@ test "Op: operandSize agrees with the documented encoding" {
     // read sites.
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_global));
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_global_or_undef));
+    // `call` carries the same call-IC slot `call_method` does, so
+    // free-function calls (`f(x)`) get the cached-callee fast path
+    // too: `[op] [r_callee:u8] [argc:u8] [ic:u16]` — 4 bytes.
+    try testing.expectEqual(@as(u8, 4), Op.operandSize(.call));
     // `call_property` is `[op] [k:u16] [r_recv:u8] [argc:u8]
     // [ic_load:u16] [ic_call:u16]` — 8 bytes of operand. Fuses the
     // `ldar + lda_property + star + call_method` 4-op sequence into

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -199,6 +199,37 @@ pub const Op = enum(u8) {
     /// pointer skips the proxy / revocable / bound / `valueAsFunction`
     /// dispatch chain and calls the function directly.
     call_method,
+    /// `[op] [k:u16] [r_recv:u8] [argc:u8] [ic_load:u16] [ic_call:u16]`
+    /// — fused property load + method call. Replaces the
+    /// `ldar r_recv; lda_property k ic_load; star r_callee;
+    /// call_method r_recv r_callee argc ic_call` 4-op sequence the
+    /// compiler used to emit for `obj.method(args)` when the property
+    /// name is a plain identifier (no private `#`, no computed key,
+    /// no optional chain, no tail position, no `super.method`). Hermes
+    /// ships the same fusion (its `CallBuiltin` / `CallPropertyN`);
+    /// Ignition's `CallProperty0/1/2` is the per-argc specialised
+    /// equivalent. Saves 3 dispatches + 5 wire bytes per call site —
+    /// material on tight method loops (`c.inc()`, `arr.push(x)`).
+    ///
+    /// Args live at `r_recv + 1.. r_recv + 1 + argc`. The compiler
+    /// reserves them contiguous to `r_recv` (no intervening
+    /// `r_callee` slot — the callee is loaded inline and never spills
+    /// to a register).
+    ///
+    /// Fast path: shape compare on the receiver, serve the cached
+    /// own- or proto-slot, pointer-compare the loaded callee against
+    /// the call IC cell, callJSFunction directly. Slow path: same
+    /// receiver-type lookup arms as `lda_property` (plain / function /
+    /// string / number / bool / bigint / symbol / proxy / namespace
+    /// / null+undefined) followed by the same call-dispatch arms as
+    /// `call_method` (proxy / bound / revocable / native / generator
+    /// / async / regular).
+    ///
+    /// `ic_load` indexes `Chunk.inline_caches` (the same proto-load
+    /// cache `lda_property` uses); `ic_call` indexes
+    /// `Chunk.inline_call_caches` (the same callee cache
+    /// `call_method` uses).
+    call_property,
     /// `[op] [r_callee:u8] [argc:u8]` — `new f(args)` (§13.3.5).
     /// Allocates a fresh ordinary object whose `[[Prototype]]` is
     /// `f.prototype`, calls `f` with `this` bound to the new
@@ -1164,6 +1195,7 @@ pub const Op = enum(u8) {
             .del_named_property => 3, // k:u16 + r_obj:u8
             .del_computed_property => 2, // r_obj:u8 + r_key:u8
             .call_method => 5, // r_recv:u8 + r_callee:u8 + argc:u8 + ic:u16
+            .call_property => 8, // k:u16 + r_recv:u8 + argc:u8 + ic_load:u16 + ic_call:u16
             .for_of_next => 3, // r_iter:u8 + r_next:u8 + r_done:u8
             .loop_inc_lt => 4, // r_counter:u8 + r_bound:u8 + offset:i16
             .make_environment => 1, // slot_count:u8
@@ -1228,6 +1260,7 @@ pub const Op = enum(u8) {
             .make_named_function_expr => "MakeNamedFunctionExpr",
             .call => "Call",
             .call_method => "CallMethod",
+            .call_property => "CallProperty",
             .new_call => "NewCall",
             .tail_call => "TailCall",
             .tail_call_method => "TailCallMethod",
@@ -1351,6 +1384,11 @@ test "Op: operandSize agrees with the documented encoding" {
     // so unit-test failures stay hidden — playground/source-map
     // hover would be the user-visible signal).
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_property));
+    // `call_property` is `[op] [k:u16] [r_recv:u8] [argc:u8]
+    // [ic_load:u16] [ic_call:u16]` — 8 bytes of operand. Fuses the
+    // `ldar + lda_property + star + call_method` 4-op sequence into
+    // one dispatch for the simple `obj.method(args)` shape.
+    try testing.expectEqual(@as(u8, 8), Op.operandSize(.call_property));
     // `sta_property` is `[op] [k:u16] [r_obj:u8] [ic:u16]` — 5 bytes
     // of operand. Same disassembler-PC-walk hazard as `lda_property`
     // if this gets out of sync with the encoding.

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -728,13 +728,23 @@ pub const Op = enum(u8) {
     /// `let` / `const` reads emit a follow-up `throw_if_hole`
     /// for §13.3.1 TDZ; that's how the global-env declarative
     /// vs property semantics is approximated.
+    ///
+    /// Wire: `[op] [k:u16] [ic:u16]`. The `ic` operand indexes
+    /// `Chunk.inline_caches`; a cell with `proto == null` and
+    /// `shape == gt.shape` caches an object-env slot on
+    /// `globalThis`. `proto_rev` is repurposed to record
+    /// `GlobalBindings.decl_revision` at fill time so a new
+    /// `let` / `const` / `class` declared at script scope
+    /// invalidates the cell (the lex binding shadows the
+    /// cached object-env slot per §9.1.1.4 lookup order).
     lda_global,
-    /// `[op] [k:u16]` — like `lda_global`, but produce
+    /// `[op] [k:u16] [ic:u16]` — like `lda_global`, but produce
     /// `undefined` instead of raising `ReferenceError` when the
     /// global isn't present. Used to compile `typeof Identifier`
     /// where `Identifier` isn't a known binding (§13.5.3 step 3:
     /// an unresolvable Reference yields the string "undefined"
-    /// rather than throwing).
+    /// rather than throwing). Shares the same IC cell shape and
+    /// invalidation contract as `lda_global`.
     lda_global_or_undef,
     /// `[op] [k:u16]` — store acc into the realm's globals map
     /// under the name held in `Chunk.constants[k]` (a `JSString`).
@@ -1148,8 +1158,6 @@ pub const Op = enum(u8) {
             .super_get,
             .lda_private,
             .private_in,
-            .lda_global,
-            .lda_global_or_undef,
             .sta_global,
             .sta_global_init,
             .sta_global_fn_decl,
@@ -1200,7 +1208,10 @@ pub const Op = enum(u8) {
             .loop_inc_lt => 4, // r_counter:u8 + r_bound:u8 + offset:i16
             .make_environment => 1, // slot_count:u8
             .lda_smi => 4, // i32 immediate
-            .lda_property => 4, // k:u16 + ic:u16 (inline-cache slot)
+            .lda_property,
+            .lda_global,
+            .lda_global_or_undef,
+            => 4, // k:u16 + ic:u16 (inline-cache slot)
             .lda_global_slot,
             .sta_global_slot,
             .sta_global_slot_init,
@@ -1384,6 +1395,14 @@ test "Op: operandSize agrees with the documented encoding" {
     // so unit-test failures stay hidden — playground/source-map
     // hover would be the user-visible signal).
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_property));
+    // `lda_global` and `lda_global_or_undef` carry an IC slot
+    // alongside the key constant index: `[op] [k:u16] [ic:u16]`,
+    // 4 bytes of operand. The IC turns a `decl_env.get` +
+    // `globalThis.lookupOwn` hash pair into a shape compare +
+    // slot load on the hot `Math` / `Object` / `Array` / `console`
+    // read sites.
+    try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_global));
+    try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_global_or_undef));
     // `call_property` is `[op] [k:u16] [r_recv:u8] [argc:u8]
     // [ic_load:u16] [ic_call:u16]` — 8 bytes of operand. Fuses the
     // `ldar + lda_property + star + call_method` 4-op sequence into

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -2635,6 +2635,326 @@ pub fn runFrames(
             continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
         },
 
+        // §13.3.6 EvaluateCall — fused property load + method call
+        // for the simple `obj.method(args)` shape. Replaces a
+        // 4-op `ldar + lda_property + star + call_method` sequence
+        // with one dispatch. Hot path: receiver shape compare +
+        // load cached own / proto slot + callee pointer compare +
+        // direct `callJSFunction`. Slow path: `slowLookupForCallProperty`
+        // (mirrors `lda_property`'s 11-arm receiver-type matrix)
+        // followed by the same call-dispatch arms as `call_method`
+        // (proxy / bound / revocable / native / generator / async /
+        // regular).
+        .call_property => {
+            const k = readU16(code, ip);
+            const r_recv = code[ip + 2];
+            const argc = code[ip + 3];
+            const ic_load_idx = readU16(code, ip + 4);
+            const ic_call_idx = readU16(code, ip + 6);
+            ip += 8;
+
+            if (k >= local_chunk.constants.len) return error.InvalidOpcode;
+            const key_v = local_chunk.constants[k];
+            if (!key_v.isString()) return error.InvalidOpcode;
+            const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
+            const recv = registers[r_recv];
+
+            // Resolve the callee. Fast path: shape compare on the
+            // receiver (and proto identity + proto_shape + proto_rev
+            // for the proto-load mode), serve `recv.slots[slot]` or
+            // `proto.slots[slot]`. Slow path: `slowLookupForCallProperty`.
+            var callee_v: Value = Value.undefined_;
+            var resolved_fast: bool = false;
+            if (heap_mod.valueAsPlainObject(recv)) |obj_in| {
+                const cell = &local_chunk.inline_caches[ic_load_idx];
+                if (cell.shape != null and cell.shape == obj_in.shape) {
+                    if (cell.proto) |proto| {
+                        if (obj_in.prototype == proto and
+                            proto.shape == cell.proto_shape and
+                            cell.proto_rev == realm.proto_revision_counter)
+                        {
+                            callee_v = proto.slots.items[cell.slot];
+                            resolved_fast = true;
+                        }
+                    } else {
+                        callee_v = obj_in.slots.items[cell.slot];
+                        resolved_fast = true;
+                    }
+                }
+            }
+            if (!resolved_fast) {
+                const lookup = try slowLookupForCallProperty(allocator, realm, frames, f, ip, recv, key_s.flatBytes());
+                callee_v = switch (lookup) {
+                    .value => |v| v,
+                    .handled => {
+                        // The helper called `unwindThrow`, which
+                        // already rewrote `f.ip` to the matching
+                        // catch handler's PC. DO NOT overwrite it
+                        // — `reEnterDispatch` reads `f.ip` to pick
+                        // up at the catch. (Mirrors the
+                        // `getThroughChain` `.handled` arm in
+                        // `lda_property`'s slow path.)
+                        committed = true;
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    },
+                    .uncaught => |ex| return .{ .thrown = ex },
+                };
+                // Refill the load IC for the simple shape-claimed
+                // own / proto-data case so the next call takes the
+                // fast path. Anything more exotic (accessor, proxy,
+                // module namespace, primitive auto-box) stays
+                // un-cached — mirrors `lda_property`'s IC fill
+                // policy.
+                if (heap_mod.valueAsPlainObject(recv)) |obj_in| {
+                    if (obj_in.shape) |sh| {
+                        const cell = &local_chunk.inline_caches[ic_load_idx];
+                        if (sh.lookup(key_s.flatBytes())) |entry| {
+                            if (entry.kind == .data) {
+                                cell.shape = sh;
+                                cell.slot = entry.slot;
+                                cell.proto = null;
+                                cell.proto_shape = null;
+                            }
+                        } else if (!chainHasProxy(obj_in) and !obj_in.hasAccessor(key_s.flatBytes())) {
+                            var cursor: ?*JSObject = obj_in.prototype;
+                            while (cursor) |proto| : (cursor = proto.prototype) {
+                                if (proto.proxy_target != null or proto.proxy_revoked) break;
+                                if (proto.is_module_namespace) break;
+                                if (proto.hasAccessor(key_s.flatBytes())) break;
+                                if (proto.shape) |proto_sh| {
+                                    if (proto_sh.lookup(key_s.flatBytes())) |entry| {
+                                        if (entry.kind == .data) {
+                                            cell.shape = sh;
+                                            cell.slot = entry.slot;
+                                            cell.proto = proto;
+                                            cell.proto_shape = proto_sh;
+                                            cell.proto_rev = realm.proto_revision_counter;
+                                            break;
+                                        }
+                                    }
+                                }
+                                if (proto.ownDataContains(key_s.flatBytes())) break;
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Call IC: pointer-compare the loaded callee against the
+            // cached `JSFunction*`. A hit skips the entire exotic-
+            // dispatch chain below (proxy / revocable / bound /
+            // `valueAsFunction`) and goes straight to the
+            // generator / native / async / regular call.
+            const call_cell = &local_chunk.inline_call_caches[ic_call_idx];
+            const callee_fn = blk: {
+                if (call_cell.callee) |cached| {
+                    if (heap_mod.valueAsFunction(callee_v)) |fn_obj| {
+                        if (fn_obj == cached) break :blk fn_obj;
+                    }
+                }
+
+                // §10.5.13 callable Proxy [[Call]].
+                if (heap_mod.valueAsPlainObject(callee_v)) |po| {
+                    if (po.proxy_target_fn != null or po.proxy_target != null or po.proxy_revoked) {
+                        const args_start = @as(usize, r_recv) + 1;
+                        const args_slice = registers[args_start .. args_start + argc];
+                        const cresult = try callValue(allocator, realm, f.running_realm orelse realm, callee_v, recv, args_slice);
+                        switch (cresult) {
+                            .value, .yielded => |v| {
+                                acc = v;
+                                continue :dispatch try decodeNext(code, &ip, &committed);
+                            },
+                            .thrown => |ex| {
+                                f.ip = ip;
+                                f.accumulator = acc;
+                                committed = true;
+                                if (!try unwindThrow(allocator, realm, frames, ex)) {
+                                    return .{ .thrown = ex };
+                                }
+                                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                            },
+                        }
+                    }
+                    // §20.2.3 — call into %Function.prototype% is undefined.
+                    if (realm.intrinsics.function_prototype == po) {
+                        acc = Value.undefined_;
+                        continue :dispatch try decodeNext(code, &ip, &committed);
+                    }
+                }
+                const fn_v = heap_mod.valueAsFunction(callee_v) orelse {
+                    const ex = try makeTypeError(realm, "value is not callable");
+                    f.ip = ip;
+                    f.accumulator = acc;
+                    committed = true;
+                    if (!try unwindThrow(allocator, realm, frames, ex)) {
+                        return .{ .thrown = ex };
+                    }
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                };
+
+                // §28.2.2.1.1 — revocation function.
+                if (fn_v.revocable_proxy) |rp| {
+                    realm.heap.setProxyTarget(rp, null);
+                    realm.heap.setProxyHandler(rp, null);
+                    realm.heap.setProxyTargetFn(rp, null);
+                    rp.proxy_revoked = true;
+                    fn_v.revocable_proxy = null;
+                    acc = Value.undefined_;
+                    continue :dispatch try decodeNext(code, &ip, &committed);
+                }
+
+                // §10.4.1 — bound function. The bound `this`
+                // overrides `recv` inside `unwrapBoundCall`.
+                if (fn_v.bound_target != null) {
+                    const args_start = @as(usize, r_recv) + 1;
+                    const result = try callJSFunction(allocator, realm, fn_v, recv, registers[args_start .. args_start + argc]);
+                    switch (result) {
+                        .value, .yielded => |v| acc = v,
+                        .thrown => |ex| {
+                            f.ip = ip;
+                            f.accumulator = acc;
+                            committed = true;
+                            if (!try unwindThrow(allocator, realm, frames, ex)) {
+                                return .{ .thrown = ex };
+                            }
+                            continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                        },
+                    }
+                    continue :dispatch try decodeNext(code, &ip, &committed);
+                }
+
+                // Plain callable — refill the call IC.
+                call_cell.callee = fn_v;
+                break :blk fn_v;
+            };
+
+            // §27.5 / §27.6 — generator / async generator wrap.
+            if (callee_fn.is_generator) {
+                const callee_chunk = callee_fn.chunk orelse return error.InvalidOpcode;
+                const args_start = @as(usize, r_recv) + 1;
+                const wrap_result = if (callee_fn.is_async)
+                    try wrapAsyncGenerator(allocator, realm, callee_chunk, callee_fn.captured_env, recv, registers[args_start .. args_start + argc], callee_fn.home_object, callee_fn.home_function, callee_fn)
+                else
+                    try wrapGenerator(allocator, realm, callee_chunk, callee_fn.captured_env, recv, registers[args_start .. args_start + argc], callee_fn.home_object, callee_fn.home_function, callee_fn);
+                switch (wrap_result) {
+                    .value, .yielded => |v| acc = v,
+                    .thrown => |ex| {
+                        f.ip = ip;
+                        f.accumulator = acc;
+                        committed = true;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) {
+                            return .{ .thrown = ex };
+                        }
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    },
+                }
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+
+            // Native fast path.
+            if (callee_fn.native_callback) |native| {
+                const prior_fn_realm = realm.active_native_fn_realm;
+                realm.active_native_fn_realm = callee_fn.realm;
+                defer realm.active_native_fn_realm = prior_fn_realm;
+                const args_start = @as(usize, r_recv) + 1;
+                const args = registers[args_start .. args_start + argc];
+                const native_this: Value = if (callee_fn.is_arrow)
+                    callee_fn.captured_this
+                else
+                    recv;
+                const result = native(realm, native_this, args) catch |err| switch (err) {
+                    error.OutOfMemory => return error.OutOfMemory,
+                    error.NativeThrew => {
+                        const ex = consumePendingException(realm) orelse try makeTypeError(realm, "native error");
+                        f.ip = ip;
+                        f.accumulator = acc;
+                        committed = true;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) {
+                            return .{ .thrown = ex };
+                        }
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    },
+                };
+                acc = result;
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+
+            if (callee_fn.is_async) {
+                const callee_chunk = callee_fn.chunk orelse return error.InvalidOpcode;
+                const args_start = @as(usize, r_recv) + 1;
+                const callee_this: Value = if (callee_fn.is_arrow) callee_fn.captured_this else recv;
+                const outcome = try startAsyncCall(allocator, realm, callee_chunk, callee_fn.captured_env, callee_this, registers[args_start .. args_start + argc], callee_fn.home_object, callee_fn.home_function, callee_fn.owning_module);
+                switch (outcome) {
+                    .value, .yielded => |v| acc = v,
+                    .thrown => |ex| {
+                        f.ip = ip;
+                        f.accumulator = acc;
+                        committed = true;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) {
+                            return .{ .thrown = ex };
+                        }
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    },
+                }
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+
+            // §15.7.14 step 1 — class constructors are not callable.
+            if (callee_fn.is_class_constructor) {
+                const ex = try makeTypeError(realm, "Class constructor cannot be invoked without 'new'");
+                f.ip = ip;
+                f.accumulator = acc;
+                committed = true;
+                if (!try unwindThrow(allocator, realm, frames, ex)) {
+                    return .{ .thrown = ex };
+                }
+                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+            }
+
+            // Plain JS callee — push a new frame.
+            const callee_chunk = callee_fn.chunk orelse return error.InvalidOpcode;
+            const callee_regs = try realm.frame_pool.acquire(allocator, @max(@as(usize, callee_chunk.register_count), @as(usize, argc)));
+            @memset(callee_regs, Value.undefined_);
+            var ai: u8 = 0;
+            while (ai < argc and @as(usize, ai) < callee_regs.len) : (ai += 1) {
+                callee_regs[ai] = registers[@as(usize, r_recv) + 1 + ai];
+            }
+
+            f.ip = ip;
+            f.accumulator = acc;
+            committed = true;
+
+            const callee_this: Value = if (callee_fn.is_arrow)
+                callee_fn.captured_this
+            else
+                recv;
+            const callee_new_target: Value = if (callee_fn.is_arrow)
+                callee_fn.captured_new_target
+            else
+                Value.undefined_;
+
+            frames.append(allocator, .{
+                .chunk = callee_chunk,
+                .ip = 0,
+                .accumulator = Value.undefined_,
+                .registers = callee_regs,
+                .env = callee_fn.captured_env,
+                .this_value = callee_this,
+                .new_target = callee_new_target,
+                .home_object = callee_fn.home_object,
+                .home_function = callee_fn.home_function,
+                .super_called_cell = callee_fn.super_called_cell,
+                .argc = argc,
+                .wrap_return_in_promise = false,
+                .owning_module = callee_fn.owning_module,
+                .running_realm = callee_fn.realm,
+            }) catch {
+                realm.frame_pool.release(allocator, callee_regs);
+                return error.OutOfMemory;
+            };
+            continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+        },
+
         // §15.10 PTC — tail call. The compiler emitted this
         // only after the §15.10.1 IsInTailPosition checks
         // passed (statically a tail expression; not in async
@@ -10391,6 +10711,195 @@ const GetChainOutcome = union(enum) {
     handled,
     uncaught: Value,
 };
+
+/// §13.3.6 EvaluateCall + §10.1.8 OrdinaryGet — resolve the callee
+/// for the fused `call_property` opcode's slow path. Mirrors
+/// `lda_property`'s 11-arm receiver-type matrix (plain object,
+/// function, string, int / double, bool, bigint, symbol, plus the
+/// proxy / module-namespace / chainHasProxy edge cases and the
+/// non-coercible `null` / `undefined` throw) and routes the
+/// resolved value through a `GetChainOutcome` instead of the
+/// dispatch loop's accumulator.
+///
+/// Pairs with the `.lda_property` slow path in the dispatch loop —
+/// any new receiver-type arm added there must be mirrored here.
+/// The decision not to fold the two into one shared helper is
+/// pragmatic: `lda_property` is the engine's hottest opcode and
+/// folding would require threading the dispatch-loop locals
+/// (`acc`, `committed`, `code`, `registers`, `local_chunk`)
+/// through every arm.
+fn slowLookupForCallProperty(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    frames: *std.ArrayListUnmanaged(CallFrame),
+    f: *CallFrame,
+    ip: usize,
+    recv: Value,
+    key: []const u8,
+) RunError!GetChainOutcome {
+    // §13.3.4.1 EvaluatePropertyAccessWithIdentifierKey step 5 —
+    // RequireObjectCoercible(baseValue) before the lookup.
+    if (recv.isNull() or recv.isUndefined()) {
+        const ex = try makeTypeError(realm, "Cannot read properties of null or undefined");
+        f.ip = ip;
+        if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+        return .handled;
+    }
+    if (heap_mod.valueAsPlainObject(recv)) |obj_in| {
+        var obj = obj_in;
+        // §10.5 Proxy [[Get]].
+        if (obj.proxy_target != null or obj.proxy_revoked) {
+            const r = try proxyGetTrap(allocator, realm, frames, f, ip, obj, key, recv);
+            switch (r) {
+                .value => |v| return .{ .value = v },
+                .fallthrough => |t| obj = t,
+                .handled => return .handled,
+                .uncaught => |ex| return .{ .uncaught = ex },
+            }
+        }
+        // §9.4.6.7 Module Namespace [[Get]] — string-key path.
+        if (obj.is_module_namespace and !std.mem.startsWith(u8, key, "@@") and !std.mem.startsWith(u8, key, "<sym:")) {
+            const v_ns = module_mod.namespaceGetThrowingOnHole(realm, obj, key) catch |err| switch (err) {
+                error.OutOfMemory => return error.OutOfMemory,
+                error.NativeThrew => {
+                    const ex = realm.pending_exception orelse Value.undefined_;
+                    realm.pending_exception = null;
+                    f.ip = ip;
+                    if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                    return .handled;
+                },
+            };
+            return .{ .value = v_ns };
+        }
+        // §10.1.8 OrdinaryGet — a proxy ancestor anywhere on the
+        // chain forces the explicit `Receiver`-preserving walk so
+        // the proxy's [[Get]] fires with the original `recv`.
+        if (chainHasProxy(obj)) {
+            switch (try getThroughChain(allocator, realm, frames, f, ip, obj, key, recv)) {
+                .value => |v| return .{ .value = v },
+                .handled => return .handled,
+                .uncaught => |ex| return .{ .uncaught = ex },
+            }
+        }
+        // Accessor wins over inherited data.
+        if (lookupAccessor(obj, key)) |acc_pair| {
+            if (acc_pair.getter) |getter| {
+                if (getter.synth_accessor) |sa| {
+                    if (!sa.is_setter) return .{ .value = sa.value };
+                }
+                const outcome = try callJSFunction(allocator, realm, getter, recv, &.{});
+                switch (outcome) {
+                    .value, .yielded => |v| return .{ .value = v },
+                    .thrown => |ex| {
+                        f.ip = ip;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                        return .handled;
+                    },
+                }
+            }
+            return .{ .value = Value.undefined_ };
+        }
+        return .{ .value = obj.get(key) };
+    }
+    if (heap_mod.valueAsFunction(recv)) |fn_obj| {
+        // §10.2.4 — `.caller` / `.arguments` are poison-pill
+        // accessors on %Function.prototype% inherited by every
+        // function object.
+        if (lookupFunctionAccessor(fn_obj, key)) |acc_pair| {
+            if (acc_pair.getter) |getter| {
+                if (getter.synth_accessor) |sa| {
+                    if (!sa.is_setter) return .{ .value = sa.value };
+                }
+                const outcome = try callJSFunction(allocator, realm, getter, recv, &.{});
+                switch (outcome) {
+                    .value, .yielded => |v| return .{ .value = v },
+                    .thrown => |ex| {
+                        f.ip = ip;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                        return .handled;
+                    },
+                }
+            }
+            return .{ .value = Value.undefined_ };
+        }
+        return .{ .value = fn_obj.get(key) };
+    }
+    if (recv.isString()) {
+        // §6.1.4.4 — String primitive: .length (UTF-16 code units),
+        // numeric-index char access, inherited String.prototype.
+        const recv_s: *JSString = @ptrCast(@alignCast(recv.asString()));
+        if (std.mem.eql(u8, key, "length")) {
+            return .{ .value = Value.fromInt32(@intCast(utf16.lengthInCodeUnits(recv_s.flatBytes()))) };
+        }
+        if (realm.intrinsics.string_prototype) |sp| {
+            if (lookupAccessor(sp, key)) |acc_pair| {
+                if (acc_pair.getter) |getter| {
+                    const outcome = try callJSFunction(allocator, realm, getter, recv, &.{});
+                    switch (outcome) {
+                        .value, .yielded => |v| return .{ .value = v },
+                        .thrown => |ex| {
+                            f.ip = ip;
+                            if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                            return .handled;
+                        },
+                    }
+                }
+                return .{ .value = Value.undefined_ };
+            }
+            return .{ .value = sp.get(key) };
+        }
+        return .{ .value = Value.undefined_ };
+    }
+    if (recv.isInt32() or recv.isDouble()) {
+        return primitiveProtoLookupForCall(allocator, realm, frames, f, ip, recv, key, (f.running_realm orelse realm).globals.get("Number") orelse Value.undefined_);
+    }
+    if (recv.isBool()) {
+        return primitiveProtoLookupForCall(allocator, realm, frames, f, ip, recv, key, (f.running_realm orelse realm).globals.get("Boolean") orelse Value.undefined_);
+    }
+    if (heap_mod.isBigInt(recv)) {
+        return primitiveProtoLookupForCall(allocator, realm, frames, f, ip, recv, key, (f.running_realm orelse realm).globals.get("BigInt") orelse Value.undefined_);
+    }
+    if (heap_mod.isSymbol(recv)) {
+        return primitiveProtoLookupForCall(allocator, realm, frames, f, ip, recv, key, (f.running_realm orelse realm).globals.get("Symbol") orelse Value.undefined_);
+    }
+    const ex = try makeTypeError(realm, "Cannot read properties of non-object");
+    f.ip = ip;
+    if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+    return .handled;
+}
+
+/// Shared tail of the Number / Boolean / BigInt / Symbol arms in
+/// `slowLookupForCallProperty` — read the ctor's `.prototype`, look
+/// up an accessor (firing the getter with the primitive as `this`),
+/// else fall back to the prototype's own / inherited data property.
+fn primitiveProtoLookupForCall(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    frames: *std.ArrayListUnmanaged(CallFrame),
+    f: *CallFrame,
+    ip: usize,
+    recv: Value,
+    key: []const u8,
+    ctor_v: Value,
+) RunError!GetChainOutcome {
+    const ctor = heap_mod.valueAsFunction(ctor_v) orelse return .{ .value = Value.undefined_ };
+    const proto = ctor.prototype orelse return .{ .value = Value.undefined_ };
+    if (lookupAccessor(proto, key)) |acc_pair| {
+        if (acc_pair.getter) |getter| {
+            const outcome = try callJSFunction(allocator, realm, getter, recv, &.{});
+            switch (outcome) {
+                .value, .yielded => |v| return .{ .value = v },
+                .thrown => |ex| {
+                    f.ip = ip;
+                    if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                    return .handled;
+                },
+            }
+        }
+        return .{ .value = Value.undefined_ };
+    }
+    return .{ .value = proto.get(key) };
+}
 
 /// §10.1.8 OrdinaryGet over a prototype chain that includes at
 /// least one Proxy ancestor. Walks the chain rung by rung: on a

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -2049,27 +2049,124 @@ pub fn runFrames(
         .call => {
             const r_callee = code[ip];
             const argc = code[ip + 1];
-            ip += 2;
+            const ic_idx = readU16(code, ip + 2);
+            ip += 4;
 
             const callee_v = registers[r_callee];
-            // §10.5.13 callable Proxy [[Call]] — if the callee
-            // is a proxy, route through `callValue` which
-            // handles the apply trap and chained proxies.
-            if (heap_mod.valueAsPlainObject(callee_v)) |po| {
-                if (po.proxy_target_fn != null or po.proxy_target != null or po.proxy_revoked) {
+            const call_cell = &local_chunk.inline_call_caches[ic_idx];
+
+            // Inline cache: a hit means the same callee was here last
+            // time AND it survived every exotic-callee check (proxy,
+            // revocable, bound, wrapped, class constructor). Skip the
+            // entire dispatch chain below and fall through to the
+            // generator / native / async / regular call path.
+            //
+            // The IC is GC-aware: the heap's mark walk weak-clears
+            // any cell whose callee isn't reachable through other
+            // refs, so a swept-and-reused address cannot match.
+            // Same `CallICCell` shape as `call_method`.
+            const callee_fn = blk: {
+                if (call_cell.callee) |cached| {
+                    if (heap_mod.valueAsFunction(callee_v)) |fn_obj| {
+                        if (fn_obj == cached) break :blk fn_obj;
+                    }
+                }
+
+                // Slow path — exotic-callee dispatch.
+
+                // §10.5.13 callable Proxy [[Call]] — if the callee
+                // is a proxy, route through `callValue` which
+                // handles the apply trap and chained proxies.
+                if (heap_mod.valueAsPlainObject(callee_v)) |po| {
+                    if (po.proxy_target_fn != null or po.proxy_target != null or po.proxy_revoked) {
+                        const args_start = @as(usize, r_callee) + 1;
+                        const args_slice = registers[args_start .. args_start + argc];
+                        const cresult = try callValue(allocator, realm, f.running_realm orelse realm, callee_v, Value.undefined_, args_slice);
+                        switch (cresult) {
+                            .value, .yielded => |v| {
+                                acc = v;
+                                // `callValue` ran the callee in its own
+                                // runFrames re-entry — no frame pushed onto
+                                // this stack, the active frame is unchanged
+                                // → decodeNext. reEnterDispatch would reload
+                                // a stale `f.ip` and re-run this call.
+                                continue :dispatch try decodeNext(code, &ip, &committed);
+                            },
+                            .thrown => |ex| {
+                                f.ip = ip;
+                                f.accumulator = acc;
+                                committed = true;
+                                if (!try unwindThrow(allocator, realm, frames, ex)) {
+                                    return .{ .thrown = ex };
+                                }
+                                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                            },
+                        }
+                    }
+                    // §20.2.3 %Function.prototype% [[Call]] — "the
+                    // Function prototype object is itself a built-in
+                    // function object that, when invoked, accepts any
+                    // arguments and returns undefined." Cynic stores
+                    // it as a JSObject (not a JSFunction) so the
+                    // identity check is the cheapest dispatch path.
+                    if (realm.intrinsics.function_prototype == po) {
+                        acc = Value.undefined_;
+                        continue :dispatch try decodeNext(code, &ip, &committed);
+                    }
+                }
+                const fn_v = heap_mod.valueAsFunction(callee_v) orelse {
+                    const ex = try makeTypeError(realm, "value is not callable");
+                    f.ip = ip;
+                    f.accumulator = acc;
+                    committed = true;
+                    if (!try unwindThrow(allocator, realm, frames, ex)) {
+                        return .{ .thrown = ex };
+                    }
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                };
+
+                // §15.7.14 step 1 — class constructors are not
+                // callable without `new`; reject with TypeError.
+                // Checked inside the blk so the IC cell never
+                // caches a class-constructor callee (the next call
+                // would skip this check and try to invoke it).
+                if (fn_v.is_class_constructor) {
+                    const ex = try makeTypeError(realm, "Class constructor cannot be invoked without 'new'");
+                    f.ip = ip;
+                    f.accumulator = acc;
+                    committed = true;
+                    if (!try unwindThrow(allocator, realm, frames, ex)) {
+                        return .{ .thrown = ex };
+                    }
+                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                }
+
+                // §28.2.2.1.1 — revocation function. Calling it
+                // clears the captured proxy's internal slots.
+                // First call returns undefined and clears the slot;
+                // subsequent calls no-op (slot is null).
+                if (fn_v.revocable_proxy) |rp| {
+                    realm.heap.setProxyTarget(rp, null);
+                    realm.heap.setProxyHandler(rp, null);
+                    realm.heap.setProxyTargetFn(rp, null);
+                    rp.proxy_revoked = true;
+                    fn_v.revocable_proxy = null;
+                acc = Value.undefined_;
+                // No frame pushed, no inline call — the active frame
+                // is unchanged → decodeNext.
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+
+                // §3.8.3.6 WrappedFunction — cross-realm callable
+                // boundary. The inline call fast-path can't marshal
+                // args/return through the §3.8.3.4 filter; delegate
+                // to `callJSFunction` which routes into the boundary
+                // handler in `shadow_realm.zig`.
+                if (!fn_v.wrapped_target.isUndefined()) {
                     const args_start = @as(usize, r_callee) + 1;
-                    const args_slice = registers[args_start .. args_start + argc];
-                    const cresult = try callValue(allocator, realm, f.running_realm orelse realm, callee_v, Value.undefined_, args_slice);
-                    switch (cresult) {
-                        .value, .yielded => |v| {
-                            acc = v;
-                            // `callValue` ran the callee in its own
-                            // runFrames re-entry — no frame pushed onto
-                            // this stack, the active frame is unchanged
-                            // → decodeNext. reEnterDispatch would reload
-                            // a stale `f.ip` and re-run this call.
-                            continue :dispatch try decodeNext(code, &ip, &committed);
-                        },
+                    const result = try callJSFunction(allocator, realm, fn_v, Value.undefined_, registers[args_start .. args_start + argc]);
+                    switch (result) {
+                        .value, .yielded => |v| acc = v,
                         .thrown => |ex| {
                             f.ip = ip;
                             f.accumulator = acc;
@@ -2080,69 +2177,22 @@ pub fn runFrames(
                             continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                         },
                     }
-                }
-                // §20.2.3 %Function.prototype% [[Call]] — "the
-                // Function prototype object is itself a built-in
-                // function object that, when invoked, accepts any
-                // arguments and returns undefined." Cynic stores
-                // it as a JSObject (not a JSFunction) so the
-                // identity check is the cheapest dispatch path.
-                if (realm.intrinsics.function_prototype == po) {
-                    acc = Value.undefined_;
                     continue :dispatch try decodeNext(code, &ip, &committed);
                 }
-            }
-            const callee_fn = heap_mod.valueAsFunction(callee_v) orelse {
-                const ex = try makeTypeError(realm, "value is not callable");
-                f.ip = ip;
-                f.accumulator = acc;
-                committed = true;
-                if (!try unwindThrow(allocator, realm, frames, ex)) {
-                    return .{ .thrown = ex };
-                }
-                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
-            };
 
-            // §15.7.14 step 1 — class constructors are not
-            // callable without `new`; reject with TypeError.
-            if (callee_fn.is_class_constructor) {
-                const ex = try makeTypeError(realm, "Class constructor cannot be invoked without 'new'");
-                f.ip = ip;
-                f.accumulator = acc;
-                committed = true;
-                if (!try unwindThrow(allocator, realm, frames, ex)) {
-                    return .{ .thrown = ex };
-                }
-                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
-            }
-
-            // §28.2.2.1.1 — revocation function. Calling it
-            // clears the captured proxy's internal slots.
-            // First call returns undefined and clears the slot;
-            // subsequent calls no-op (slot is null).
-            if (callee_fn.revocable_proxy) |rp| {
-                realm.heap.setProxyTarget(rp, null);
-                realm.heap.setProxyHandler(rp, null);
-                realm.heap.setProxyTargetFn(rp, null);
-                rp.proxy_revoked = true;
-                callee_fn.revocable_proxy = null;
-                acc = Value.undefined_;
-                // No frame pushed, no inline call — the active frame
-                // is unchanged → decodeNext.
-                continue :dispatch try decodeNext(code, &ip, &committed);
-            }
-
-            // §3.8.3.6 WrappedFunction — cross-realm callable
-            // boundary. The inline call fast-path can't marshal
-            // args/return through the §3.8.3.4 filter; delegate
-            // to `callJSFunction` which routes into the boundary
-            // handler in `shadow_realm.zig`.
-            if (!callee_fn.wrapped_target.isUndefined()) {
-                const args_start = @as(usize, r_callee) + 1;
-                const result = try callJSFunction(allocator, realm, callee_fn, Value.undefined_, registers[args_start .. args_start + argc]);
-                switch (result) {
-                    .value, .yielded => |v| acc = v,
-                    .thrown => |ex| {
+                // §10.4.1 — bound functions unwrap and re-enter
+                // through `callJSFunction` (which builds a fresh
+                // frame stack with the concatenated args). Plain
+                // calls pass `this = undefined` (strict).
+                if (fn_v.bound_target != null) {
+                    // §10.2.1 step 2 — the bound wrapper's own
+                    // `is_class_constructor` is false, but the
+                    // inner target preserves the class-ctor brand.
+                    // `Subclass.bind(obj)(...)` must throw.
+                    var inner_target = fn_v;
+                    while (inner_target.bound_target) |i_t| inner_target = i_t;
+                    if (inner_target.is_class_constructor) {
+                        const ex = try makeTypeError(realm, "Class constructor cannot be invoked without 'new'");
                         f.ip = ip;
                         f.accumulator = acc;
                         committed = true;
@@ -2150,51 +2200,33 @@ pub fn runFrames(
                             return .{ .thrown = ex };
                         }
                         continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
-                    },
-                }
-                continue :dispatch try decodeNext(code, &ip, &committed);
-            }
-
-            // §10.4.1 — bound functions unwrap and re-enter
-            // through `callJSFunction` (which builds a fresh
-            // frame stack with the concatenated args). Plain
-            // calls pass `this = undefined` (strict).
-            if (callee_fn.bound_target != null) {
-                // §10.2.1 step 2 — the bound wrapper's own
-                // `is_class_constructor` is false, but the
-                // inner target preserves the class-ctor brand.
-                // `Subclass.bind(obj)(...)` must throw.
-                var inner_target = callee_fn;
-                while (inner_target.bound_target) |i_t| inner_target = i_t;
-                if (inner_target.is_class_constructor) {
-                    const ex = try makeTypeError(realm, "Class constructor cannot be invoked without 'new'");
-                    f.ip = ip;
-                    f.accumulator = acc;
-                    committed = true;
-                    if (!try unwindThrow(allocator, realm, frames, ex)) {
-                        return .{ .thrown = ex };
                     }
-                    continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    const args_start = @as(usize, r_callee) + 1;
+                    const result = try callJSFunction(allocator, realm, fn_v, Value.undefined_, registers[args_start .. args_start + argc]);
+                    switch (result) {
+                        .value, .yielded => |v| acc = v,
+                        .thrown => |ex| {
+                            f.ip = ip;
+                            f.accumulator = acc;
+                            committed = true;
+                            if (!try unwindThrow(allocator, realm, frames, ex)) {
+                                return .{ .thrown = ex };
+                            }
+                            continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                        },
+                    }
+                    // `callJSFunction` ran the bound target in its own
+                    // runFrames re-entry — no frame pushed onto this
+                    // stack, the active frame is unchanged → decodeNext.
+                    continue :dispatch try decodeNext(code, &ip, &committed);
                 }
-                const args_start = @as(usize, r_callee) + 1;
-                const result = try callJSFunction(allocator, realm, callee_fn, Value.undefined_, registers[args_start .. args_start + argc]);
-                switch (result) {
-                    .value, .yielded => |v| acc = v,
-                    .thrown => |ex| {
-                        f.ip = ip;
-                        f.accumulator = acc;
-                        committed = true;
-                        if (!try unwindThrow(allocator, realm, frames, ex)) {
-                            return .{ .thrown = ex };
-                        }
-                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
-                    },
-                }
-                // `callJSFunction` ran the bound target in its own
-                // runFrames re-entry — no frame pushed onto this
-                // stack, the active frame is unchanged → decodeNext.
-                continue :dispatch try decodeNext(code, &ip, &committed);
-            }
+
+                // Survived every exotic check — `fn_v` is a plain
+                // function. Refill the IC so the next call takes
+                // the fast path.
+                call_cell.callee = fn_v;
+                break :blk fn_v;
+            };
 
             // §27.5 / §27.6 — calling a `function*` or
             // `async function*` allocates a generator wrapper

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -7391,18 +7391,8 @@ pub fn runFrames(
         // ── Globals ─────────────────────────────────────────────────
         .lda_global => {
             const k = readU16(code, ip);
-            ip += 2;
-            if (k >= local_chunk.constants.len) return error.InvalidOpcode;
-            const key_v = local_chunk.constants[k];
-            if (!key_v.isString()) return error.InvalidOpcode;
-            const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
-            // §9.1.1.4 GetBindingValue — declarative env-
-            // record first, then object env-record. The
-            // `realm.globals.get` helper does the lookup in
-            // that order; `throw_if_hole` (emitted by the
-            // compiler when the binding is `let`/`const`/
-            // `class`) catches the TDZ case.
-            //
+            const ic_idx = readU16(code, ip + 2);
+            ip += 4;
             // §8.3 / §9.1: free globals resolve through the
             // *executing* function's global environment, which is
             // its [[Realm]]'s. With a shared heap (a ShadowRealm
@@ -7410,20 +7400,31 @@ pub fn runFrames(
             // realm, so route the lookup through the active frame's
             // `running_realm` rather than the top-level `realm`.
             const gr = f.running_realm orelse realm;
-            if (gr.globals.get(key_s.flatBytes())) |v| {
-                acc = v;
-            } else switch (try lookupGlobalAccessor(allocator, gr, key_s.flatBytes())) {
+            // IC fast path: shape compare on the global object plus
+            // a decl-revision snapshot. A hit means no new `let` /
+            // `const` / `class` has been declared since fill and
+            // the global object hasn't transitioned to a different
+            // shape — the cached object-env slot is still
+            // authoritative.
+            if (gr.globals.target) |gt| {
+                const cell = &local_chunk.inline_caches[ic_idx];
+                if (cell.shape != null and cell.shape == gt.shape and cell.proto == null and cell.proto_rev == gr.globals.decl_revision) {
+                    acc = gt.slots.items[cell.slot];
+                    continue :dispatch try decodeNext(code, &ip, &committed);
+                }
+            }
+            if (k >= local_chunk.constants.len) return error.InvalidOpcode;
+            const key_v = local_chunk.constants[k];
+            if (!key_v.isString()) return error.InvalidOpcode;
+            const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
+            switch (try slowLdaGlobal(allocator, realm, frames, f, ip, gr, key_s.flatBytes(), &local_chunk.inline_caches[ic_idx])) {
                 .value => |v| acc = v,
-                .thrown => |ex| {
-                    f.ip = ip;
-                    f.accumulator = acc;
+                .handled => {
                     committed = true;
-                    if (!try unwindThrow(allocator, realm, frames, ex)) {
-                        return .{ .thrown = ex };
-                    }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 },
-                .none => {
+                .uncaught => |ex| return .{ .thrown = ex },
+                .not_found => {
                     const ex = try makeReferenceError(gr, key_s.flatBytes());
                     f.ip = ip;
                     f.accumulator = acc;
@@ -7439,35 +7440,31 @@ pub fn runFrames(
         .lda_global_or_undef => {
             // §13.5.3 step 3 — typeof of an unresolvable
             // Reference is "undefined", not a thrown
-            // ReferenceError. The compiler emits this op
-            // for `typeof Identifier` when `Identifier`
-            // doesn't bind to any known scope slot. Fires
-            // an accessor getter installed via
-            // `Object.defineProperty(globalThis, "y", {get: …})`
-            // so `typeof y` observes the side effect per
-            // §13.5.3 step 1 (`val = GetValue(val)`).
+            // ReferenceError. Shares the IC machinery with
+            // `lda_global`; only the `.not_found` case differs.
             const k = readU16(code, ip);
-            ip += 2;
+            const ic_idx = readU16(code, ip + 2);
+            ip += 4;
+            const gr = f.running_realm orelse realm;
+            if (gr.globals.target) |gt| {
+                const cell = &local_chunk.inline_caches[ic_idx];
+                if (cell.shape != null and cell.shape == gt.shape and cell.proto == null and cell.proto_rev == gr.globals.decl_revision) {
+                    acc = gt.slots.items[cell.slot];
+                    continue :dispatch try decodeNext(code, &ip, &committed);
+                }
+            }
             if (k >= local_chunk.constants.len) return error.InvalidOpcode;
             const key_v = local_chunk.constants[k];
             if (!key_v.isString()) return error.InvalidOpcode;
             const key_s: *JSString = @ptrCast(@alignCast(key_v.asString()));
-            // Same home-realm routing as `lda_global` (see note there).
-            const gr = f.running_realm orelse realm;
-            if (gr.globals.get(key_s.flatBytes())) |v| {
-                acc = v;
-            } else switch (try lookupGlobalAccessor(allocator, gr, key_s.flatBytes())) {
+            switch (try slowLdaGlobal(allocator, realm, frames, f, ip, gr, key_s.flatBytes(), &local_chunk.inline_caches[ic_idx])) {
                 .value => |v| acc = v,
-                .thrown => |ex| {
-                    f.ip = ip;
-                    f.accumulator = acc;
+                .handled => {
                     committed = true;
-                    if (!try unwindThrow(allocator, realm, frames, ex)) {
-                        return .{ .thrown = ex };
-                    }
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 },
-                .none => acc = Value.undefined_,
+                .uncaught => |ex| return .{ .thrown = ex },
+                .not_found => acc = Value.undefined_,
             }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
@@ -10711,6 +10708,90 @@ const GetChainOutcome = union(enum) {
     handled,
     uncaught: Value,
 };
+
+const LdaGlobalSlowOutcome = union(enum) {
+    /// Resolved synchronously (object-env slot, decl-env value,
+    /// accessor returning a value, or bootstrap fallback hit).
+    value: Value,
+    /// A user function (proxy / accessor getter) ran inline and
+    /// the helper already arranged the dispatch state for a
+    /// caught throw. Caller must `reEnterDispatch` without
+    /// re-stamping `f.ip`.
+    handled,
+    /// Uncaught exception — propagate.
+    uncaught: Value,
+    /// No binding for the name. Caller decides:
+    ///   • `lda_global` → ReferenceError.
+    ///   • `lda_global_or_undef` → `undefined`.
+    not_found,
+};
+
+/// Slow path of `lda_global` / `lda_global_or_undef`. Pulled out
+/// of the dispatch loop to keep each handler tight (better i-cache
+/// over the giant switch) and to dedupe the receiver-type matrix
+/// the two opcodes share. Fills `ic_cell` on a shape-resolvable
+/// object-env hit; leaves the cell alone on decl-env / fallback /
+/// accessor paths so they keep re-walking the slow path until the
+/// shape becomes the authoritative source.
+fn slowLdaGlobal(
+    allocator: std.mem.Allocator,
+    realm: *Realm,
+    frames: *std.ArrayListUnmanaged(CallFrame),
+    f: *CallFrame,
+    ip: usize,
+    gr: *Realm,
+    key: []const u8,
+    ic_cell: *@import("../../bytecode/chunk.zig").ICCell,
+) RunError!LdaGlobalSlowOutcome {
+    // §9.1.1.4 GetBindingValue — declarative env-record FIRST.
+    // A decl-env hit MUST shadow the cached object-env slot; that's
+    // why we don't fill `ic_cell` on this path. Subsequent calls
+    // pay the small `decl_env.get` cost, which the
+    // `decl_revision` snapshot guarantees stays in sync.
+    if (gr.globals.decl_env.get(key)) |v| return .{ .value = v };
+    if (gr.globals.target) |gt| {
+        // Shape lookup — the common case for host-installed
+        // intrinsics (`Math`, `Object`, …) and top-level
+        // `function` / `var` declarations (added through
+        // `installScriptFunctionBinding` / `installScriptVarBinding`,
+        // which route through `setWithFlags` / `shadowSet` and
+        // stamp the shape).
+        if (gt.shape) |sh| {
+            if (sh.lookup(key)) |entry| {
+                if (entry.kind == .data) {
+                    ic_cell.shape = sh;
+                    ic_cell.slot = entry.slot;
+                    ic_cell.proto = null;
+                    ic_cell.proto_shape = null;
+                    ic_cell.proto_rev = gr.globals.decl_revision;
+                    return .{ .value = gt.slots.items[entry.slot] };
+                }
+            }
+        }
+        // Shape miss / dictionary mode / accessor descriptor.
+        if (gt.lookupOwn(key)) |v| return .{ .value = v };
+        switch (try lookupGlobalAccessor(allocator, gr, key)) {
+            .value => |v| return .{ .value = v },
+            .thrown => |ex| {
+                f.ip = ip;
+                if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+                return .handled;
+            },
+            .none => return .not_found,
+        }
+    }
+    // Pre-`bindToObject` bootstrap — `target` not yet wired.
+    if (gr.globals.fallback.get(key)) |v| return .{ .value = v };
+    switch (try lookupGlobalAccessor(allocator, gr, key)) {
+        .value => |v| return .{ .value = v },
+        .thrown => |ex| {
+            f.ip = ip;
+            if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .uncaught = ex };
+            return .handled;
+        },
+        .none => return .not_found,
+    }
+}
 
 /// §13.3.6 EvaluateCall + §10.1.8 OrdinaryGet — resolve the callee
 /// for the fused `call_property` opcode's slow path. Mirrors

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -9903,3 +9903,93 @@ test "fused method-call: proto chain swap invalidates the IC" {
         \\first + second;
     , "AB");
 }
+
+// `lda_global` IC — bare-identifier reads that resolve through the
+// realm's global env. `globalThis` is one shape-stable object after
+// `intrinsics.install` runs (the SES freeze pass marks it
+// non-extensible), so a per-callsite `(gt_shape, slot)` cache turns
+// every `Object` / `Array` / `Math` / `console` lookup from a
+// `decl_env.get(key)` + `gt.lookupOwn(key)` hash pair into a shape
+// compare + slot load. The slow path still consults `decl_env` first
+// — `let X = …` at script scope MUST shadow a homonym builtin —
+// which is what `GlobalBindings.decl_revision` guards: any new lex
+// binding bumps the counter, every filled cell records it, the fast
+// path compares.
+
+test "lda_global IC: intrinsic builtin read (Math)" {
+    try expectScriptIntWithBuiltins(
+        \\let acc = 0;
+        \\for (let i = 0; i < 5; i++) acc += Math.abs(-1);
+        \\acc;
+    , 5);
+}
+
+test "lda_global IC: host-installed name (print is callable across iters)" {
+    // `print` is installed by `installBuiltinsAllFeatures` so the
+    // lookup must keep resolving it as the iterations re-execute
+    // the `lda_global "print"` site.
+    try expectScriptIntWithBuiltins(
+        \\let n = 0;
+        \\for (let i = 0; i < 3; i++) {
+        \\  if (typeof print === "function") n += 1;
+        \\}
+        \\n;
+    , 3);
+}
+
+test "lda_global_or_undef IC: typeof of an unbound name is \"undefined\"" {
+    // `typeof DefinitelyNotDeclared` compiles to `lda_global_or_undef`,
+    // which must surface `undefined` instead of ReferenceError both
+    // on cold (cell empty) and warm (cell filled to a real binding
+    // for a different key) callsites.
+    try expectScriptStringWithBuiltins(
+        \\let acc = "";
+        \\for (let i = 0; i < 3; i++) acc += typeof DefinitelyNotDeclared;
+        \\acc;
+    , "undefinedundefinedundefined");
+}
+
+test "lda_global IC: --unhardened — accessor on globalThis still fires its getter" {
+    // `Object.defineProperty(globalThis, …, { get })` installs an
+    // accessor on the global object. The IC must NOT take a data-
+    // slot fast path for accessors — the getter must run on every
+    // read, observably incrementing a counter held in a closure.
+    // Only sensible under `--unhardened`: the default SES posture
+    // freezes globalThis (`extensible = false`) so the define
+    // would itself throw before testing the IC.
+    try expectScriptIntUnhardened(
+        \\let calls = 0;
+        \\Object.defineProperty(globalThis, "g", { get() { calls++; return 1; } });
+        \\let acc = 0;
+        \\for (let i = 0; i < 5; i++) acc += g;
+        \\acc * 100 + calls;
+    , 5 * 100 + 5);
+}
+
+test "lda_global IC: --unhardened — adding a new global mid-loop invalidates the cache" {
+    // The first reads of `late` resolve via `lda_global_or_undef`
+    // (typeof) and surface "undefined"; halfway through, the
+    // script assigns `globalThis.late = 7`, which mutates
+    // `gt.shape`. A cell filled with the old shape (empty for
+    // this name) MUST miss the new shape and the slow path
+    // refills. If the cell served a stale "undefined" through the
+    // shape change, the second-half typeof would also surface
+    // "undefined" — wrong.
+    try expectScriptStringUnhardened(
+        \\let acc = "";
+        \\for (let i = 0; i < 4; i++) {
+        \\  if (i === 2) globalThis.late = 7;
+        \\  acc += typeof late;
+        \\}
+        \\acc;
+    , "undefinedundefinednumbernumber");
+}
+
+test "lda_global IC: ReferenceError on truly unbound name" {
+    try expectScriptStringWithBuiltins(
+        \\let msg = "no-throw";
+        \\try { totallyMissingBinding + 1; }
+        \\catch (e) { msg = e.constructor.name; }
+        \\msg;
+    , "ReferenceError");
+}

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -9769,3 +9769,137 @@ test "SES Phase 3: iter spread on built-in iterators works under hardened" {
         \\[...Iterator.concat(new Iterable())].join(",");
     , "10,20,30");
 }
+
+// `obj.method(args)` — the fused-call-property shape. The compiler
+// emits a single dispatch (`call_property`) for the simple
+// identifier-property method-call form, in place of the
+// `ldar + lda_property + star + call_method` 4-op sequence used for
+// the harder shapes. These tests pin the observable behavior the
+// fused op must preserve across every receiver-type arm
+// `lda_property` covers: own / proto data, accessor (getter / setter),
+// proxy chain, module namespace, primitive auto-box (string, number,
+// bool, bigint), plus the `this` binding and the argument-count
+// matrix on the call dispatch side.
+
+test "fused method-call: proto-data method (the c.inc() shape)" {
+    try expectScriptIntWithBuiltins(
+        \\class Counter {
+        \\  constructor() { this.n = 0; }
+        \\  inc() { this.n += 1; return this.n; }
+        \\}
+        \\const c = new Counter();
+        \\let acc = 0;
+        \\for (let i = 0; i < 5; i++) acc = c.inc();
+        \\acc;
+    , 5);
+}
+
+test "fused method-call: own-data method shadows prototype" {
+    try expectScriptStringWithBuiltins(
+        \\const obj = {
+        \\  greet() { return "own"; },
+        \\};
+        \\Object.setPrototypeOf(obj, { greet() { return "proto"; } });
+        \\obj.greet();
+    , "own");
+}
+
+test "fused method-call: accessor returning a function fires the getter" {
+    // The getter MUST run (returning the inner function), then the
+    // returned function gets called. A fast path that read the data
+    // slot directly would skip the getter.
+    try expectScriptStringWithBuiltins(
+        \\let getter_called = 0;
+        \\const obj = {
+        \\  get fn() { getter_called++; return function () { return "ok"; }; },
+        \\};
+        \\const r = obj.fn();
+        \\r + ":" + getter_called;
+    , "ok:1");
+}
+
+test "fused method-call: getter that throws surfaces as TypeError" {
+    try expectScriptStringWithBuiltins(
+        \\const obj = {
+        \\  get bad() { throw new TypeError("nope"); },
+        \\};
+        \\let msg = "no-throw";
+        \\try { obj.bad(); } catch (e) { msg = e.message; }
+        \\msg;
+    , "nope");
+}
+
+test "fused method-call: `this` binds to the receiver, not undefined" {
+    try expectScriptStringWithBuiltins(
+        \\const obj = {
+        \\  name: "alice",
+        \\  who() { return this.name; },
+        \\};
+        \\obj.who();
+    , "alice");
+}
+
+test "fused method-call: primitive string receiver auto-boxes" {
+    try expectScriptStringWithBuiltins(
+        \\"hello".toUpperCase();
+    , "HELLO");
+}
+
+test "fused method-call: primitive number receiver auto-boxes" {
+    try expectScriptStringWithBuiltins(
+        \\(3.14).toFixed(1);
+    , "3.1");
+}
+
+test "fused method-call: argc = 0 / 1 / many" {
+    try expectScriptIntWithBuiltins(
+        \\const obj = {
+        \\  zero() { return 7; },
+        \\  one(x) { return x * 2; },
+        \\  many(a, b, c, d) { return a + b + c + d; },
+        \\};
+        \\obj.zero() + obj.one(5) + obj.many(1, 2, 3, 4);
+    , 7 + 10 + 10);
+}
+
+test "fused method-call: missing method throws TypeError, not a silent miss" {
+    try expectScriptStringWithBuiltins(
+        \\const obj = {};
+        \\let msg = "no-throw";
+        \\try { obj.missing(); } catch (e) { msg = e.constructor.name; }
+        \\msg;
+    , "TypeError");
+}
+
+test "fused method-call: monomorphic loop, second receiver same shape" {
+    // Two different Counter instances share an own shape and the
+    // same Counter.prototype — the IC must remain monomorphic and
+    // serve both with one cell.
+    try expectScriptIntWithBuiltins(
+        \\class Counter {
+        \\  constructor(start) { this.n = start; }
+        \\  inc() { this.n += 1; return this.n; }
+        \\}
+        \\const a = new Counter(0);
+        \\const b = new Counter(100);
+        \\let s = 0;
+        \\for (let i = 0; i < 3; i++) s += a.inc();
+        \\for (let i = 0; i < 3; i++) s += b.inc();
+        \\s;
+    , (1 + 2 + 3) + (101 + 102 + 103));
+}
+
+test "fused method-call: proto chain swap invalidates the IC" {
+    // The proto-load IC stores the cached proto pointer + its shape
+    // + `realm.proto_revision_counter`. `Object.setPrototypeOf`
+    // bumps the counter — so the next call must take the slow path
+    // and resolve through the new prototype.
+    try expectScriptStringWithBuiltins(
+        \\const obj = {};
+        \\Object.setPrototypeOf(obj, { greet() { return "A"; } });
+        \\const first = obj.greet();
+        \\Object.setPrototypeOf(obj, { greet() { return "B"; } });
+        \\const second = obj.greet();
+        \\first + second;
+    , "AB");
+}

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -9993,3 +9993,76 @@ test "lda_global IC: ReferenceError on truly unbound name" {
         \\msg;
     , "ReferenceError");
 }
+
+// Free-function `call` IC — the bare `f(args)` site (not
+// `obj.f(args)`). Caches the last plain (non-bound, non-proxy,
+// non-revoked) callee pointer so subsequent calls skip the proxy /
+// revocable / bound / `valueAsFunction` exotic dispatch chain and
+// go straight to `callJSFunction`. Mirrors `call_method`'s
+// per-call-site cache but targets the closure-captured-callee
+// pattern (parsers, traversals, FP-style helpers).
+
+test "free-function call IC: closure-captured callee in a tight loop" {
+    try expectScriptIntWithBuiltins(
+        \\function add(x) { return x + 1; }
+        \\let acc = 0;
+        \\for (let i = 0; i < 5; i++) acc = add(acc);
+        \\acc;
+    , 5);
+}
+
+test "free-function call IC: callee swap mid-loop invalidates the cell" {
+    // First half of the loop uses `f = a`; second half rebinds `f`
+    // to a different function. The cell must miss on rebind and
+    // refill — otherwise the second-half iterations would keep
+    // calling `a` (the cached callee), producing the wrong total.
+    try expectScriptIntWithBuiltins(
+        \\function a() { return 1; }
+        \\function b() { return 10; }
+        \\let f = a;
+        \\let acc = 0;
+        \\for (let i = 0; i < 4; i++) {
+        \\  if (i === 2) f = b;
+        \\  acc += f();
+        \\}
+        \\acc;
+    , 1 + 1 + 10 + 10);
+}
+
+test "free-function call IC: bound function still binds its captured this" {
+    // Bound functions are an exotic-callee case the IC must NOT
+    // serve as a plain JSFunction — the bound `this` would be
+    // dropped. The cell shouldn't fill for bound callees; the
+    // slow path's bound-target arm carries the binding.
+    try expectScriptIntWithBuiltins(
+        \\function take() { return this.n; }
+        \\const obj = { n: 42 };
+        \\const f = take.bind(obj);
+        \\let acc = 0;
+        \\for (let i = 0; i < 3; i++) acc += f();
+        \\acc;
+    , 42 * 3);
+}
+
+test "free-function call IC: calling a non-function throws TypeError" {
+    try expectScriptStringWithBuiltins(
+        \\const f = 5;
+        \\let msg = "no-throw";
+        \\try { f(); } catch (e) { msg = e.constructor.name; }
+        \\msg;
+    , "TypeError");
+}
+
+test "free-function call IC: a callable proxy still routes through its apply trap" {
+    // The IC must NOT serve a cached callee for a proxy-callable
+    // value — the proxy's `apply` trap must run on every call.
+    try expectScriptStringWithBuiltins(
+        \\let trap_calls = 0;
+        \\const f = new Proxy(function () { return "raw"; }, {
+        \\  apply(target, thisArg, args) { trap_calls++; return "trapped"; },
+        \\});
+        \\let last = "";
+        \\for (let i = 0; i < 3; i++) last = f();
+        \\last + ":" + trap_calls;
+    , "trapped:3");
+}

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -304,6 +304,18 @@ pub const GlobalBindings = struct {
     /// constructed `GlobalBindings` exists briefly before `init`
     /// wires it; every store path that matters runs after.
     heap: ?*Heap = null,
+    /// Bump-on-add counter for the declarative env. The `lda_global`
+    /// IC records this at fill time so the fast path can confirm
+    /// no new `let` / `const` / `class` has been declared at script
+    /// scope under a name that would now shadow the cached
+    /// object-env hit. Only `installScriptLexBinding` bumps it (and
+    /// only on a fresh `!found_existing` add) — reassigning a
+    /// pre-existing decl via `putDecl` doesn't change which env a
+    /// lookup resolves through, so an already-filled cell stays
+    /// authoritative. `decl_env`-resolved names never fill a cell
+    /// (the fast path serves the object-env slot), so a cell hit
+    /// implies an object-env hit at fill time.
+    decl_revision: u64 = 0,
 
     fn map(self: *GlobalBindings) *std.StringArrayHashMapUnmanaged(Value) {
         if (self.target) |t| return &t.properties;
@@ -594,6 +606,10 @@ pub const GlobalBindings = struct {
         const gop = try self.decl_env.getOrPut(allocator, key);
         if (!gop.found_existing) {
             gop.value_ptr.* = Value.hole_;
+            // Invalidate every `lda_global` IC cell in the realm
+            // — a newly-declared lex binding outranks the cached
+            // object-env slot for the same name.
+            self.decl_revision +%= 1;
         }
         try self.decl_consts.put(allocator, key, is_const);
     }
@@ -1916,4 +1932,27 @@ test "FramePool: zero-length acquire round-trips" {
     const empty = try pool.acquire(testing.allocator, 0);
     try testing.expectEqual(@as(usize, 0), empty.len);
     pool.release(testing.allocator, empty);
+}
+
+test "GlobalBindings.decl_revision: bumps once per fresh installScriptLexBinding" {
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    const allocator = testing.allocator;
+
+    const r0 = realm.globals.decl_revision;
+    try realm.globals.installScriptLexBinding(allocator, "x", false);
+    try testing.expect(realm.globals.decl_revision == r0 + 1);
+
+    // Re-installing the same name is idempotent — no bump.
+    try realm.globals.installScriptLexBinding(allocator, "x", false);
+    try testing.expect(realm.globals.decl_revision == r0 + 1);
+
+    // A second fresh name bumps again.
+    try realm.globals.installScriptLexBinding(allocator, "y", true);
+    try testing.expect(realm.globals.decl_revision == r0 + 2);
+
+    // `putDecl` updates an existing entry's VALUE — no shadow-
+    // resolution change, no bump.
+    try realm.globals.putDecl(allocator, "x", Value.fromInt32(42));
+    try testing.expect(realm.globals.decl_revision == r0 + 2);
 }

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -48,42 +48,58 @@ pub const FeatureSet = features.FeatureSet;
 /// call. The pool keeps freed buffers in a per-size bin so a hot
 /// method loop pops the same buffer back out every iteration.
 ///
-/// Size key is `register_count` (u32 to cover both u8 and the
-/// `argc` path). Bin entries are owned `[]Value` slices freed
-/// individually at `realm.deinit`.
+/// Bins are direct-indexed by `register_count` (the array is grown
+/// lazily on first release of each size). That replaces the earlier
+/// `AutoHashMap(u32, …)` keyed on the count, whose `Wyhash(u32)` on
+/// every acquire + release showed up at ~6 % of `method_call.js`
+/// samples — a hot method loop hashed the same tiny integer twice
+/// per call. Direct indexing collapses that to one bounds check +
+/// one load. Empty bins are 16-byte `ArrayListUnmanaged` headers, so
+/// the memory overhead is bounded by the largest function's register
+/// count (~tens of KB even at pathological extremes).
+///
+/// Bin entries are owned `[]Value` slices freed individually at
+/// `realm.deinit`.
 pub const FramePool = struct {
-    bins: std.AutoHashMapUnmanaged(u32, std.ArrayListUnmanaged([]Value)) = .empty,
+    bins: std.ArrayListUnmanaged(std.ArrayListUnmanaged([]Value)) = .empty,
 
     /// Pop a register file of exactly `n` from the pool, or
     /// allocate a fresh one on miss. Caller is responsible for
     /// memset'ing to `undefined` before use — buffer contents
     /// are stale from the previous frame.
     pub fn acquire(self: *FramePool, allocator: std.mem.Allocator, n: usize) ![]Value {
-        if (self.bins.getPtr(@intCast(n))) |list| {
-            if (list.items.len > 0) return list.pop().?;
+        if (n < self.bins.items.len) {
+            const bin = &self.bins.items[n];
+            if (bin.items.len > 0) return bin.pop().?;
         }
         return try allocator.alloc(Value, n);
     }
 
     /// Return a register file to its size's bin. On allocation
-    /// failure (the bins map can't grow), fall back to freeing
-    /// the slice directly — pool growth is best-effort.
+    /// failure (the bins vector can't grow, or its inner list
+    /// can't append), fall back to freeing the slice directly —
+    /// pool growth is best-effort.
     pub fn release(self: *FramePool, allocator: std.mem.Allocator, regs: []Value) void {
-        const gop = self.bins.getOrPut(allocator, @intCast(regs.len)) catch {
-            allocator.free(regs);
-            return;
-        };
-        if (!gop.found_existing) gop.value_ptr.* = .empty;
-        gop.value_ptr.append(allocator, regs) catch {
+        const n = regs.len;
+        if (n >= self.bins.items.len) {
+            const new_len = n + 1;
+            self.bins.ensureTotalCapacity(allocator, new_len) catch {
+                allocator.free(regs);
+                return;
+            };
+            while (self.bins.items.len < new_len) {
+                self.bins.appendAssumeCapacity(.empty);
+            }
+        }
+        self.bins.items[n].append(allocator, regs) catch {
             allocator.free(regs);
         };
     }
 
     pub fn deinit(self: *FramePool, allocator: std.mem.Allocator) void {
-        var it = self.bins.iterator();
-        while (it.next()) |e| {
-            for (e.value_ptr.items) |buf| allocator.free(buf);
-            e.value_ptr.deinit(allocator);
+        for (self.bins.items) |*bin| {
+            for (bin.items) |buf| allocator.free(buf);
+            bin.deinit(allocator);
         }
         self.bins.deinit(allocator);
     }
@@ -1806,4 +1822,98 @@ test "Realm: deinit frees heap-allocated strings" {
     var realm = Realm.init(testing.allocator);
     _ = try realm.heap.allocateString("leakable");
     realm.deinit();
+}
+
+// FramePool — sized free-list of `[]Value` register files. The pool
+// fires on every JS-function call (acquire) and return (release), so
+// these tests pin the wire-level contract the interpreter relies on:
+//   * acquire(n) on a cold bin allocates a length-n slice;
+//   * release(s) followed by acquire(s.len) returns the same buffer
+//     (the LIFO that makes a hot method loop reuse one slice);
+//   * different sizes live in different bins;
+//   * deinit frees every buffer the pool is still holding.
+
+test "FramePool: acquire on cold pool allocates a length-n slice" {
+    var pool: FramePool = .{};
+    defer pool.deinit(testing.allocator);
+
+    const regs = try pool.acquire(testing.allocator, 4);
+    defer testing.allocator.free(regs);
+
+    try testing.expectEqual(@as(usize, 4), regs.len);
+}
+
+test "FramePool: release then acquire reuses the same buffer (LIFO)" {
+    var pool: FramePool = .{};
+    defer pool.deinit(testing.allocator);
+
+    const first = try pool.acquire(testing.allocator, 6);
+    const first_ptr = first.ptr;
+    pool.release(testing.allocator, first);
+
+    const reused = try pool.acquire(testing.allocator, 6);
+    defer testing.allocator.free(reused);
+    try testing.expectEqual(first_ptr, reused.ptr);
+    try testing.expectEqual(@as(usize, 6), reused.len);
+}
+
+test "FramePool: different sizes do not cross-pollinate bins" {
+    var pool: FramePool = .{};
+    defer pool.deinit(testing.allocator);
+
+    const a = try pool.acquire(testing.allocator, 3);
+    pool.release(testing.allocator, a);
+
+    // A request for a different size must not return the 3-slot buffer.
+    const b = try pool.acquire(testing.allocator, 5);
+    defer testing.allocator.free(b);
+    try testing.expectEqual(@as(usize, 5), b.len);
+    try testing.expect(b.ptr != a.ptr);
+
+    // The 3-slot buffer is still pooled — re-acquiring at 3 returns it.
+    const a2 = try pool.acquire(testing.allocator, 3);
+    defer testing.allocator.free(a2);
+    try testing.expectEqual(a.ptr, a2.ptr);
+}
+
+test "FramePool: LIFO ordering within a bin" {
+    var pool: FramePool = .{};
+    defer pool.deinit(testing.allocator);
+
+    const a = try pool.acquire(testing.allocator, 8);
+    const b = try pool.acquire(testing.allocator, 8);
+    // Distinct allocations even though same size.
+    try testing.expect(a.ptr != b.ptr);
+
+    pool.release(testing.allocator, a);
+    pool.release(testing.allocator, b);
+
+    // Last in, first out — b returned before a.
+    const got1 = try pool.acquire(testing.allocator, 8);
+    const got2 = try pool.acquire(testing.allocator, 8);
+    defer testing.allocator.free(got1);
+    defer testing.allocator.free(got2);
+    try testing.expectEqual(b.ptr, got1.ptr);
+    try testing.expectEqual(a.ptr, got2.ptr);
+}
+
+test "FramePool: deinit frees buffers still parked in any bin" {
+    // Leak detection runs through `testing.allocator`. If `deinit`
+    // misses any bin's parked slices, this test fails on shutdown.
+    var pool: FramePool = .{};
+    const sizes = [_]usize{ 1, 4, 4, 7, 32, 32, 64 };
+    for (sizes) |n| {
+        const buf = try pool.acquire(testing.allocator, n);
+        pool.release(testing.allocator, buf);
+    }
+    pool.deinit(testing.allocator);
+}
+
+test "FramePool: zero-length acquire round-trips" {
+    var pool: FramePool = .{};
+    defer pool.deinit(testing.allocator);
+
+    const empty = try pool.acquire(testing.allocator, 0);
+    try testing.expectEqual(@as(usize, 0), empty.len);
+    pool.release(testing.allocator, empty);
 }


### PR DESCRIPTION
## Summary

Five commits clearing the Tier 1 + start of Tier 2 IC frontier per [`docs/inline-caches.md`](docs/inline-caches.md). Test262 stable at **45166 / 4642 / 90.68 %** across all five; bench shows wins on every fixture vs the pre-session baseline.

```
6621d3e  bytecode: inline-cache the free-function `call` opcode
50a59eb  docs(inline-caches): record three landed ICs and the slow-path lesson
e2c5b59  bytecode: inline-cache lda_global / lda_global_or_undef
fdf3940  bytecode: fuse obj.method(args) into a single call_property op
a7ff87f  runtime: direct-index FramePool bins to drop Wyhash from JS calls
```

### Per-commit rationale

| Commit | What | Why |
|---|---|---|
| `a7ff87f` | `FramePool.bins` switched from `AutoHashMap(u32, …)` to direct-indexed `ArrayListUnmanaged` | Every JS call hashed the same `register_count: u32` twice — `Wyhash` was 6.3 % of the `method_call.js` profile, all of it in `FramePool.{acquire,release}`. Direct indexing collapses to bounds-check + load. |
| `fdf3940` | Fused `call_property` opcode for `obj.method(args)` | Replaces a 4-op `ldar + lda_property + star + call_method` sequence (15 bytes operand, 4 dispatches) with one 8-byte-operand dispatch. Hermes / Ignition both ship this fusion. |
| `e2c5b59` | `lda_global` / `lda_global_or_undef` IC | Caches `(globalThis_shape, slot, decl_revision)` per call site. Every `Math.abs` / `Object.keys` / `print(v)` becomes shape compare + slot load instead of a `decl_env.get` + `globalThis.lookupOwn` hash pair. |
| `50a59eb` | `docs/inline-caches.md` update | Moves the two landed ICs to *Shipped*, adds two architecture notes (ICCell dual-use across three opcodes; the slow-path-factoring lesson that turned regressions into wins on the global IC). |
| `6621d3e` | Free-function `call` opcode IC | Mirror `call_method`'s `CallICCell` pattern on bare `f(x)`. Cell hit skips proxy / revocable / bound / wrapped / class-ctor / `valueAsFunction` dispatch. |

### Cumulative bench delta (cynic-bench --runs=30, p50 / min, vs `c2bdd77`)

| bench | baseline | final | Δ p50 |
|---|---:|---:|---:|
| prop_access | 13.55 | 12.25 | **-9.6 %** |
| prop_write | 15.06 | 13.89 | **-7.8 %** |
| array_iter | 23.83 | 21.83 | **-8.4 %** |
| string_concat | 51.44 | 44.86 | **-12.8 %** |
| object_alloc | 52.15 | 49.14 | **-5.8 %** |
| method_call | 19.80 | 18.67 | **-5.7 %** |
| arith_loop | 38.42 | 31.72 | **-17.4 %** |
| class_instantiate | 145.00 | 121.16 | **-16.4 %** |
| tail_recursion | 99.66 | 82.14 | **-17.6 %** |
| json_stringify | 46.28 | 40.31 | **-12.9 %** |
| promise_chain | 18.55 | 12.97 | **-30.1 %** |

Every fixture improved. No regressions.

## Test plan

- [x] `zig build test-fast` — green (full suite + 11 new `fused method-call: …` tests + 7 new `lda_global IC: …` tests + 5 new `free-function call IC: …` tests + 6 new `FramePool: …` tests + 1 `decl_revision` Zig unit test)
- [x] `zig build test262 -- --quiet` — **45166 / 4642 / 90.68 %**, byte-for-byte match with the recorded baseline through every commit
- [x] `zig build test262 -- --filter=language/expressions --top-rss=10` — top per-fixture RSS deltas all 11–19 MB (healthy band)
- [x] `cynic-bench --runs=30` — wins on every fixture, no regressions outside noise band
- [x] `samply` confirmed `CallProperty` fires at the hot site on `method_call.js` (no `CallMethod` / `LdaProperty` for that call); Wyhash dropped out of the symbolicated set entirely after `a7ff87f`

## Notes for review

- All commits keep the existing test262 contract byte-for-byte stable. Any regression at any commit was caught by the per-commit full sweep before push.
- `fdf3940`'s slow path is a faithful mirror of `lda_property`'s 11-arm receiver-type matrix, factored into `slowLookupForCallProperty` and documented as paired code at both sites.
- `e2c5b59`'s slow-path-helper factoring was discovered necessary mid-implementation: an earlier inlined-handler version regressed unrelated micros (`class_instantiate` +12 % despite zero `lda_global` in its hot loop) due to i-cache pressure on the giant dispatch switch. Pulling the slow path into a function and keeping each handler at ~25 lines turned regressions into 5–13 % wins. Documented as a durable lesson in `docs/inline-caches.md`.
- `e2c5b59` repurposes `ICCell.proto_rev` for `lda_global` to snapshot `GlobalBindings.decl_revision` — the new counter that's bumped exactly once per fresh `installScriptLexBinding`. `putDecl` reassignments don't bump (they don't change which env a free-identifier lookup resolves through).