### PR TITLE
Fix three gc1 use-after-free clusters; widen gc-stress CI to catch them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,13 +354,16 @@ jobs:
 
   test262-gc-stress:
     name: test262 GC stress / ${{ matrix.bucket }} (advisory)
-    # Advisory + main-only: gc-stress is a 5-bucket ReleaseSafe build
-    # plus a slow `--gc-threshold=1` sweep — too expensive to run on
-    # every PR for a non-gating signal. Catch GC rooting / write-
-    # barrier regressions post-merge; bisect from there. The default
-    # `test262` job (gating, ReleaseFast, every PR) is the front-line
-    # check; gc-stress is the deeper net.
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Advisory, runs on PRs and main: gc-stress is a per-bucket
+    # ReleaseSafe build plus a slow `--gc-threshold=1` sweep. It stays
+    # `continue-on-error` (does not gate merges) because a gc1 sweep is
+    # slow and, at `--threads=4`, prone to the occasional flake under
+    # libc-malloc contention — surfacing a GC regression as a pre-merge
+    # annotation a reviewer can act on is the goal, not blocking. The
+    # default `test262` job (gating, ReleaseFast, every PR) is the
+    # front-line check; gc-stress is the deeper net. It runs on PRs now
+    # — not just post-merge — so a rooting hole is caught before it
+    # lands, not bisected afterward.
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: build-and-test
@@ -381,15 +384,24 @@ jobs:
     # `built-ins/RegExp/property-escapes` fixtures each exceed the
     # per-fixture watchdog (huge generated patterns × per-alloc GC),
     # so a whole-corpus gc1 run is timeout-bound. Instead it probes
-    # the GC-mutation-heavy buckets (Array / String / TypedArray /
-    # Iterator / generators) — the areas where the rooting
+    # the GC-mutation-heavy buckets — the areas where the rooting
     # contract and the iterative-marker contract are most often
     # exercised. See docs/handbook/gc.md ("Finding these bugs").
     #
     # `Iterator` and `generators` were added after the shadow-shape
     # removal class (9c4b70c) and the recursive-marker overflow
     # (9ac49ff, f97155a) — both surfaced in those buckets and
-    # would slip past Array / String / TypedArray.
+    # would slip past Array / String / TypedArray. `Map` / `Set` /
+    # `WeakMap` / `WeakSet` / `Promise` / `Function` / `Object` were
+    # added after this net caught three real use-after-free clusters
+    # in them: the `Object.create` / `defineProperties` / `assign`
+    # accessor path (a hard segfault — unrooted receiver / key / getter
+    # result across the descriptor re-entry), the `Set` set-like ops
+    # (raw `*JSFunction` has/keys held across the iteration), and the
+    # `Promise` aggregators (the once-read `resolve` held across every
+    # element). Set covers the `collections.zig` family; WeakMap /
+    # WeakSet additionally exercise the ephemeron-marking path; Object
+    # is the property-bag / shape mutation surface.
     #
     # Matrix-parallelized: each bucket runs as its own job, so a
     # single regression points at the bucket directly and wall-time
@@ -403,6 +415,13 @@ jobs:
           - built-ins/TypedArray
           - built-ins/Iterator
           - language/expressions/generators
+          - built-ins/Map
+          - built-ins/Set
+          - built-ins/WeakMap
+          - built-ins/WeakSet
+          - built-ins/Promise
+          - built-ins/Function
+          - built-ins/Object
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@v2

--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -1875,12 +1875,17 @@ const SetLike = struct {
     size: usize,
 };
 
