### PR TITLE
test+docs: microtask allocation storms self-throttle via the per-entry safe-point

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -129,20 +129,29 @@ code construction (aligns with SES).
   `collectYoung` with promotion-by-relink — has shipped (see the
   Performance section); incremental marking of the mature set is
   the remaining GC step.
-- **GC trigger at every safe-point, not only JS loop back-edges.**
+- **GC trigger at every safe-point — the pure-native residual.**
   The allocation-pressure check (`gc_threshold` / `gc_byte_threshold`)
-  runs at bytecode loop back-edges, so a microtask-driven or
-  pure-native allocation storm — e.g. a promise chain that re-defers
-  itself and never returns to a JS loop — crosses no back-edge and
-  never triggers GC. V8 / SpiderMonkey / JSC scavenge when the nursery
-  fills regardless of context; checking allocation pressure on the
-  microtask-drain boundary (and other native re-entry points) would
-  self-throttle such storms instead of relying on a later loop. A
-  companion harness fix: a real timer queue in `tools/test262.zig` so
-  the test262 `setTimeout` polyfill resolves a delay by wall-clock
-  instead of busy-spinning (what `d8` / `jsc` / Node give the runner).
-  Both were surfaced landing the `$262.agent` cross-agent `waitAsync`
-  fixtures, whose parent busy-loops on exactly this pattern.
+  fires at every interpreter safe-point: each bytecode loop back-edge
+  AND the first opcode of every `runFrames` entry (interpreter.zig
+  `runSafePoint`). So a microtask-driven JS storm — e.g. a self-deferring
+  `.then` chain that re-defers and never returns to a JS loop — already
+  self-throttles: each reaction is a fresh `runFrames` entry that crosses
+  the entry safe-point (verified — a 400-step self-deferring storm runs
+  ~25 minor cycles mid-drain, heap bounded; `realm_test.zig`). The
+  residual is a *pure-native* allocation storm that never re-enters the
+  interpreter — a native builtin looping over user-sized input, or a
+  reaction with no JS handler — which crosses no safe-point; those are
+  bounded per-builtin by the host-safety checklist rather than a global
+  trigger, so a drain-boundary check is belt-and-suspenders rather than a
+  correctness gap. V8 / SpiderMonkey / JSC scavenge when the nursery fills
+  regardless of context; a microtask-drain-boundary check (and other
+  native re-entry points) would close the residual uniformly if a native
+  path is ever found to grow unbounded. A companion harness fix: a real
+  timer queue in `tools/test262.zig` so the test262 `setTimeout` polyfill
+  resolves a delay by wall-clock instead of busy-spinning (what `d8` /
+  `jsc` / Node give the runner). Both were surfaced landing the
+  `$262.agent` cross-agent `waitAsync` fixtures, whose parent busy-loops
+  on exactly this pattern.
 
 **Recently landed (was in progress; now done).**
 

--- a/src/runtime/realm_test.zig
+++ b/src/runtime/realm_test.zig
@@ -776,3 +776,36 @@ test "Error.prototype.stack: accessor-pair contract (proposal-error-stacks)" {
     };
     try testing.expect(v.isInt32() and v.asInt32() == 1);
 }
+
+// ── Host-safety: a self-deferring microtask storm is GC-throttled ────
+
+test "GC: a self-deferring microtask allocation storm is throttled mid-drain" {
+    // Host-safety invariant (AGENTS.md never-abort-the-host: "no unbounded
+    // resource growth"): a promise reaction that allocates and re-defers
+    // itself — a loopless chain that crosses no JS loop back-edge — must
+    // still self-throttle. It does, because each reaction runs as a fresh
+    // `runFrames` entry and the interpreter crosses a safe-point on the
+    // first opcode of every entry (interpreter.zig — `runSafePoint`), not
+    // only at loop back-edges. So allocation pressure built up across a
+    // microtask-drain storm is collected during the drain rather than
+    // growing unbounded until control happens back to a JS loop. Regression
+    // guard for that safe-point; if it ever moves to back-edges only, the
+    // drain would stop collecting and this goes red.
+    var ra = try freshRealm(false);
+    defer ra.deinit();
+    // Low young threshold so the storm crosses it during the drain.
+    ra.heap.gc_young_threshold = 64;
+    _ = try lantern.evaluateScript(testing.allocator, &ra,
+        \\var n = 0;
+        \\function step() { var junk = { a: 1, b: 2 }; if (n++ < 400) Promise.resolve().then(step); }
+        \\Promise.resolve().then(step);
+    );
+    // `evaluateScript` doesn't drain; the loopless setup is well under the
+    // threshold, so no cycle has run yet.
+    const before = ra.heap.gc_cycles_total;
+    try lantern.drainMicrotasks(testing.allocator, &ra);
+    // The drain self-throttled: collections fired while processing the storm
+    // (≈ one per `gc_young_threshold` allocations), so the heap stayed
+    // bounded instead of accreting all 400 steps' garbage.
+    try testing.expect(ra.heap.gc_cycles_total > before);
+}


### PR DESCRIPTION
While scoping the ROADMAP item "GC trigger at every safe-point, not only JS loop back-edges", I found it's already covered for the realistic case: `runSafePoint` fires at the first opcode of **every** `runFrames` entry (interpreter.zig), not just loop back-edges, so each promise reaction crosses a safe-point and checks allocation pressure. A 400-step self-deferring `.then` storm runs ~25 minor cycles mid-drain with the heap bounded.

- **Regression guard** (`realm_test.zig`): locks in the host-safety invariant that a self-deferring microtask allocation storm is GC-throttled mid-drain. Goes red if the safe-point ever moves to back-edges only.
- **ROADMAP correction**: the note claimed back-edges-only / "never triggers GC" — stale. Narrowed to the pure-native residual (a native builtin / native-only reaction that allocates without re-entering the interpreter), which is bounded per-builtin by the host-safety checklist.

Test + docs only; no engine behavior change. `zig build fmt-check` and full `test-fast` green locally.