### PR TITLE
results: refresh test262 + bench at 8642fb21

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,30 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-06-19 — cynic `8642fb21`, host `Darwin 25.6.0 arm64`
+
+Eight fixtures faster ≥5 % vs `cd2dd5c`: object_alloc −39 %, prop_access
+−13 %, prop_write −12 %, arith_loop −9 %, class_instantiate −9 %,
+ctor_array_build −8 %, json_stringify −7 %, array_iter −6 % — from the
+spasm / JIT / bytecode work landed since. Default tier (Bistromath).
+Idle machine (load ~2.7); `arith_loop` spread 17.4 % (desktop-UI jitter),
+so its median is approximate.
+
+| bench | median_ms | min_ms | max_ms | rss_kb |
+|---|---:|---:|---:|---:|
+| arith_loop | 13.82 | 13.17 | 15.57 | 5696 |
+| prop_access | 11.81 | 11.49 | 12.07 | 5632 |
+| prop_write | 11.20 | 10.98 | 11.48 | 5664 |
+| array_iter | 19.09 | 18.61 | 19.47 | 6768 |
+| string_concat | 24.82 | 24.70 | 25.32 | 15720 |
+| promise_chain | 10.57 | 10.38 | 11.07 | 24024 |
+| object_alloc | 14.90 | 14.69 | 15.07 | 9152 |
+| method_call | 13.74 | 13.47 | 14.31 | 5928 |
+| class_instantiate | 24.74 | 24.09 | 25.87 | 9328 |
+| ctor_array_build | 162.74 | 159.48 | 164.61 | 9944 |
+| json_stringify | 21.98 | 21.22 | 23.75 | 8528 |
+| tail_recursion | 5.39 | 5.33 | 5.45 | 5696 |
+
 ### 2026-06-12 — cynic `cd2dd5c` (L4 register promotion complete + neg-fold), host `Darwin 25.6.0 arm64`
 
 Closes the ctor_array_build campaign: **176.60 median — from 497.45 at

--- a/test262-results.md
+++ b/test262-results.md
@@ -2,15 +2,15 @@
 
 **Cynic passes 90.86 % of the 49895 test262 fixtures it runs**, scored binary pass/fail under a single posture (`--unhardened --allow=eval`):
 
-- **45333 passing** — Cynic produced the spec-expected result.
-- **4562 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only / SES / eval miss counts as a plain fail, same as an engine bug. Honest, not flattering.
+- **45335 passing** — Cynic produced the spec-expected result.
+- **4560 failing** — every other scored fixture. No "expected fail" category: an Annex-B / no-Intl / strict-only / SES / eval miss counts as a plain fail, same as an engine bug. Honest, not flattering.
 - **Excluded from the denominator**: the upstream `harness/` and `staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal (decorators, import-defer, …), and structurally-unrunnable fixtures (no / malformed frontmatter). Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) get their own scoreboard below.
 
 ## Current scores
 
 | posture | passing | failing | total | pass% |
 |---|---:|---:|---:|---:|
-| **`--unhardened --allow=eval`** | 45333 | 4562 | 49895 | 90.86 % |
+| **`--unhardened --allow=eval`** | 45335 | 4560 | 49895 | 90.86 % |
 
 > **pass%** = `passing / (passing + failing)`. Every scored
 > fixture is a plain pass or fail — there is no "expected
@@ -65,7 +65,6 @@ count; the per-area table below it is the work list.
 | ECMA-402 not implemented | 3245 | the whole `intl402/` tree — `Intl` (and the `intl402/Temporal` twins of the excluded Temporal proposal) is an unbuilt subsystem |
 | sloppy-mode-only fixtures | 1142 | `flags: [noStrict]` — Cynic is strict-only by design (`with`, sloppy direct-eval `arguments` bindings, legacy S11-era semantics, ...) |
 | Annex B builtins | 69 | `__proto__` accessor + `__define`/`__lookup{Getter,Setter}__` are not shipped by design |
-| cannot-block agent semantics | 2 | `flags: [CanBlockIsFalse]` — fixtures requiring `Atomics.wait` to throw on a non-blocking agent |
 | **engine gaps** | 104 | failures the policy classes do not explain — the work list (an upper bound: it includes a residue of fixtures whose sloppy semantics hide inside dynamic `Function(...)` bodies, undetectable from frontmatter) |
 
 **Failing areas.** Only areas with at least one failure are
@@ -115,7 +114,6 @@ list. Bucketed on the first two path components.
 | `intl402/Number` | 3 | 4 | 0 | 43 % |
 | `built-ins/Promise` | 637 | 3 | 0 | 100 % |
 | `built-ins/undefined` | 5 | 3 | 0 | 63 % |
-| `built-ins/Atomics` | 379 | 2 | 0 | 99 % |
 | `built-ins/Infinity` | 4 | 2 | 0 | 67 % |
 | `built-ins/NaN` | 4 | 2 | 0 | 67 % |
 | `built-ins/Symbol` | 96 | 2 | 0 | 98 % |
@@ -144,29 +142,23 @@ top-line score.
 
 ## History
 
+### 2026-06-19 — cynic `8642fb21`, test262 `8642fb21`
+
+| passing | failing | total | pass% | Δ pass | elapsed |
+|---:|---:|---:|---:|---:|---:|
+| 45335 | 4560 | 49895 | 90.86 % | +2 | 55.1 s |
+
 ### 2026-06-14 — cynic `c48da45`, test262 `de8e621cdb`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 45333 | 4562 | 49895 | 90.86 % | +34 | 1m 25s |
 
-Biggest movers:
-
-- `built-ins/Error` +34
-
 ### 2026-06-12 — cynic `9026203`, test262 `de8e621c`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 45299 | 4596 | 49895 | 90.79 % | +58 | 55.1 s |
-
-Biggest movers:
-
-- `built-ins/Temporal` +4603
-- `built-ins/Date` +594
-- `built-ins/DataView` +550
-- `built-ins/Iterator` +432
-- `built-ins/Number` +340
 
 ### 2026-06-11 — cynic `b2adad7`, test262 `d0c1b4555b`
 


### PR DESCRIPTION
Checkpoint refresh against current main.

- **test262**: 45335 / 90.86% (Δ +2) — no regression. Dropped the auto-generated "Biggest movers" lines (the known `--write-results` stale-baseline artifact; real delta is +2).
- **bench**: fresh single-engine row (Bistromath default, idle machine). 8 fixtures faster ≥5% vs `cd2dd5c` (object_alloc −39%, prop_access −13%, …) from the spasm/JIT/bytecode work landed since.
- **cross-engine**: left at the committed snapshot — desktop-UI subprocess jitter made a fresh run too noisy.

Results-files only; no code change.