-fn validateSetLike(realm: *Realm, op: []const u8, value: Value) NativeError!SetLike {
+fn validateSetLike(realm: *Realm, op: []const u8, value: Value, scope: *heap_mod.HandleScope) NativeError!SetLike {
     const obj = heap_mod.valueAsPlainObject(value) orelse {
         var buf: [128]u8 = undefined;
         const msg = std.fmt.bufPrint(&buf, "Set.prototype.{s}: argument must be a set-like object", .{op}) catch op;
         return throwTypeError(realm, msg);
     };
+    // Root the set-like object for the lifetime of the operation —
+    // the caller holds the returned `SetLike` (and its raw `has` /
+    // `keys` `*JSFunction` pointers) across the iteration, which
+    // re-enters JS and GCs under allocation pressure.
+    scope.push(value) catch return error.OutOfMemory;
     // §24.2.1.2 GetSetRecord step 6 — ToIntegerOrInfinity(size).
     // Route through the accessor chain so `get size() { return 2; }`
     // getters fire instead of the bare data-slot lookup returning
@@ -1923,6 +1928,10 @@ fn validateSetLike(realm: *Realm, op: []const u8, value: Value) NativeError!SetL
         const msg = std.fmt.bufPrint(&buf, "Set.prototype.{s}: argument is not set-like (no callable 'has')", .{op}) catch op;
         return throwTypeError(realm, msg);
     };
+    // Root `has` before the `keys` getter runs — a `get has() { return
+    // function(){…} }` returns a fresh function reachable through
+    // nothing, and the `keys` getter below allocates / can GC.
+    scope.push(has_v) catch return error.OutOfMemory;
     // §24.2.1.2 step 9-10 — `Get(obj, "keys")`. Accessor-aware.
     const keys_v = try intrinsics.getPropertyChain(realm, obj, "keys");
     const keys_fn = heap_mod.valueAsFunction(keys_v) orelse {
@@ -1930,6 +1939,7 @@ fn validateSetLike(realm: *Realm, op: []const u8, value: Value) NativeError!SetL
         const msg = std.fmt.bufPrint(&buf, "Set.prototype.{s}: argument is not set-like (no callable 'keys')", .{op}) catch op;
         return throwTypeError(realm, msg);
     };
+    scope.push(keys_v) catch return error.OutOfMemory;
     return .{ .has = has_fn, .keys = keys_fn, .obj = value, .size = size_usize };
 }
 
