### PR TITLE
ci: add Reflect and Proxy to the gc-stress matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,12 @@ jobs:
     # WeakSet additionally exercise the ephemeron-marking path; Object
     # is the property-bag / shape mutation surface.
     #
+    # `Reflect` and `Proxy` are the trap-forwarding / receiver re-entry
+    # surfaces (every Proxy trap and `Reflect.{get,set,apply,construct,
+    # ownKeys}` re-enters JS). Both probed gc1-clean when the cluster
+    # above was fixed — they're here as a regression net to keep them
+    # that way, not because a bug was found in them.
+    #
     # Matrix-parallelized: each bucket runs as its own job, so a
     # single regression points at the bucket directly and wall-time
     # is the slowest bucket, not the sum.
@@ -422,6 +428,8 @@ jobs:
           - built-ins/Promise
           - built-ins/Function
           - built-ins/Object
+          - built-ins/Reflect
+          - built-ins/Proxy
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@v2


### PR DESCRIPTION
## Summary

Adds `built-ins/Reflect` and `built-ins/Proxy` to the `test262-gc-stress` matrix.

Both are the heaviest native→JS re-entry surfaces outside the clusters fixed earlier (every Proxy trap; `Reflect.{get,set,apply,construct,ownKeys}` forward through receivers / arg arrays). A local `--gc-threshold=1` probe found them **already clean** — gc1 failure counts identical to the default threshold, no crashes, including under the CI's `--threads=4` mode:

- Reflect: 153/0 (gc1) == 153/0 (default)
- Proxy: 300/11 (gc1) == 300/11 (default) — the 11 are pre-existing conformance gaps

So this is **regression coverage, not a bugfix**: it locks in that these surfaces stay clean, so a future rooting hole on a trap path is caught pre-merge instead of shipped.

## Notes

- Advisory job (`continue-on-error`), parallel matrix — wall-time is the slowest bucket, not the sum; +2 jobs per code PR.
- Comment updated to explain the rationale (probed-clean, here as a net).
- `actionlint` clean.