### PR TITLE
docs: codify the host-abort safety invariant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,22 @@ These are project rules — they apply to everyone.
 - **Spec-faithful naming.** Internal function names mirror
   ECMA-262 abstract operations so test262 failures map cleanly to
   spec sections.
+- **Never abort the host on untrusted input.** Cynic runs untrusted
+  JS inside a host process, so any input — however hostile or
+  pathological — must produce a normal completion or a *catchable*
+  JS exception, never a `panic`, `unreachable`, a segfault, an
+  `@intFromFloat` / `@intCast` trap, or unbounded resource growth.
+  A `RangeError` the script can `try`/`catch` is correct; a SIGABRT
+  / SIGSEGV is a denial-of-service (and a use-after-free is worse).
+  This is a robustness contract distinct from spec conformance, and
+  several bugs in this class are invisible to a normal test262 run —
+  they surface only under allocation-pressure GC or deep recursion —
+  so apply it at authoring time: saturate / range-check casts on
+  user-controlled numbers (`doubleToI64Saturating`), bound recursion
+  over user-sized input, root heap pointers held across a JS re-entry
+  (the `HandleScope` contract), and propagate `error.OutOfMemory` to
+  a throw. The mechanisms, precedents, and the per-builtin checklist
+  are in [docs/handbook/host-safety.md](docs/handbook/host-safety.md).
 - **No engine state on user-visible objects.** Internal engine
   state — iterator cursors, aggregator records, cached methods,
   captured inputs — must never be stored as ordinary property-bag
@@ -249,6 +265,7 @@ These are project rules — they apply to everyone.
 | See what's planned and what's done | [docs/ROADMAP.md](docs/ROADMAP.md) |
 | Decide between two designs | [docs/handbook/prior-art.md](docs/handbook/prior-art.md) |
 | Add a lexer / parser / runtime feature | [docs/handbook/tdd.md](docs/handbook/tdd.md), then [docs/handbook/compiler-engineering.md](docs/handbook/compiler-engineering.md) |
+| Add / touch a builtin that coerces user numbers, recurses over user-sized input, or re-enters JS | [docs/handbook/host-safety.md](docs/handbook/host-safety.md) (the never-abort-the-host invariant + per-builtin checklist) |
 | Touch heap-allocating native code | [docs/handbook/gc.md](docs/handbook/gc.md) (`HandleScope` contract for natives that re-enter JS) |
 | Touch binding / scope / top-level resolution | [docs/handbook/environments.md](docs/handbook/environments.md) (GlobalEnvironmentRecord split, named-fn-expr wrapper, module env-record, top-level write opcodes) |
 | Touch the property-storage layout (bag / shape / slots) | [docs/inline-caches.md](docs/inline-caches.md) (shape substrate + read/write IC); [docs/lazy-property-bag.md](docs/lazy-property-bag.md) (Phase 3 shipped — shape-mode writes skip the bag mirror entirely) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -109,8 +109,15 @@ What the engine does today, not a claim that it does it perfectly:
   `new AsyncFunction(string)` throw `EvalError` unless `--allow=eval`
   is passed. Matches Node's
   `--disallow-code-generation-from-strings`.
+- **No host abort on untrusted input.** Pathological input yields a
+  catchable JS exception (`RangeError` / `EvalError`), not a panic,
+  segfault, numeric-cast trap, or unbounded growth — enforced by
+  saturating casts, recursion bounds, a native-reentry stack guard,
+  and the GC rooting contract. See
+  [`docs/handbook/host-safety.md`](docs/handbook/host-safety.md).
 - **CI safety nets.** CodeQL static analysis on every push,
-  dependabot on the dependency surface, `test262` and
-  `test262-gc-stress` runtime conformance gating, and ReleaseSafe
-  builds in the unit-test and conformance jobs so GC verifiers and
-  free-poison are armed in CI.
+  dependabot on the dependency surface, the `test262` runtime sweep
+  gating on a pass-rate floor, the advisory `test262-gc-stress` job
+  (ReleaseSafe + `--gc-threshold=1` across the GC-mutation-heavy
+  buckets, on every PR), and ReleaseSafe builds in the unit-test and
+  conformance jobs so the GC verifiers and free-poison are armed.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1187,6 +1187,47 @@ direct-eval interaction), no `with` (drops out of the spec
 walk), no DevTools surface today (no installed expectation
 that `Error.stack` shows eliminated frames).
 