@@ -1995,7 +2005,6 @@ fn forEachSetLikeKey(
     const scope = realm.heap.openScope() catch return error.OutOfMemory;
     defer scope.close();
     scope.push(iter) catch return error.OutOfMemory;
-    const loop_base = scope.handles.items.len;
     const iter_obj = heap_mod.valueAsPlainObject(iter) orelse return throwTypeError(realm, "set-like keys() did not return an iterator");
     // §7.4.1 GetIteratorFromMethod step 4 — `next` is cached on
     // the IteratorRecord at open time, not refetched every step.
@@ -2003,6 +2012,13 @@ fn forEachSetLikeKey(
     // exactly once (`set-like-class-order.js` asserts this).
     const next_v = try intrinsics.getPropertyChain(realm, iter_obj, "next");
     const next_fn = heap_mod.valueAsFunction(next_v) orelse return throwTypeError(realm, "set-like keys() iterator missing callable 'next'");
+    // Pin the cached `next` function for the whole walk — a
+    // `get next() { return function(){…} }` returns a fresh function
+    // reachable through nothing, and it is reused as the callee on
+    // every iteration. Push it before capturing `loop_base` so the
+    // per-iteration `shrinkRetainingCapacity` keeps it rooted.
+    scope.push(next_v) catch return error.OutOfMemory;
+    const loop_base = scope.handles.items.len;
     const max_iter: usize = 1 << 24;
     var step: usize = 0;
     while (step < max_iter) : (step += 1) {
@@ -2075,17 +2091,16 @@ fn allocateEmptySet(realm: *Realm) NativeError!*JSObject {
 
 fn setUnion(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     if (setDataOf(this_value) == null) return throwTypeError(realm, "Set.prototype.union called on non-Set");
-    const sl = try validateSetLike(realm, "union", argOr(args, 0, Value.undefined_));
+    // One scope roots the set-like (its raw has/keys/obj pointers) and
+    // the half-built result for the whole operation — both are held
+    // across `forEachSetLikeKey`, which re-enters JS (the set-like's
+    // `keys()` iterator + accessors) and GCs under allocation pressure.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "union", argOr(args, 0, Value.undefined_), op_scope);
 
     const out = try allocateEmptySet(realm);
-    // `out` is held raw across `forEachSetLikeKey`, which re-enters
-    // JS (the set-like's `keys()` iterator + accessors) and can GC
-    // under allocation pressure. Root the half-built result so a
-    // sweep can't collect it before `setAddInternal` dereferences
-    // `out.getSetData()`.
-    const out_scope = realm.heap.openScope() catch return error.OutOfMemory;
-    defer out_scope.close();
-    out_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
+    op_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
     // Copy this set first, then add other's keys (sameValueZero
     // dedup keeps duplicates out).
     {
@@ -2106,17 +2121,16 @@ fn setUnion(realm: *Realm, this_value: Value, args: []const Value) NativeError!V
 
 fn setIntersection(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.intersection called on non-Set");
-    const sl = try validateSetLike(realm, "intersection", argOr(args, 0, Value.undefined_));
+    // One scope roots the set-like (its raw has/keys/obj pointers) and
+    // the half-built result for the whole operation — both are held
+    // across `setLikeHas` / `forEachSetLikeKey`, which re-enter JS (the
+    // set-like's `has` / `keys` / iterator accessors) and GC.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "intersection", argOr(args, 0, Value.undefined_), op_scope);
 
     const out = try allocateEmptySet(realm);
-    // `out` is held raw across `setLikeHas` / `forEachSetLikeKey`,
-    // both of which re-enter JS (the set-like's `has` / `keys` /
-    // iterator accessors) and can GC. Root the half-built result
-    // so a sweep there can't collect it before `setAddInternal`
-    // dereferences `out.getSetData()`.
-    const out_scope = realm.heap.openScope() catch return error.OutOfMemory;
-    defer out_scope.close();
-    out_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
+    op_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
     // §24.2.4.5 step 5 — branch on size. When `this` is smaller
     // (or equal), iterate `this` and probe `other.has(value)`.
     // Otherwise iterate `other`'s keys() and probe `this.has`.
@@ -2167,16 +2181,16 @@ fn activeSetSize(d: *@import("../object.zig").SetData) usize {
 
 fn setDifference(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.difference called on non-Set");
-    const sl = try validateSetLike(realm, "difference", argOr(args, 0, Value.undefined_));
+    // One scope roots the set-like (its raw has/keys/obj pointers) and
+    // the half-built result (and its cached `out_d` slot) for the whole
+    // operation — both are held across `setLikeHas` / `forEachSetLikeKey`,
+    // which re-enter JS and GC.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "difference", argOr(args, 0, Value.undefined_), op_scope);
 
     const out = try allocateEmptySet(realm);
-    // `out` (and the `out_d` slot pointer cached below) are held raw
-    // across `setLikeHas` / `forEachSetLikeKey`, both of which
-    // re-enter JS and can GC. Root `out` so neither it nor its
-    // `getSetData()` slot is swept mid-loop.
-    const out_scope = realm.heap.openScope() catch return error.OutOfMemory;
-    defer out_scope.close();
-    out_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
+    op_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
     // §24.2.4.5 step 5-7 — start from a copy of `this`, then branch
     // on size. When `this` is smaller (or equal), call `other.has`
     // for each `this` entry and drop matches. When `this` is larger,
@@ -2223,7 +2237,12 @@ fn setDifference(realm: *Realm, this_value: Value, args: []const Value) NativeEr
 
 fn setSymmetricDifference(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.symmetricDifference called on non-Set");
-    const sl = try validateSetLike(realm, "symmetricDifference", argOr(args, 0, Value.undefined_));
+    // One scope roots the set-like (its raw has/keys/obj pointers) and
+    // the half-built result for the whole operation — both are held
+    // across `forEachSetLikeKey`, which re-enters JS and GCs.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "symmetricDifference", argOr(args, 0, Value.undefined_), op_scope);
 
     // §24.2.4.10 — `Set.prototype.symmetricDifference` MUST NOT
     // invoke `has` on the set-like. The spec algorithm:
@@ -2240,13 +2259,7 @@ fn setSymmetricDifference(realm: *Realm, this_value: Value, args: []const Value)
     // mid-iteration and asserts the toggle reads the post-
     // mutation membership.
     const out = try allocateEmptySet(realm);
-    // `out` (and the `out_d` slot pointer cached below) are held raw
-    // across `forEachSetLikeKey`, which re-enters JS (the set-like's
-    // `keys()` iterator + accessors) and can GC. Root `out` so a
-    // sweep can't free it (or its `getSetData()` slot) mid-loop.
-    const out_scope = realm.heap.openScope() catch return error.OutOfMemory;
-    defer out_scope.close();
-    out_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
+    op_scope.push(heap_mod.taggedObject(out)) catch return error.OutOfMemory;
     {
         var i: usize = 0;
         while (i < this_d.entries.items.len) : (i += 1) {
@@ -2293,7 +2306,11 @@ fn setSymmetricDifference(realm: *Realm, this_value: Value, args: []const Value)
 
 fn setIsSubsetOf(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.isSubsetOf called on non-Set");
-    const sl = try validateSetLike(realm, "isSubsetOf", argOr(args, 0, Value.undefined_));
+    // Root the set-like (its raw has/keys/obj pointers) across the
+    // operation — `setLikeHas` re-enters JS and GCs.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "isSubsetOf", argOr(args, 0, Value.undefined_), op_scope);
     // §24.2.4.7 step 4 — fast-reject: a larger set can't be a
     // subset of a smaller one.
     if (activeSetSize(this_d) > sl.size) return Value.false_;
@@ -2309,7 +2326,11 @@ fn setIsSubsetOf(realm: *Realm, this_value: Value, args: []const Value) NativeEr
 
 fn setIsSupersetOf(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.isSupersetOf called on non-Set");
-    const sl = try validateSetLike(realm, "isSupersetOf", argOr(args, 0, Value.undefined_));
+    // Root the set-like (its raw has/keys/obj pointers) across the
+    // operation — `forEachSetLikeKey` re-enters JS and GCs.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "isSupersetOf", argOr(args, 0, Value.undefined_), op_scope);
     // §24.2.4.9 step 4 — fast-reject: a smaller set can't be a
     // superset of a larger one. Avoids invoking the set-like's
     // `keys()` iterator unnecessarily.
@@ -2332,7 +2353,11 @@ fn setIsSupersetOf(realm: *Realm, this_value: Value, args: []const Value) Native
 
 fn setIsDisjointFrom(realm: *Realm, this_value: Value, args: []const Value) NativeError!Value {
     const this_d = setDataOf(this_value) orelse return throwTypeError(realm, "Set.prototype.isDisjointFrom called on non-Set");
-    const sl = try validateSetLike(realm, "isDisjointFrom", argOr(args, 0, Value.undefined_));
+    // Root the set-like (its raw has/keys/obj pointers) across the
+    // operation — `setLikeHas` / `forEachSetLikeKey` re-enter JS and GC.
+    const op_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer op_scope.close();
+    const sl = try validateSetLike(realm, "isDisjointFrom", argOr(args, 0, Value.undefined_), op_scope);
 
     // §24.2.4.4 step 5 — pick the smaller side to iterate.
     // When `this` is smaller (or equal), iterate `this` + probe

--- a/src/runtime/builtins/object.zig
+++ b/src/runtime/builtins/object.zig
@@ -2003,11 +2003,16 @@ fn objectDefineProperties(realm: *Realm, this_value: Value, args: []const Value)
         }
         // §20.1.2.3.1 step 5.b.ii — `Let descObj be ? Get(props, nextKey)`.
         // Route through `getPropertyValue` so a Proxy `get` trap fires.
+        // When `props` holds an accessor, `descObj` is a fresh value
+        // reachable through nothing — root it (and the freshly
+        // allocated key string) before `objectDefineProperty`
+        // re-enters JS / allocates, or an allocation-pressure GC frees
+        // them mid-define (use-after-free).
         const desc_v = try getPropertyValue(realm, props, key, heap_mod.taggedObject(props));
-        const inner_args = [_]Value{ heap_mod.taggedObject(target), blk: {
-            const k_str = realm.heap.allocateString(key) catch return error.OutOfMemory;
-            break :blk Value.fromString(k_str);
-        }, desc_v };
+        dps_scope.push(desc_v) catch return error.OutOfMemory;
+        const k_str = realm.heap.allocateString(key) catch return error.OutOfMemory;
+        dps_scope.push(Value.fromString(k_str)) catch return error.OutOfMemory;
+        const inner_args = [_]Value{ heap_mod.taggedObject(target), Value.fromString(k_str), desc_v };
         _ = try objectDefineProperty(realm, Value.undefined_, &inner_args);
     }
     return heap_mod.taggedObject(target);
@@ -2027,6 +2032,20 @@ fn defineFromFunctionProps(
 ) NativeError!Value {
     var seen: std.StringHashMapUnmanaged(void) = .empty;
     defer seen.deinit(realm.allocator);
+    // Root the receiver and the Properties function across the loop.
+    // `allocateString` (every iteration) and the accessor getter
+    // (`callJSFunction`) each allocate, so under allocation-pressure
+    // GC an unrooted `target` would be swept before
+    // `objectDefineProperty` consumes it — a use-after-free that
+    // segfaults when the getter re-enters JS
+    // (`built-ins/Object/create/15.2.3.5-4-5.js`: a Function
+    // `Properties` whose accessor getter returns a fresh object).
+    // Rooting `props_fn` also keeps its property / accessor bags —
+    // and the borrowed `key` slices into them — alive across the loop.
+    const scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer scope.close();
+    scope.push(heap_mod.taggedObject(target)) catch return error.OutOfMemory;
+    scope.push(heap_mod.taggedFunction(props_fn)) catch return error.OutOfMemory;
     var pit = props_fn.properties.iterator();
     while (pit.next()) |entry| {
         const key = entry.key_ptr.*;
@@ -2039,6 +2058,10 @@ fn defineFromFunctionProps(
         const flags = props_fn.property_flags.get(key) orelse @import("../object.zig").PropertyFlags{};
         if (!flags.enumerable) continue;
         const k_str = realm.heap.allocateString(key) catch return error.OutOfMemory;
+        // `desc_v` is a data value already reachable through the
+        // rooted `props_fn`; root only the freshly-allocated key
+        // string across `objectDefineProperty`'s re-entry.
+        scope.push(Value.fromString(k_str)) catch return error.OutOfMemory;
         const desc_v = entry.value_ptr.*;
         const inner = [_]Value{ heap_mod.taggedObject(target), Value.fromString(k_str), desc_v };
         _ = try objectDefineProperty(realm, Value.undefined_, &inner);
@@ -2050,6 +2073,9 @@ fn defineFromFunctionProps(
         const flags = props_fn.property_flags.get(key) orelse continue;
         if (!flags.enumerable) continue;
         const k_str = realm.heap.allocateString(key) catch return error.OutOfMemory;
+        // Root the key string before the getter runs — the getter
+        // allocates and can GC.
+        scope.push(Value.fromString(k_str)) catch return error.OutOfMemory;
         var desc_v: Value = Value.undefined_;
         if (entry.value_ptr.getter) |getter| {
             const lantern = @import("../lantern/interpreter.zig");
@@ -2065,6 +2091,10 @@ fn defineFromFunctionProps(
                 },
             };
         }
+        // The getter's result is a fresh value reachable through
+        // nothing yet — root it across `objectDefineProperty`, which
+        // re-enters JS and allocates.
+        scope.push(desc_v) catch return error.OutOfMemory;
         const inner = [_]Value{ heap_mod.taggedObject(target), Value.fromString(k_str), desc_v };
         _ = try objectDefineProperty(realm, Value.undefined_, &inner);
     }
@@ -2751,6 +2781,14 @@ fn objectAssign(realm: *Realm, this_value: Value, args: []const Value) NativeErr
     // null throw. The wrapper itself is what gets returned.
     const target_v = argOr(args, 0, Value.undefined_);
     const target = try intrinsics.toObjectThis(realm, target_v);
+    // Root the receiver across every source's key loop — each source
+    // fires accessor getters (`getPropertyChain`) and strict setters
+    // (`assignSetOrThrow`) that re-enter JS and allocate, so an
+    // unrooted `target` would be swept by an allocation-pressure GC
+    // and the next `assignSetOrThrow` would write through freed memory.
+    const target_scope = realm.heap.openScope() catch return error.OutOfMemory;
+    defer target_scope.close();
+    target_scope.push(heap_mod.taggedObject(target)) catch return error.OutOfMemory;
     var i: usize = 1;
     while (i < args.len) : (i += 1) {
         const src_v = args[i];
@@ -2784,6 +2822,10 @@ fn objectAssign(realm: *Realm, this_value: Value, args: []const Value) NativeErr
             // and now). Use objectGetOwnPropertyDescriptor so the
             // Proxy invariants and abrupt completions propagate.
             const key_string = realm.heap.allocateString(key) catch return error.OutOfMemory;
+            // Root the key string across the descriptor lookup, the
+            // getter, and the strict setter below — all re-enter JS /
+            // allocate and would otherwise free it mid-copy.
+            key_scope.push(Value.fromString(key_string)) catch return error.OutOfMemory;
             const desc_args = [_]Value{ src_value, Value.fromString(key_string) };
             const desc_v = try objectGetOwnPropertyDescriptor(realm, Value.undefined_, &desc_args);
             // §20.1.2.1 step 4.a.iii.2 — only act when `desc` is not
@@ -2811,6 +2853,9 @@ fn objectAssign(realm: *Realm, this_value: Value, args: []const Value) NativeErr
                 }
                 break :blk_v try getPropertyChain(realm, cur_get, key);
             };
+            // The getter's result is reachable through nothing yet —
+            // root it across the strict setter's re-entry / allocation.
+            key_scope.push(v) catch return error.OutOfMemory;
             // §20.1.2.1 step 4.a.iii.2.b — `Set(to, nextKey, propValue, true)`.
             // Strict-mode Set per §10.1.9 throws TypeError on any
             // failure (non-extensible + new key, non-writable own

--- a/src/runtime/builtins/promise.zig
+++ b/src/runtime/builtins/promise.zig
@@ -1269,18 +1269,25 @@ fn iterateAggregator(
     };
     const resolve_fn = heap_mod.valueAsFunction(resolve_v) orelse return throwTypeError(realm, "Promise aggregator: resolve is not a function");
 
+    // Root the iterator object + its `next` method AND the once-read
+    // `resolve` function for the whole walk. `iteratorStep`, the
+    // per-item `resolve` call, and `process` all re-enter JS and can
+    // GC; each of these is reachable only through a native record, so
+    // without rooting a collection sweeps it and a later dereference
+    // (`iteratorClose`, the next `iteratorStep`, or the next
+    // `resolve` call) reads freed memory. `resolve` especially: a
+    // `get resolve() { return function(){…} }` returns a fresh
+    // function reachable through nothing, yet it is the callee on
+    // every iteration — root it BEFORE `iteratorOpen`, which itself
+    // re-enters JS (via @@iterator) and can GC.
+    const it_sc = realm.heap.openScope() catch return error.OutOfMemory;
+    defer it_sc.close();
+    it_sc.push(resolve_v) catch return error.OutOfMemory;
+
     // `iteratorOpen` always returns a record or throws — no
     // array-like fallback (spec §7.4.2 only allows GetIterator).
     const rec_in = (try iteratorOpen(realm, source_v)) orelse unreachable;
     var rec = rec_in;
-    // Root the iterator object + its `next` method for the whole
-    // walk. `iteratorStep`, the per-item `resolve` call, and
-    // `process` all re-enter JS and can GC; the user-created
-    // iterator is reachable only through this native record, so
-    // without rooting it a collection sweeps it and `iteratorClose`
-    // (or the next `iteratorStep`) dereferences freed memory.
-    const it_sc = realm.heap.openScope() catch return error.OutOfMemory;
-    defer it_sc.close();
     it_sc.push(rec.iter_v) catch return error.OutOfMemory;
     it_sc.push(heap_mod.taggedFunction(rec.next_fn)) catch return error.OutOfMemory;
     const max_iter: usize = 1 << 24;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -6584,6 +6584,116 @@ test "GC: native constructor via Reflect.construct survives re-entrant arg coerc
     , "M05/7");
 }
 
+test "GC: Object.create with a Function Properties + accessor getter survives gc_threshold=1" {
+    // §20.1.2.3.1 ObjectDefineProperties, Function-`Properties` path
+    // (`defineFromFunctionProps`). The accessor getter returns a fresh
+    // descriptor object; `allocateString` and the getter's
+    // `callJSFunction` each allocate, so under threshold=1 the unrooted
+    // `target` / key string / getter result were swept mid-define — a
+    // null deref (segfault). Mirrors
+    // `built-ins/Object/create/15.2.3.5-4-5.js`.
+    try expectScriptIntUnderGcPressure(
+        \\function P() {}
+        \\Object.defineProperty(P, "x", {
+        \\  enumerable: true,
+        \\  get: function () { return { value: 42, enumerable: true, configurable: true }; },
+        \\});
+        \\var o = Object.create({}, P);
+        \\o.x;
+    , 42);
+}
+
+test "GC: Object.defineProperties with an accessor in Properties survives gc_threshold=1" {
+    // §20.1.2.3.1 main loop: a plain-object `Properties` whose key is
+    // an accessor returns a fresh descriptor (`getPropertyValue` fires
+    // the getter). That `descObj` was held across the key-string
+    // `allocateString` before `objectDefineProperty` consumed it —
+    // freed under threshold=1.
+    try expectScriptIntUnderGcPressure(
+        \\var props = {};
+        \\Object.defineProperty(props, "k", {
+        \\  enumerable: true,
+        \\  get: function () { return { value: 99, enumerable: true, configurable: true }; },
+        \\});
+        \\var o = Object.defineProperties({}, props);
+        \\o.k;
+    , 99);
+}
+
+test "GC: Object.assign with accessor sources survives gc_threshold=1" {
+    // §20.1.2.1 Object.assign: `target`, the per-key string, and each
+    // getter result were held across the descriptor lookup, the getter,
+    // and the strict setter (all re-enter JS / allocate). Under
+    // threshold=1 the unrooted receiver was swept before
+    // `assignSetOrThrow` wrote through it.
+    try expectScriptIntUnderGcPressure(
+        \\var src = {};
+        \\Object.defineProperty(src, "a", { enumerable: true, get: function () { return 7; } });
+        \\Object.defineProperty(src, "b", { enumerable: true, get: function () { return 13; } });
+        \\var t = Object.assign({}, src);
+        \\t.a + t.b;
+    , 20);
+}
+
+test "GC: Set.union over a set-like class survives gc_threshold=1" {
+    // §24.2.1.2 GetSetRecord + §24.2.4.x. The set-like's `get has` /
+    // `get keys` / `get next` accessors each return a FRESH function
+    // reachable through nothing; the raw `*JSFunction` pointers in the
+    // native `SetLike` record (and the iterator's cached `next`) were
+    // held across the iteration's re-entries — swept under threshold=1.
+    // Mirrors `built-ins/Set/prototype/union/set-like-class-order.js`.
+    try expectScriptIntUnderGcPressure(
+        \\class SL {
+        \\  get size() { return 2; }
+        \\  get has() { return function () { return false; }; }
+        \\  get keys() {
+        \\    return function () {
+        \\      var i = 0, a = [10, 20];
+        \\      return { next: function () { return i < a.length ? { value: a[i++], done: false } : { value: undefined, done: true }; } };
+        \\    };
+        \\  }
+        \\}
+        \\new Set([1]).union(new SL()).size;
+    , 3);
+}
+
+test "GC: Set.intersection probing a set-like .has survives gc_threshold=1" {
+    // §24.2.4.5 — the smaller-receiver branch iterates `this` and
+    // probes the set-like's `has`. The fresh `has` function from the
+    // `get has()` accessor is held raw across every probe call.
+    try expectScriptIntUnderGcPressure(
+        \\class SL2 {
+        \\  get size() { return 3; }
+        \\  get has() { return function (v) { return v === 1; }; }
+        \\  get keys() {
+        \\    return function () {
+        \\      var i = 0, a = [1, 2, 3];
+        \\      return { next: function () { return i < a.length ? { value: a[i++], done: false } : { value: undefined, done: true }; } };
+        \\    };
+        \\  }
+        \\}
+        \\new Set([1, 9]).intersection(new SL2()).size;
+    , 1);
+}
+
+test "GC: Promise.all reading a fresh constructor.resolve survives gc_threshold=1" {
+    // §27.2.4.1.1 PerformPromiseAll — `Get(C, "resolve")` runs once
+    // before the loop and is the callee on every element. A
+    // `get resolve()` returning a fresh function leaves it reachable
+    // through nothing; it was unrooted across `iteratorOpen` and every
+    // per-element call, so threshold=1 swept it. Mirrors
+    // `built-ins/Promise/all/invoke-resolve-get-once-multiple-calls.js`.
+    try expectScriptIntUnderGcPressure(
+        \\var calls = 0;
+        \\function C(executor) { executor(function () {}, function () {}); }
+        \\Object.defineProperty(C, "resolve", {
+        \\  get: function () { return function (v) { calls++; return Promise.resolve(v); }; },
+        \\});
+        \\Promise.all.call(C, [1, 2, 3]);
+        \\calls;
+    , 3);
+}
+
 // ---------------------------------------------------------------------------
 // §23.1.3 Array.prototype — receiver coercion + spec dispatch regressions.
 //


### PR DESCRIPTION
## Summary

A security-audit follow-up to widen the `test262-gc-stress` CI net (run it on PRs, add the GC-mutation-heavy buckets). Standing up the new buckets locally at `--gc-threshold=1` immediately surfaced **three real use-after-free clusters** — so this PR fixes those first, then lands the CI change that catches them.

### The three UAF fixes (`1b4ae8e`)

All three are the same class: a native loop held a heap pointer across a JS re-entry (accessor getter / set-like method / Promise `resolve`) without rooting it, so an allocation-pressure GC swept it mid-operation. Invisible at the default threshold and in ReleaseFast (verifiers compile out); only a ReleaseSafe `--gc-threshold=1` sweep exposes them.

- **§20.1.2.3.1 `Object.defineProperties` / §20.1.2.1 `Object.assign`** — root the receiver, each allocated key string, and each getter-produced descriptor/value across `objectDefineProperty` / the strict setter. The Function-`Properties` path (`defineFromFunctionProps`) had **no HandleScope at all** — `Object.create({}, fnWithAccessor)` hard-**segfaulted**.
- **§24.2.1.2 `GetSetRecord`** — thread the caller's HandleScope into `validateSetLike` so the set-like's *fresh* `has`/`keys` functions (and the iterator's cached `next`) stay rooted across the whole set operation. Affected all 7 ES2025 set ops.
- **§27.2.4.1.1 `PerformPromiseAll`** and the `allSettled`/`any`/`race` siblings — root the once-read `constructor.resolve` before `iteratorOpen` and across every element.

### The CI change (`e6867f4`)

- `test262-gc-stress` now runs on **pull requests**, not just post-merge — a rooting regression is annotated before it lands. Stays **advisory** (`continue-on-error`): a gc1 sweep is slow and occasionally flakes at `--threads=4` under libc-malloc contention.
- Adds the missing GC-mutation-heavy buckets: `Map`, `Set`, `WeakMap`, `WeakSet`, `Promise`, `Function`, `Object`. (Map/WeakMap/WeakSet/Function were already gc1-clean; Set/Promise/Object are clean after the fixes above.)

## Verification

- Per-cluster gc1 diff (gc1 vs default failure sets):
  - Object: hard segfault → **0 gc1-only failures** (82 == default conformance gaps).
  - Set: 8 → **1** (the 7 gc1-only gone; remainder is the pre-existing gap).
  - Promise: 7 → **3** (the 4 gc1-only gone), clean at `--threads=1` and `--threads=4`.
- 6 new regression tests in the GC cluster (`gc_threshold=1`), each mirroring the triggering test262 fixture — green via `zig build test-fast`.
- Full `zig build test-fast` — green.
- Full ReleaseSafe `test262` sweep — **45166 / 4642 / 90.68 %**, unchanged from baseline (the fixes are pure rooting, score-neutral).
- `actionlint` clean on the edited workflow.