### PR TITLE
interpreter: precise Linux stack bounds for native re-entry guard

### DIFF
--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -206,22 +206,43 @@ const max_call_frames: usize = 1024;
 // shallow nesting depth exhausts a 2 MiB worker stack.
 //
 // The guard measures *actual remaining native stack* at each
-// `runFrames` entry and throws before the red zone. Two strategies:
+// `runFrames` entry and throws before the red zone. Three strategies,
+// in precision order:
 //   • macOS — exact thread stack bounds via `pthread_get_stackaddr_np`
 //     / `pthread_get_stacksize_np`. Adapts to the thread's real stack
 //     size (the harness runs 2 MiB agent workers AND larger default
 //     workers), so the limit is precise per thread.
-//   • Other targets — a portable growth-from-base heuristic: the
-//     first `runFrames` on the thread records its SP as the high-water
-//     base; the guard trips once growth past it exceeds
-//     `stack_growth_budget`, chosen safely below the smallest stack
-//     the engine runs on.
+//   • Linux (glibc / musl) — exact bounds via the GNU extension
+//     `pthread_getattr_np` → `pthread_attr_getstack`, which yields the
+//     stack's low address and size. (`pthread_get_stackaddr_np` is a
+//     BSD/Darwin spelling that glibc/musl don't provide.) Precise per
+//     thread, just like macOS. Without this the portable heuristic
+//     below tripped on legitimate shallow re-entry: its 1 MiB growth
+//     budget sits under depth-50 `Array.prototype.forEach` recursion
+//     on the larger default worker stacks, producing a false
+//     `RangeError`. See commit 63c5811 (which added the guard) and
+//     the `bounded callback recursion still completes` test.
+//   • Any other target (e.g. wasm-freestanding, which has no pthread)
+//     — a portable growth-from-base heuristic: the first `runFrames`
+//     on the thread records its SP as the high-water base; the guard
+//     trips once growth past it exceeds `stack_growth_budget`, chosen
+//     safely below the smallest stack the engine runs on. Last resort
+//     only — it still genuinely protects against overflow.
 // `runFrames` entry is per-native-re-entry (NOT per JS call — those
 // stay in the dispatch loop), so the check is off the hot path.
 
 extern "c" fn pthread_self() *anyopaque;
+// Darwin / BSD spelling — returns the stack's *high* address (stack
+// grows down). Only referenced under `builtin.os.tag.isDarwin()`.
 extern "c" fn pthread_get_stackaddr_np(thread: *anyopaque) *anyopaque;
 extern "c" fn pthread_get_stacksize_np(thread: *anyopaque) usize;
+// glibc / musl GNU extension — fills `attr` with the running thread's
+// attributes (incl. its real stack base + size). Only referenced under
+// `builtin.os.tag == .linux`, so the externs never resolve on targets
+// (macOS, wasm-freestanding) whose libc lacks them.
+extern "c" fn pthread_getattr_np(thread: *anyopaque, attr: *anyopaque) c_int;
+extern "c" fn pthread_attr_getstack(attr: *anyopaque, stackaddr: *?*anyopaque, stacksize: *usize) c_int;
+extern "c" fn pthread_attr_destroy(attr: *anyopaque) c_int;
 
 /// Headroom kept below the true stack limit: enough for the
 /// `makeRangeError` allocation plus the worst-case native frames
@@ -273,6 +294,30 @@ inline fn nearNativeStackLimit() bool {
             if (size > stack_red_zone and base > size) {
                 stack_limit_addr = base - size + stack_red_zone;
                 return sp <= stack_limit_addr;
+            }
+        } else if (builtin.os.tag == .linux and builtin.link_libc) {
+            // glibc / musl: `pthread_getattr_np` reports the running
+            // thread's real stack bounds. `pthread_attr_getstack`
+            // returns the LOW address (unlike Darwin's high-address
+            // `pthread_get_stackaddr_np`), so the limit is
+            // `low + red_zone`. `pthread_attr_t` is opaque and its
+            // size varies by libc/arch (glibc x86_64 = 56 B,
+            // aarch64 = 64 B; musl = 64 B on LP64); a 16-aligned
+            // 128-byte buffer covers every 64-bit target the engine
+            // builds for.
+            var attr: [128]u8 align(16) = undefined;
+            const attr_ptr: *anyopaque = @ptrCast(&attr);
+            if (pthread_getattr_np(pthread_self(), attr_ptr) == 0) {
+                defer _ = pthread_attr_destroy(attr_ptr);
+                var low_ptr: ?*anyopaque = null;
+                var size: usize = 0;
+                if (pthread_attr_getstack(attr_ptr, &low_ptr, &size) == 0) {
+                    const low = @intFromPtr(low_ptr);
+                    if (size > stack_red_zone and low != 0) {
+                        stack_limit_addr = low + stack_red_zone;
+                        return sp <= stack_limit_addr;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## The bug

The native re-entry stack guard (commit 63c5811) throws `RangeError("Maximum call stack size exceeded")` when a native builtin re-entering JS (accessor getter, `Array.prototype.map`/`forEach` callback, `Reflect.apply`, Proxy trap, promise reaction) is about to overflow the host stack. It had two strategies:

- **macOS** — precise per-thread bounds via `pthread_get_stackaddr_np` / `pthread_get_stacksize_np`. Correct.
- **Everywhere else (incl. Linux)** — a portable growth-from-base heuristic with a 1 MiB growth budget.

On Linux the heuristic is **too aggressive**: its 1 MiB budget sits below legitimate *shallow* re-entry on the larger default worker stacks. A depth-50 `Array.prototype.forEach` recursion (the `sumDown(50)` control test) wrongly throws `RangeError`. This is a genuine false positive — well-behaved user code gets a spurious throw — and it turned the `bounded callback recursion still completes` control test RED on the Linux ReleaseSafe CI job.

## The fix

Give Linux (glibc / musl) the same precise per-thread bounds as macOS, via the GNU extension `pthread_getattr_np` → `pthread_attr_getstack`, which reports the running thread's real stack **low** address and size; the limit becomes `low + red_zone`. (`pthread_get_stackaddr_np` is a BSD/Darwin spelling glibc/musl don't provide; both libcs do provide `pthread_getattr_np`.)

The growth-from-base heuristic stays **only as a last-resort fallback** for targets with no pthread stack introspection (e.g. wasm-freestanding), where it still genuinely bounds against overflow. The budget was not inflated, the test was not weakened, and the depth threshold was not raised — so the guard still trips on real unbounded recursion.

The new externs are gated behind `builtin.os.tag == .linux and builtin.link_libc` (a comptime-known condition), so the dead branch is pruned on non-Linux targets and the symbols never resolve there.

## Verification

- `zig build test-fast -Dtest-filter="native reentry"` → exit 0 (macOS, precise path).
- `zig build test-fast` (full suite) → exit 0.
- `zig build fmt-check` → exit 0.
- Cross-compiles all succeed: `x86_64-linux-gnu`, `x86_64-linux-musl`, `aarch64-linux-gnu`, `aarch64-macos`.

The recursive-overflow guard tests from 63c5811 (recursive accessor / recursive `map` / recursive `Reflect.apply` throwing a catchable `RangeError`) still pass — crash protection is intact.

## Can't-repro caveat

The Linux false positive **cannot be reproduced locally on macOS** (which uses the precise Darwin path and passes). The Linux precise path is made correct by construction — mirroring the macOS structure, using the documented glibc/musl stack-introspection API with the correct low-address semantics — and verified to compile for every Linux CI target via cross-build. **Linux CI is the proof.**