### PR TITLE
Add SECURITY.md with disclosure policy and scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,11 @@ Contributors — human or AI agent — should read
 prior-art surveys, spec-faithful naming) and pointers into the
 engineering handbook under [`docs/handbook/`](docs/handbook/).
 
+## Security
+
+Security policy, in-scope / out-of-scope, and disclosure channel:
+see [`SECURITY.md`](SECURITY.md).
+
 ## License
 
 Cynic is [MIT-licensed](LICENSE). Bundled third-party data under

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,116 @@
+# Security
+
+Cynic is intended to run untrusted JavaScript inside a host process —
+edge runtimes, server JS, the WASM playground. A bug that aborts the
+host, reads memory it shouldn't, or breaks out of the SES posture is a
+real security problem, pre-alpha or not. Report them; they get
+acknowledged.
+
+## Supported versions
+
+`main` at HEAD only. No release branches, no backports, no tagged
+releases. `build.zig.zon` pins `version = "0.0.0"` on purpose.
+
+| Version       | Supported |
+|---------------|-----------|
+| `main`        | yes       |
+| anything else | no        |
+
+## Reporting
+
+[Open a private advisory on this repository.][ghsa] GitHub routes the
+report to the maintainers without making it public.
+
+Useful to include:
+
+- a minimal reproducer — a `cynic eval '...'` one-liner or a short
+  `cynic run` script;
+- the build mode (`Debug` / `ReleaseSafe` / `ReleaseFast`);
+- the CLI flags it ran under — `--allow=eval`, `--unhardened`,
+  any `--enable=…`;
+- expected vs. observed behaviour.
+
+[ghsa]: https://github.com/chicoxyzzy/cynic/security/advisories/new
+
+## What we commit to
+
+Acknowledgement within 7 days of the report landing in GHSA.
+
+That is the entire SLA. Cynic is a part-time project; fix timelines
+depend on the bug, the day, and whether anyone else is awake. No
+promises beyond "we read it and we'll tell you we read it."
+
+## In scope
+
+- **Host abort from user JavaScript.** `panic`, `unreachable`, an
+  unchecked numeric cast, or OOM that crashes the process instead of
+  throwing a JS exception.
+- **Memory-safety violations reachable from user code.**
+  Out-of-bounds read or write, use-after-free, type confusion through
+  the NaN-boxed value representation.
+- **Sandbox escape.** Arbitrary host-code execution from user JS.
+- **Eval-gate bypass.** Any path that compiles or executes
+  user-supplied source while `--allow=eval` is off.
+- **SES-hardening bypass on a hardened realm.** Mutating a frozen
+  primordial, defeating the override-mistake fix, or reaching state
+  that ought to be sealed.
+- **Cross-realm authority escape.** A `ShadowRealm` or multi-realm
+  boundary that leaks intrinsics, scope-chain access, or `Function`
+  constructors into the wrong realm.
+- **Parser, lexer, or Perlex DoS on small input.** Catastrophic
+  backtracking, super-linear time or space on adversarial source.
+- **`Atomics` / `SharedArrayBuffer` races** that cross into undefined
+  behaviour or memory-safety violations. Torn reads producing
+  non-spec *values* without UB are conformance bugs, not security
+  bugs.
+
+## Out of scope
+
+- The 15 documented Annex B regex carve-outs — see "Regex" in
+  [`AGENTS.md`](AGENTS.md).
+- Divergences from sloppy-mode behaviour. Cynic is strict-only by
+  design — file these against test262, not security.
+- Pre-Stage-4 proposal behaviour gated behind `--enable=`. The flag
+  exists to opt into instability.
+- Spec-conformance bugs without an exploitation path. Add a failing
+  test262 fixture or a Cynic unit test instead.
+- Anything that requires `--unhardened`. The flag is the explicit
+  opt-out from SES; mutable primordials are the trade.
+- Anything that requires `--allow=eval` and reduces to "with eval on,
+  user code can monkey-patch things." Eval is the capability.
+- Issues in `vendor/` (test262, UCD). Report those upstream.
+- Performance or memory-use regressions that don't cross into DoS
+  territory.
+
+## Disclosure
+
+Coordinated. Default embargo is 90 days from acknowledgement,
+adjustable in either direction if a fix lands sooner or the
+investigation needs more time. Advisories get published through GHSA
+once a fix ships or the embargo expires.
+
+## Safe harbour
+
+Good-faith research on a local build of Cynic — fuzzing, manual
+review, building a reproducer — is welcome. The maintainers will not
+pursue legal action against research that stays within the scope
+above and reports findings through the GHSA workflow.
+
+## Current posture
+
+What the engine does today, not a claim that it does it perfectly:
+
+- **SES-hardened by default.** Every intrinsic is frozen at realm
+  boot; `harden()` ships as a native global; the override-mistake fix
+  is in place. `--unhardened` opts the whole posture out atomically.
+  See [`docs/ses-alignment.md`](docs/ses-alignment.md).
+- **Dynamic code generation off by default.** `eval`,
+  `new Function(string)`, `new GeneratorFunction(string)`, and
+  `new AsyncFunction(string)` throw `EvalError` unless `--allow=eval`
+  is passed. Matches Node's
+  `--disallow-code-generation-from-strings`.
+- **CI safety nets.** CodeQL static analysis on every push,
+  dependabot on the dependency surface, `test262` and
+  `test262-gc-stress` runtime conformance gating, and ReleaseSafe
+  builds in the unit-test and conformance jobs so GC verifiers and
+  free-poison are armed in CI.


### PR DESCRIPTION
## Summary

- New `SECURITY.md` at repo root. GHSA-only reporting channel (no email fallback), 7-day acknowledgement SLA (no fix-time promise), explicit in-scope / out-of-scope lists, 90-day default embargo, safe-harbour clause, and a "current posture" recap (SES-hardened-by-default, eval gate, CodeQL + dependabot + test262-gc-stress in CI).
- One-line `## Security` pointer added to `README.md` above the License section.
- Out of scope for this PR (separate work referenced in the recent security audit): the `@intFromFloat` continuation sweep, a GC-stress CI job, and a parser/JSON/Perlex fuzzer harness.

## Manual follow-up after merge

- **Settings → Code security → Private vulnerability reporting → Enable.** Without this toggle, the "Report a vulnerability" button does not appear on the Security tab even with `SECURITY.md` in place. The GHSA new-advisory link in the doc still works either way.

## Test plan

- [ ] Render `SECURITY.md` on the GitHub PR view; re-read for voice drift against `AGENTS.md` "Website voice" rules.
- [ ] After enabling private vulnerability reporting, click the GHSA link in the rendered file and confirm it resolves to the new-advisory form for this repo.
- [ ] Confirm the Security tab on the repo now shows "Security policy" populated.
- [ ] CI green on the existing gating jobs (no code change, but `fmt-check` and `actionlint` should pass cleanly).