### PR TITLE
Saturate two more @intFromFloat host-aborts (array-like iterator, ShadowRealm arity)

### DIFF
--- a/docs/test262-upstream-gaps.md
+++ b/docs/test262-upstream-gaps.md
@@ -722,3 +722,67 @@ the corpus under the relevant section's directory before adding.
   string with an astral code point on `""` and asserting the surrogate
   halves via `charCodeAt` would catch any engine whose internal
   encoding leaks through `split("")`.
+
+### Array-like iterator `next()` aborted the host on an out-of-range `length`
+
+- **Fixed in:** `3cf3386`
+- **Spec:** §23.1.5.2.1 %ArrayIteratorPrototype%.next step 6 —
+  `len = ? LengthOfArrayLike(O)` = `F(ToLength(? Get(O, "length")))`
+  (§7.1.20 ToLength clamps NaN / -∞ / negatives to 0 and caps at
+  2⁵³ - 1).
+- **Reproducer:**
+  ```js
+  // Array.prototype.values over a non-array array-like reads `length`
+  // directly. A user-controlled `length` that exceeds i64 range — or
+  // is NaN / ±Infinity — must coerce via ToLength, not crash.
+  Array.prototype.values.call({ length: Infinity, 0: "a" }).next(); // → { value: "a", done: false }
+  Array.prototype.values.call({ length: 1e30, 0: "a" }).next();     // → { value: "a", done: false }
+  Array.prototype.values.call({ length: NaN, 0: "a" }).next();      // → { value: undefined, done: true }
+  ```
+- **Before fix:** the array-like iterator step cast a `Double` `length`
+  with a raw `@intFromFloat`, which panics (SIGABRT, uncatchable by JS
+  `try`/`catch`) for any finite magnitude past i64 range, NaN, or
+  ±Infinity — a trivial host-abort DoS reachable from
+  `[].values.call(arrayLike)` / `Array.prototype[Symbol.iterator]`.
+- **After fix:** the step routes the `length` Get through the shared
+  §7.1.20 `ToLength` helper, so the three reproducers return their spec
+  completions and never abort.
+- **Suggested fixture shape:** positive runtime fixtures under
+  `built-ins/Array/prototype/Symbol.iterator/` — one each for
+  `{ length: Infinity }`, a large finite `{ length: 1e30 }`, and
+  `{ length: NaN }` on a non-array array-like, asserting the first
+  `next()` result. The corpus exercises the iterator on real Arrays and
+  TypedArrays, but not a plain array-like whose `length` is an
+  out-of-range Number coerced via `LengthOfArrayLike` → `ToLength`.
+
+### ShadowRealm callable-boundary `length` copy aborted on an out-of-range arity
+
+- **Fixed in:** `3cf3386`
+- **Spec:** §3.8.3.5.1 (ShadowRealm proposal) CopyNameAndLength
+  step 4.b — `targetLen = max(0, trunc(L))`, then set the wrapped
+  function's `length` to that integer.
+- **Reproducer:**
+  ```js
+  // requires --enable=ShadowRealm
+  const sr = new ShadowRealm();
+  const f = sr.evaluate(
+    'Object.defineProperty(function g() {}, "length", { value: 1e30 });'
+  );
+  f.length; // → 1e30 (no host abort)
+  ```
+- **Before fix:** CopyNameAndLength gated the `length` box on a
+  round-trip equality `clamped == @floatFromInt(@intFromFloat(clamped))`,
+  but the inner `@intFromFloat` ran unconditionally — so wrapping a
+  callable whose `length` exceeds i64 range aborted the host before the
+  comparison could short-circuit. NaN / -∞ were already handled; only the
+  large-finite arity tripped it.
+- **After fix:** the cast is gated by the i32 upper-bound check first
+  (`clamped <= 2147483647.0` boxes Int32, else Double); the cast only
+  runs once `clamped` is known to fit, so a `1e30` arity round-trips as a
+  Double.
+- **Suggested fixture shape:** positive runtime fixture under
+  `built-ins/ShadowRealm/prototype/evaluate/` (feature: `ShadowRealm`)
+  wrapping a callable whose `length` is `Object.defineProperty`'d to a
+  large finite value, asserting the wrapped function's `length` matches.
+  Existing fixtures cover the +∞ and 0/NaN cases; none drives an arity
+  past the engine's native integer width.