+## Robustness & host-safety
+
+The invariant: untrusted JS never aborts the host — any input yields
+a normal completion or a catchable JS exception, never a panic /
+`unreachable` / segfault / numeric-cast trap / unbounded growth. See
+[handbook/host-safety.md](handbook/host-safety.md) for the mechanisms
+and the per-builtin checklist; this section tracks status.
+
+**Shipped**
+
+- **Saturating numeric casts** — §7.1.5 / §7.1.20 sites route through
+  `doubleToI64Saturating` instead of trapping on out-of-range user
+  doubles; length×size multiplies guard against overflow. Began with
+  eight Number/String/Array/TypedArray sites, extended to the
+  array-like iterator and ShadowRealm-arity paths.
+- **Recursion bounds** — parser nesting and `JSON.parse` depth throw
+  `RangeError` instead of overflowing the host stack.
+- **Native re-entry stack guard** — `nearNativeStackLimit()` throws
+  `RangeError` before a native→JS re-entry (accessor getter, array
+  callback, `Reflect.apply`, Proxy trap, promise drain) overflows the
+  host stack; precise per-thread bounds on macOS + Linux.
+- **GC rooting under re-entry** — the `HandleScope` contract (see
+  [handbook/gc.md](handbook/gc.md)); the Object / Set / Promise
+  accessor + set-like + aggregator paths root the values they hold
+  across a JS re-entry.
+- **`test262-gc-stress` CI** — ReleaseSafe + `--gc-threshold=1` across
+  the GC-mutation-heavy buckets, on every PR, so a missed root is a
+  deterministic crash pre-merge.
+
+**Planned**
+
+- **CI lint for the cast/abort class** — fail the build on a new
+  `@intFromFloat` / `@intCast`-from-float / bare `@panic` /
+  `unreachable` reachable from `builtins/`, so the class can't
+  regress silently.
+- **Fuzzer harness** — structure-aware over the parser, `JSON.parse`,
+  and Perlex (ReleaseSafe target so a trap surfaces as a crash).
+- **Make gc-stress gating** — promote from advisory once the
+  occasional `--threads=4` gc1 flake is understood, so a real
+  use-after-free blocks rather than annotates.
+
 ## Future work (post-strict-only-runtime)
 
 - **Bistromath** — baseline JIT (T1). Direct opcode-to-native,

--- a/docs/handbook/host-safety.md
+++ b/docs/handbook/host-safety.md
@@ -1,0 +1,141 @@
+# Host-abort safety
+
+Cynic runs untrusted JavaScript inside a host process — edge
+runtimes, server JS, the WASM playground. The single invariant that
+makes that safe:
+
+> **Untrusted JS must never abort the host. Any input — however
+> hostile or pathological — produces a normal completion or a
+> *catchable* JS exception, never a `panic`, `unreachable`, a
+> segfault, an `@intFromFloat`/`@intCast` trap, or unbounded
+> resource growth that the OS kills.**
+
+A `RangeError` the script can `try`/`catch` is correct. A SIGABRT,
+SIGSEGV, or `EXC_BAD_ACCESS` at a Zig `unreachable` is a security
+bug — it's a denial-of-service on any embedder that accepts
+user-controlled input, and a memory-safety violation is worse.
+
+This is a *robustness* contract, distinct from spec conformance: a
+spec-conformant result is still a host-abort bug if a crafted input
+reaches it through a trap. Several of these bugs are invisible to a
+normal test262 run — they only surface under allocation-pressure GC
+or deep recursion — so the rule has to be applied at authoring time,
+not discovered later.
+
+## The mechanisms
+
+Each recurring host-abort class has a standard mitigation. Use the
+existing one; don't reinvent it.
+
+### 1. Numeric casts on user-controlled doubles
+
+`@intFromFloat` / `@intCast` **trap** (and abort in ReleaseFast,
+panic in safe builds) for any finite value outside the destination
+range — e.g. `@as(i64, @intFromFloat(1e30))`. Every JS number is a
+user-controlled `f64`, so a bare cast on an argument is a host-abort
+waiting to happen.
+
+- Route §7.1.5 ToIntegerOrInfinity / §7.1.20 ToLength sites through
+  `doubleToI64Saturating` (saturates ±∞ and out-of-range finites to
+  the i64 bounds, which is where the spec's clamping lands anyway).
+- For a radix / digit count / index, range-check *before* the cast
+  and emit the spec value (or `RangeError`) explicitly.
+- Guard length × element-size multiplies (`byte_len * count`) against
+  overflow and throw `RangeError` (§22.1.3.16-style).
+
+Precedent: `cd1d038` (eight Number/String/Array/TypedArray sites),
+the array-like iterator and ShadowRealm-arity follow-ups. When you
+add a builtin that coerces a number, grep your diff for
+`@intFromFloat` / `@intCast(` and confirm each is range-checked or
+saturating.
+
+### 2. Recursion depth
+
+User input controls nesting depth: `[[[[…]]]]`, `{"a":{"a":…}}`,
+`(((((…)))))`. Unbounded native recursion overflows the host stack.
+
+- The parser bounds expression / statement nesting.
+- `JSON.parse` bounds its recursion and throws `RangeError`
+  (`aa5010c`).
+- Any new recursive descent over user-sized input needs a depth
+  backstop that throws, not a stack that grows until the OS faults.
+
+### 3. Native re-entry into JS (the stack guard)
+
+`max_call_frames` bounds the *JS* frame stack within one `runFrames`
+dispatch, but a native builtin that calls back into JS — an accessor
+getter, a `.map` / `.forEach` callback, `Reflect.apply`, a Proxy
+trap, a promise-reaction drain — starts a *fresh* `runFrames` on a
+fresh native stack frame. That nesting was once unbounded and
+crashed the process.
+
+`nearNativeStackLimit()` in `src/runtime/lantern/interpreter.zig`
+measures actual remaining native stack at each `runFrames` entry and
+throws `RangeError("Maximum call stack size exceeded")` before the
+red zone — precise per-thread bounds on macOS
+(`pthread_get_stackaddr_np`) and Linux (`pthread_getattr_np` +
+`pthread_attr_getstack`), a growth-from-base heuristic elsewhere
+(`63c5811`, `e5d637c`). You don't normally touch this, but if you
+add a *new* native→JS re-entry path, it's already covered by the
+entry check — don't bypass `runFrames`.
+
+### 4. Heap pointers across a re-entry or allocation (GC rooting)
+
+A native that holds a raw `*JSObject` / `*JSString` / `*JSFunction`
+or a `Value` across a call that can GC — any allocation, any JS
+re-entry — and doesn't root it has a use-after-free: the sweep frees
+the object, the post-call dereference reads poison (segfault in
+ReleaseSafe, silent corruption in ReleaseFast). The fresh value
+returned by an accessor getter, a set-like's `has`/`keys`, or a
+once-read `constructor.resolve` is the classic offender — reachable
+through nothing until you root it.
+
+Root with a `HandleScope` (or move engine state into a typed
+`JSObject` slot). The contract is in
+[gc.md](gc.md) ("the `HandleScope` contract for natives"); the
+"No engine state on user-visible objects" rule in
+[../../AGENTS.md](../../AGENTS.md) is the typed-slot half. Precedent:
+the Object / Set / Promise re-entry fixes (`d87eed3`).
+
+### 5. Out-of-memory
+
+An allocation failure must surface as a JS-visible `RangeError`
+(`error.OutOfMemory` propagated to a throw), never an unchecked
+`catch unreachable` that aborts.
+
+## The contributor checklist
+
+When you add or touch a builtin, ask:
+
+1. Does it cast a user-controlled number? → saturate / range-check
+   (§1).
+2. Does it recurse over user-sized input? → depth backstop (§2).
+3. Does it call back into JS — getter, callback, trap, `then`,
+   species constructor, coercion hook? → every heap pointer / `Value`
+   held across that call is rooted (§4); the re-entry itself is
+   covered by the stack guard (§3).
+4. Does every allocation propagate `error.OutOfMemory` to a throw
+   rather than `catch unreachable`? (§5).
+5. Add a regression test. UAF / rooting tests go in the `GC:` cluster
+   in `src/runtime/lantern/tests.zig` under `gc_threshold = 1`
+   (`expectScriptIntUnderGcPressure`); host-abort-on-numeric tests go
+   alongside the relevant builtin's tests. A bug that only reproduces
+   under GC pressure or deep recursion needs a test that recreates
+   that pressure.
+
+## How it's enforced
+
+- **`test262-gc-stress` CI** — ReleaseSafe (verifiers + 0xaa
+  free-poison armed) at `--gc-threshold=1` across the
+  GC-mutation-heavy buckets, on every PR. A missed root is a
+  deterministic crash there even though it's invisible to the
+  ReleaseFast scoring sweep. See the job in
+  `.github/workflows/ci.yml` and the `/gc-stress` workflow.
+- **Unit regression tests** — the `GC:` cluster runs each fixed
+  re-entry path under `gc_threshold = 1`.
+- **The full ReleaseSafe sweep completes** — a host-abort mid-corpus
+  used to wedge the run; a clean full sweep is itself a signal.
+
+When a host-abort fix lands that no existing test262 fixture catches,
+log it in
+[../test262-upstream-gaps.md](../test262-upstream-gaps.md).


### PR DESCRIPTION
## Summary

This cycle shipped five fixes that all enforce one principle — **untrusted JS must never abort the host** — but the principle lived nowhere durable (only in commit messages and `test262-upstream-gaps.md`). This PR writes it down so the next contributor adding a builtin has a rule and a checklist for the exact bug class.

The five precedents: saturating `@intFromFloat` casts (#28), the array-like-iterator + ShadowRealm-arity casts and three GC-rooting use-after-frees (#29), plus the JSON.parse recursion bound and native-reentry stack guard that landed on `main` alongside.

## Changes (docs only)

- **`docs/handbook/host-safety.md`** (new) — the invariant stated plainly, the five mechanism categories (saturating casts, recursion bounds, native-reentry stack guard, GC rooting, OOM→throw) each with its standard mitigation + precedent SHA, the per-builtin contributor checklist, and how it's enforced (gc-stress CI + unit tests).
- **`AGENTS.md`** — a "Never abort the host on untrusted input" convention bullet (matching the existing rule style) + a row in the handbook table.
- **`docs/ROADMAP.md`** — a "Robustness & host-safety" section: shipped (the five mechanisms) vs planned (a CI lint for the cast/abort class, a parser/JSON/Perlex fuzzer, promoting gc-stress to gating).
- **`SECURITY.md`** — a "No host abort on untrusted input" posture bullet linking the new doc; corrected the gc-stress wording (it's advisory, not gating).

## Notes

Docs-only — no engine change. `gh-pages` intentionally untouched.