--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -564,12 +564,20 @@ fn arrayLikeIterStep(realm: *Realm, this_value: Value) StepOutcome {
             }
         } else {
             // §23.1.5.2.1 step 6 — \`length = LengthOfArrayLike(O)\`,
-            // which routes through \`[[Get]]\` and therefore accessors.
+            // which is \`F(ToLength(? Get(O, "length")))\`. ToLength
+            // (§7.1.20) clamps NaN / ±∞ / negatives to 0 and caps the
+            // result at 2^53 - 1, and a raw \`@intFromFloat(len_v)\`
+            // on a user-controlled \`{length: Infinity}\` /
+            // \`{length: 1e30}\` / \`{length: NaN}\` would panic the
+            // host instead.
             const len_v = intrinsics.getPropertyChain(realm, obj, "length") catch {
                 state.done = true;
                 return .propagated;
             };
-            if (len_v.isInt32()) length = len_v.asInt32() else if (len_v.isDouble()) length = @intFromFloat(len_v.asDouble());
+            length = intrinsics.toLengthValue(realm, len_v) catch {
+                state.done = true;
+                return .propagated;
+            };
             if (idx < length) {
                 var ibuf: [16]u8 = undefined;
                 const islice = std.fmt.bufPrint(&ibuf, "{d}", .{idx}) catch unreachable;

--- a/src/runtime/builtins/shadow_realm.zig
+++ b/src/runtime/builtins/shadow_realm.zig
@@ -509,9 +509,17 @@ fn copyNameAndLength(realm: *Realm, wrapped: *JSFunction, target_v: Value) Nativ
         } else if (std.math.isInf(d)) {
             length_value = if (d > 0) Value.fromDouble(std.math.inf(f64)) else Value.fromInt32(0);
         } else {
+            // §3.8.3.5.1 step 4.b — `length = max(trunc(n), 0)`.
+            // Boxing as Int32 when the value fits and Double when it
+            // doesn't keeps `Number.isInteger(wrapped.length)` true
+            // for the common spec-mandated small cases. The upper-
+            // bound check has to gate the `@intFromFloat` cast:
+            // wrapping a callable whose `length` is `1e30` (or any
+            // |x| > i64::MAX) would otherwise abort the host before
+            // the comparison short-circuited.
             const ti: f64 = @trunc(d);
             const clamped: f64 = if (ti > 0) ti else 0;
-            if (clamped == @as(f64, @floatFromInt(@as(i64, @intFromFloat(clamped)))) and clamped < 2147483647.0) {
+            if (clamped <= 2147483647.0) {
                 length_value = Value.fromInt32(@intFromFloat(clamped));
             } else {
                 length_value = Value.fromDouble(clamped);

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -7310,6 +7310,35 @@ test "huge numeric args on String/Array/TypedArray builtins don't panic (#23)" {
     , 10);
 }
 
+test "huge length on array-like iter and ShadowRealm wrap don't panic" {
+    // §23.1.5.2.1 step 6 LengthOfArrayLike and §3.8.3.5.1 step 4.b
+    // WrappedFunction-length each consume a Number whose magnitude
+    // the caller can drive. A raw `@intFromFloat` on |x| > i64::MAX,
+    // NaN, or ±Infinity would SIGABRT the host process, uncatchable
+    // by JS try/catch. The first now routes through `ToLength`
+    // (NaN / -∞ / negative → 0; +∞ and large finite → 2^53 - 1);
+    // the second boxes the spec-derived `length` as Int32 only when
+    // it fits in i32, otherwise as a Double — without round-tripping
+    // through i64.
+    try expectScriptIntWithBuiltins(
+        \\var ok = 0;
+        \\if (Array.prototype.values.call({length: Infinity, 0: "a"}).next().value === "a") ok++;
+        \\if (Array.prototype.values.call({length: NaN, 0: "a"}).next().done === true) ok++;
+        \\if (Array.prototype.values.call({length: -Infinity, 0: "a"}).next().done === true) ok++;
+        \\if (Array.prototype.values.call({length: 1e30, 0: "a"}).next().value === "a") ok++;
+        \\const sr = new ShadowRealm();
+        \\const f1 = sr.evaluate('Object.defineProperty(function f1() {}, "length", {value: 1e30});');
+        \\if (f1.length === 1e30) ok++;
+        \\const f2 = sr.evaluate('Object.defineProperty(function f2() {}, "length", {value: NaN});');
+        \\if (f2.length === 0) ok++;
+        \\const f3 = sr.evaluate('Object.defineProperty(function f3() {}, "length", {value: -Infinity});');
+        \\if (f3.length === 0) ok++;
+        \\const f4 = sr.evaluate('Object.defineProperty(function f4() {}, "length", {value: Infinity});');
+        \\if (f4.length === Infinity) ok++;
+        \\ok;
+    , 8);
+}
+
 test "later: Array [[Construct]] derives result proto from newTarget's realm" {
     // §22.1.1 Array(...) + §10.1.14 — `Reflect.construct(Array, args,
     // C)` where `C` is a cross-realm function with a non-object


### PR DESCRIPTION
## Summary

Continuation of the `@intFromFloat` host-abort sweep started in cd1d038. An audit of all surviving `@intFromFloat` sites in `builtins/` and `lantern/` surfaced two more uncatchable SIGABRTs reachable from plain user JS:

- **`built-ins/Array/prototype/Symbol.iterator` (collections.zig)** — `Array.prototype.values.call({length: Infinity}).next()` aborts the host. The array-like iterator step cast a `Double` `length` with a raw `@intFromFloat`, which panics for any finite magnitude past i64 range, NaN, or ±Infinity. Now coerces via the shared §7.1.20 `ToLength` helper.
- **`ShadowRealm` callable boundary (shadow_realm.zig)** — wrapping a callable whose `length` is `Object.defineProperty`'d to a large finite value (e.g. `1e30`) aborts. CopyNameAndLength ran the inner `@intFromFloat` unconditionally before the round-trip equality check could short-circuit. Now gated on the i32 upper bound first, so an out-of-range arity round-trips as a Double.

Both are uncatchable by JS `try`/`catch` — the same trivial-DoS class as cd1d038.

The remaining ~120 `@intFromFloat` sites were triaged and confirmed already guarded (explicit range checks, NaN/Infinity handling, or unreachable-from-user-JS).

## Test plan

- Regression test in `src/runtime/lantern/tests.zig` covering Infinity / NaN / -Infinity / 1e30 on both paths (red pre-fix, green post-fix).
- `zig build test-fast` — green.
- Full `zig build test262` sweep — 45166 / 4642 / 90.68 %, exact match to the published baseline (no regression; the fixed inputs aren't in the corpus, hence the upstream-gap entries).
- Touched buckets re-verified: `built-ins/Array/prototype/Symbol.iterator` 100 %, `feature:ShadowRealm` unchanged.
- No RSS abort under `--max-rss=4096`; smoke bucket RSS healthy.

## Notes

- Two entries added to `docs/test262-upstream-gaps.md` — neither host-abort is caught by an existing fixture, with the contributable fixture shape sketched for each.