### PR TITLE
runtime: graduate joint-iteration to default-on (Stage 4, May 2026)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,9 +181,10 @@ These are project rules — they apply to everyone.
     primordials. Now shipped (§19.2.1 / §20.2.1.1.1) — see the
     `eval` bullet above and `docs/ses-alignment.md`.
   Three distinct CLI verbs to keep separate: **`--enable=<name>`**
-  turns on a not-yet-stable spec feature (`joint-iteration` is
-  the only one shipping today; `upsert` graduated to default-on
-  in 2026-05 when it advanced to Stage 4); **`--unhardened`** is
+  turns on a not-yet-stable spec feature (`ShadowRealm` is the
+  only one shipping today; `upsert` (2026-05) and
+  `joint-iteration` (2026-07) graduated to default-on when they
+  advanced to Stage 4); **`--unhardened`** is
   the SES-posture toggle;
   **`--allow=<name>`** relaxes a default-on restriction (only
   `--allow=eval` lives here today). See
@@ -383,8 +384,9 @@ Common commands:
     zig build run -- repl                           # interactive REPL (persistent realm)
 
 The `cynic` CLI defaults pre-Stage-4 / experimental TC39
-proposals (currently `joint-iteration`; `upsert` graduated
-to default-on when it advanced to Stage 4 in 2026-05) to off
+proposals (currently `ShadowRealm`; `upsert` (2026-05) and
+`joint-iteration` (2026-07) graduated to default-on when they
+advanced to Stage 4) to off
 so embedders see only stable ECMA-262. Opt in:
 
     cynic --enable=<name> run foo.js                # one feature
@@ -491,7 +493,7 @@ are only (a) the `harness/`, `staging/`, and `annexB/` walk-time
 prefixes; (b) pre-Stage-4 proposals (unshipped — decorators,
 import-defer, source-phase-imports, import-bytes,
 immutable-arraybuffer, await-dictionary — and shipped —
-joint-iteration, ShadowRealm; the shipped ones get their own
+ShadowRealm; the shipped ones get their own
 dedicated per-feature scoreboard); and (c) structurally-unrunnable
 fixtures (no / malformed frontmatter). Re-running for the same
 date replaces that day's row. Each row records `passing`,

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ your local `zig version` reports an older dev tag, bump it.
 
 - `--filter=<substring>` — run only matching paths.
 - `--list-failures=<n>` — print the first `n` failing paths after the tally.
-- `--phase=<spec>` — pin the harness to a single sweep. `--phase=main` is the headline ECMA-262 sweep (pre-Stage-4 fixtures excluded); `--phase=feature:<name>` (e.g. `feature:joint-iteration`, `feature:upsert`) runs only that proposal's dedicated isolated sweep. Default: just main, unless `--write-results` is set — then main + every tracked feature run in sequence.
+- `--phase=<spec>` — pin the harness to a single sweep. `--phase=main` is the headline ECMA-262 sweep (pre-Stage-4 fixtures excluded); `--phase=feature:<name>` (e.g. `feature:ShadowRealm`) runs only that proposal's dedicated isolated sweep. Default: just main, unless `--write-results` is set — then main + every tracked feature run in sequence.
 - `--quiet` / `--verbose` — progress noise dial.
 - `--no-harness` — skip the `sta.js` + `assert.js` preamble (for measuring the no-harness floor).
 - `--threads=<n>` — worker count (`0` = auto, `1` = sequential, `>1` = pool).
@@ -214,7 +214,7 @@ by default — embedders see only stable ECMA-262. Opt in:
 
 ```sh
 cynic --list-features                       # show available proposals
-cynic --enable=joint-iteration eval '...'   # one feature
+cynic --enable=ShadowRealm eval '...'       # one feature
 cynic --enable-experimental run foo.js      # all tracked features
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -558,35 +558,27 @@ Each shipped proposal carries a `PRE-STAGE-4 PROPOSAL` comment at
 the installer site so a future spec shift surfaces the right
 place to revisit. The current set:
 
-- **`joint-iteration`** (Stage 3) — `Iterator.zip(iterables)` and
-  `Iterator.zipKeyed(iterables, options?)` on the `Iterator`
-  global. Installer in `src/runtime/builtins/iterator.zig`.
-  Semantics of the `mode` option ("shortest" | "longest" |
-  "strict") and padding may still shift. The dedicated feature
-  phase is at 76 / 2: `Iterator.zip` and `Iterator.zipKeyed` are
-  conformant — the keyed-iterables walk routes through the spec
-  `[[OwnPropertyKeys]]` / `[[GetOwnProperty]]` / `[[Get]]`
-  operations (Proxy traps fire), padding is a keyed object for
-  `zipKeyed` and an iterable for `zip`, `IteratorClose` runs in
-  reverse, and the result tuples / per-input state live in typed
-  internal slots with no observable `__cynic_*` own property.
-  Helper results inherit `%IteratorHelperPrototype%`. The 2
-  remaining `result-is-iterator.js` fixtures are **environmentally
-  blocked, not an engine gap**: the test262 harness's
-  `getWellKnownIntrinsicObject` (`wellKnownIntrinsicObjects.js`)
-  populates every intrinsic by evaluating `new Function("return "
-  + source)()`, and Cynic deliberately ships no `new Function`
-  (SES alignment), so the helper can obtain no intrinsic at all.
-  Off by default in the CLI and excluded from headline
-  conformance.
+- **`ShadowRealm`** (Stage 2.7) — the `ShadowRealm` constructor
+  plus the §3.8 cross-realm callable boundary (`.evaluate` /
+  `.importValue`). Installer in
+  `src/runtime/builtins/shadow_realm.zig`, gated in
+  `intrinsics.install`. See [docs/multi-realm.md](multi-realm.md)
+  for the per-realm substrate and teardown story. Off by default
+  in the CLI and excluded from headline conformance.
+
+(`joint-iteration` — `Iterator.zip` / `Iterator.zipKeyed` —
+graduated out of this list on 2026-07-08 when the proposal
+advanced to Stage 4 (May 2026, ES2027 bucket); the methods
+install unconditionally now, same move as `upsert` in 2026-05.)
+
 Revisit this list each TC39 meeting cycle. If a proposal stalls,
 demotes, or its semantics flip, follow the comment trail in the
 installer and either back the change out or update.
 
 The conformance harness scores each tracked feature as its own
-**dedicated phase sweep** — a `joint-iteration` fixture runs in a
-realm where `Map.prototype.getOrInsert` is undefined, and vice
-versa, so each row reflects the proposal in honest isolation.
+**dedicated phase sweep** — each proposal's fixtures run in a
+realm with only that one flag enabled, so each row reflects the
+proposal in honest isolation.
 A `zig build test262 -- --write-results` invocation runs the
 main ECMA-262 sweep (pre-Stage-4 fixtures excluded entirely
 from `total` / cache / per-area buckets) followed by one

--- a/docs/ses-alignment.md
+++ b/docs/ses-alignment.md
@@ -234,7 +234,8 @@ Why one umbrella switch instead of per-constraint flags:
 
 Two distinct CLI verbs to keep separate:
 - `--enable=<feature>` — turns on a not-yet-stable spec feature
-  (`joint-iteration`, `upsert`, etc.). Forward-looking.
+  (`ShadowRealm`, etc.; `upsert` and `joint-iteration` graduated
+  to default-on at Stage 4). Forward-looking.
 - `--unhardened` — the SES-posture toggle. Backward-compatible-
   with-legacy-JS.
 - `--allow=<relaxation>` — kept as a verb for restrictions that

--- a/src/runtime/builtins/iterator.zig
+++ b/src/runtime/builtins/iterator.zig
@@ -65,19 +65,14 @@ pub fn install(realm: *Realm) !void {
 
     try installNativeMethod(realm, fn_obj, "from", iteratorFrom, 1);
     try installNativeMethod(realm, fn_obj, "concat", iteratorConcat, 0);
-    // PRE-STAGE-4 PROPOSAL — `joint-iteration` (Stage 3 as of 2026-05).
-    // `Iterator.zip(iterables)` and `Iterator.zipKeyed(iterables, options?)`
-    // ship ahead of inclusion in a published edition; spec text may
-    // still shift before Stage 4 advancement (semantics of the `mode`
-    // option, padding behavior). Gated on the per-realm feature flag
-    // so embedders / the `cynic` CLI need `--enable=joint-iteration`
-    // (or `--enable-experimental`) to see the methods. The test262
-    // harness flips every flag on at fixture init. Documented in
-    // `docs/ROADMAP.md` under "Pre-Stage-4 proposals shipped".
-    if (realm.feature_flags.contains(.joint_iteration)) {
-        try installNativeMethod(realm, fn_obj, "zip", iteratorZip, 1);
-        try installNativeMethod(realm, fn_obj, "zipKeyed", iteratorZipKeyed, 1);
-    }
+    // §27.1.4.3 / §27.1.4.4 — `Iterator.zip(iterables)` and
+    // `Iterator.zipKeyed(iterables, options?)`. The joint-iteration
+    // proposal reached Stage 4 in May 2026 (ES2027 bucket) —
+    // graduated out of the pre-Stage-4 feature flag on 2026-07-08.
+    // Always installed now; shared machinery + design notes live
+    // with `iteratorZip` / `iteratorZipKeyed` below.
+    try installNativeMethod(realm, fn_obj, "zip", iteratorZip, 1);
+    try installNativeMethod(realm, fn_obj, "zipKeyed", iteratorZipKeyed, 1);
 
     try installNativeMethodOnProto(realm, proto, "map", iteratorMap, 1);
     try installNativeMethodOnProto(realm, proto, "filter", iteratorFilter, 1);

--- a/src/runtime/features.zig
+++ b/src/runtime/features.zig
@@ -23,11 +23,6 @@
 const std = @import("std");
 
 pub const FeatureFlag = enum {
-    /// `Iterator.zip(iterables)` and
-    /// `Iterator.zipKeyed(iterables, options?)`. Stage 3 as of
-    /// 2026-05. Installer site: `src/runtime/builtins/iterator.zig`.
-    joint_iteration,
-
     /// `ShadowRealm` constructor + the §3.8 cross-realm callable
     /// boundary (`.evaluate` / `.importValue`). Stage 2.7 as of
     /// 2026-05. Installer site: `src/runtime/builtins/shadow_realm.zig`,
@@ -36,11 +31,10 @@ pub const FeatureFlag = enum {
 
     /// CLI flag / test262 `features:` frontmatter name. Case follows
     /// the upstream tc39/test262 tag, which varies by proposal —
-    /// kebab-case for newer tags (`joint-iteration`), PascalCase for
-    /// older ones (`ShadowRealm`).
+    /// kebab-case for newer tags (`joint-iteration`, graduated
+    /// 2026-07), PascalCase for older ones (`ShadowRealm`).
     pub fn name(self: FeatureFlag) []const u8 {
         return switch (self) {
-            .joint_iteration => "joint-iteration",
             .shadow_realm => "ShadowRealm",
         };
     }
@@ -48,7 +42,6 @@ pub const FeatureFlag = enum {
     /// One-line description for `cynic --list-features`.
     pub fn description(self: FeatureFlag) []const u8 {
         return switch (self) {
-            .joint_iteration => "Iterator.zip / Iterator.zipKeyed (Stage 3)",
             .shadow_realm => "ShadowRealm + cross-realm callable boundary (Stage 2.7)",
         };
     }

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -1040,10 +1040,10 @@ pub const Realm = struct {
     /// or `--enable-experimental`; the test262 harness sets this
     /// to `features.all()` so proposal fixtures actually exercise
     /// the surface they're testing. Read by gated installers (e.g.
-    /// `Iterator.zip`, `Map.prototype.getOrInsert`) before they
-    /// register their methods on the prototype, so a disabled
-    /// feature is invisible at the property-lookup level rather
-    /// than just throwing at call time.
+    /// the `ShadowRealm` constructor) before they register their
+    /// surface on the realm, so a disabled feature is invisible at
+    /// the property-lookup level rather than just throwing at call
+    /// time.
     feature_flags: FeatureSet = FeatureSet.empty,
     /// Heap-allocated bool cells tracking `[[ThisBindingStatus]]`
     /// for derived-class constructors that have outlived their

--- a/test262-results.md
+++ b/test262-results.md
@@ -4,7 +4,7 @@
 
 - **48571 passing** — Cynic produced the spec-expected result.
 - **1324 failing** — every other scored fixture. No "expected fail" category: an Annex-B / strict-only / SES / eval / not-yet-implemented-Intl miss counts as a plain fail, same as an engine bug. Honest, not flattering.
-- **Excluded from the denominator**: the upstream `harness/` and `staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal (decorators, import-defer, …), and structurally-unrunnable fixtures (no / malformed frontmatter). Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) get their own scoreboard below.
+- **Excluded from the denominator**: the upstream `harness/` and `staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal (decorators, import-defer, …), and structurally-unrunnable fixtures (no / malformed frontmatter). Shipped pre-Stage-4 proposals (ShadowRealm) get their own scoreboard below.
 
 ## Current scores
 
@@ -131,7 +131,6 @@ top-line score.
 
 | feature | passing | failing | total | pass% |
 |---|---:|---:|---:|---:|
-| `joint-iteration` | 82 | 0 | 82 | 100.0 % |
 | `ShadowRealm` | 63 | 1 | 64 | 98.4 % |
 
 

--- a/tools/bench.zig
+++ b/tools/bench.zig
@@ -150,8 +150,9 @@ fn runOnce(
 ) !Sample {
     const t0 = std.Io.Clock.now(.awake, io);
     // `--enable-experimental` flips every tracked pre-Stage-4
-    // proposal on (joint-iteration, upsert, tail-call-optimization)
-    // so fixtures gated on those flags execute the gated path. No
+    // proposal on (ShadowRealm today; joint-iteration and upsert
+    // graduated to default-on at Stage 4) so fixtures gated on
+    // those flags execute the gated path. No
     // effect on the older arith / alloc / promise fixtures, which
     // don't touch any gated surface. `--jit` (opt-in, mirroring the
     // engine default) measures the Bistromath posture with its

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -6,9 +6,8 @@
 //! Every fixture is scored a plain pass or fail under one posture
 //! (`--unhardened --allow=eval`); prints a final report.
 //!
-//! Pre-Stage-4 TC39 proposals Cynic ships (joint-iteration,
-//! ShadowRealm) are scored as their own dedicated phase sweeps — see
-//! `--phase`.
+//! Pre-Stage-4 TC39 proposals Cynic ships (ShadowRealm) are scored
+//! as their own dedicated phase sweeps — see `--phase`.
 //!
 //! Usage:
 //!   zig build test262 -- [flags]
@@ -1143,7 +1142,7 @@ const SkipReason = enum {
     /// compatibility but never produced by the current `classifyAndRun`.
     annex_b,
     /// Fixture is tagged with a pre-Stage-4 proposal — Cynic ships
-    /// shipped ones (joint-iteration, ShadowRealm) only in their
+    /// shipped ones (ShadowRealm) only in their
     /// dedicated feature phases, and unshipped ones (decorators,
     /// import-defer, …) drop here. Removed from `total` entirely;
     /// the headline only moves when Cynic does, not when TC39 lands
@@ -1307,7 +1306,7 @@ const Options = struct {
     /// run main + every tracked pre-Stage-4 feature in dedicated
     /// per-feature sweeps. Setting this pins the harness to one
     /// phase regardless of `--write-results`. Accepted spellings:
-    /// `--phase=main`, `--phase=feature:<flag>` (e.g. `feature:joint-iteration`).
+    /// `--phase=main`, `--phase=feature:<flag>` (e.g. `feature:ShadowRealm`).
     phase: ?Phase = null,
     /// Minimum acceptable `pass%` (= `passing / (passing + failing)`)
     /// for the headline sweep. When >0 and the run is unfiltered, a
@@ -1639,8 +1638,8 @@ const PreStage4Stats = struct {
 /// `stats`. Each `.feature` phase runs a dedicated sweep with
 /// only its one flag enabled, so the per-feature scoreboard
 /// reflects what each proposal looks like in isolation (a
-/// `joint-iteration` fixture runs in a realm where
-/// `Map.prototype.getOrInsert` is undefined, and vice versa).
+/// `ShadowRealm` fixture runs in a realm where only that one
+/// flag is enabled).
 const Phase = union(enum) {
     /// The headline sweep — runs every in-scope fixture under the
     /// single scored posture (`--unhardened --allow=eval`):
@@ -2883,7 +2882,7 @@ fn classifyAndRunInner(
     // policy reclassification.
     //
     // Pre-Stage-4 (Stage ≤ 3) proposals stay dropped: shipped ones
-    // (joint-iteration, ShadowRealm) are filtered above via the
+    // (ShadowRealm) are filtered above via the
     // `out_of_phase` gate so they only run in their dedicated feature
     // sweeps; unshipped ones (decorators, import-defer, …) drop here
     // via `.pre_stage4` — excluded from the corpus denominator.
@@ -4068,7 +4067,7 @@ fn writeFileBody(
                 "`staging/` paths, the whole `annexB/` tree, every Stage ≤ 3 proposal " ++
                 "(decorators, import-defer, …), and structurally-unrunnable fixtures " ++
                 "(no / malformed frontmatter). Shipped pre-Stage-4 proposals " ++
-                "(joint-iteration, ShadowRealm) get their own scoreboard below.\n\n",
+                "(ShadowRealm) get their own scoreboard below.\n\n",
             .{ r.pass_pct, r.total, r.passing, r.failing },
         );
         try out.appendSlice(gpa, tldr);

--- a/tools/test262/skip.zig
+++ b/tools/test262/skip.zig
@@ -17,8 +17,8 @@
 //!      hasn't implemented (decorators, import-defer, …). Dropped from
 //!      `total` so the headline can't decay as TC39 lands proposal
 //!      fixtures upstream. (Proposals Cynic *has* shipped —
-//!      joint-iteration, ShadowRealm — are kept out of the main rows
-//!      by the harness's per-phase feature-tag gate, not by this file,
+//!      ShadowRealm — are kept out of the main rows by the
+//!      harness's per-phase feature-tag gate, not by this file,
 //!      and get their own dedicated `feature:<name>` scoreboard.)
 
 const std = @import("std");
@@ -100,9 +100,9 @@ pub fn pathIsSkipped(rel_path: []const u8) bool {
 ///   - the proposal reaches **Stage 4** → it's specced, so it leaves
 ///     `stage_maturity_features` and re-enters `total`; or
 ///   - Cynic **implements** it → it graduates to a dedicated
-///     `feature:<name>` phase (a `FeatureFlag` — `joint-iteration`,
-///     `ShadowRealm`), kept out of the main rows by the harness's
-///     per-phase feature-tag gate.
+///     `feature:<name>` phase (a `FeatureFlag` — `ShadowRealm`),
+///     kept out of the main rows by the harness's per-phase
+///     feature-tag gate.
 pub fn featureIsUnimplementedProposal(feature: []const u8) bool {
     for (stage_maturity_features) |f| {
         if (std.mem.eql(u8, feature, f)) return true;
@@ -134,12 +134,14 @@ test "skip: pre-Stage-4 proposals dropped from total" {
     try testing.expect(featureIsUnimplementedProposal("source-phase-imports"));
     try testing.expect(featureIsUnimplementedProposal("await-dictionary"));
     try testing.expect(featureIsUnimplementedProposal("immutable-arraybuffer"));
-    // Shipped pre-Stage-4 proposals (joint-iteration, ShadowRealm) are
-    // NOT here — the harness keeps them out of the main rows via the
-    // per-phase feature-tag gate, and scores them in dedicated phases.
+    // Shipped pre-Stage-4 proposals (ShadowRealm) are NOT here —
+    // the harness keeps them out of the main rows via the per-phase
+    // feature-tag gate, and scores them in dedicated phases.
     try testing.expect(!featureIsUnimplementedProposal("ShadowRealm"));
+    // Shipped, specced features are runnable. `joint-iteration`
+    // reached Stage 4 in May 2026 and graduated to default-on
+    // (2026-07): its fixtures score in the main rollup now.
     try testing.expect(!featureIsUnimplementedProposal("joint-iteration"));
-    // Shipped, specced features are runnable.
     try testing.expect(!featureIsUnimplementedProposal("class"));
     try testing.expect(!featureIsUnimplementedProposal("regexp-modifiers"));
     try testing.expect(!featureIsUnimplementedProposal("explicit-resource-management"));


### PR DESCRIPTION
## Before / After

**Before:** `Iterator.zip(iterables)` and `Iterator.zipKeyed(iterables, options?)` only exist behind `--enable=joint-iteration` (or `--enable-experimental`); their 82 test262 fixtures score in a dedicated `feature:joint-iteration` sweep, outside the headline number.

**After:** both methods install unconditionally on the `Iterator` constructor — available by default in `cynic eval` / `run` / `repl` and for embedders. The `joint-iteration` flag is gone from `--list-features`, and the tagged fixtures flow into the main-phase denominator on the next full sweep.

**Why now:** the Joint Iteration proposal is listed in [tc39/proposals finished-proposals.md](https://github.com/tc39/proposals/blob/main/finished-proposals.md) — Stage 4, ES2027 bucket. Per the runbook comment at the top of `src/runtime/features.zig`, a Stage 4 advance means: remove the gate, remove the enum variant, let the fixtures re-enter the main rollup.

## How

Mirrors the 2026-05 `upsert` graduation (f48b7b01) exactly:

- `src/runtime/features.zig` — drop the `.joint_iteration` variant (+ its `name` / `description` arms). The test262 harness derives its phase list, per-feature scoreboard, and main-phase feature-tag gate comptime from this enum, so the dedicated sweep disappears and the fixtures re-enter the main phase with no harness logic changes.
- `src/runtime/builtins/iterator.zig` — remove the `realm.feature_flags.contains(.joint_iteration)` install gate; comment now cites §27.1.4.3 / §27.1.4.4 and the graduation date.
- `tools/test262.zig`, `tools/test262/skip.zig` — comment/doc updates plus the generated TL;DR string ("Shipped pre-Stage-4 proposals (ShadowRealm) …"); the skip.zig unit test reclassifies `joint-iteration` from the shipped-pre-Stage-4 group to the shipped-specced group (same assertion, new rationale).
- `test262-results.md` — drop the `joint-iteration` row from the pre-Stage-4 scoreboard (82/0/82 at the last sweep, so the headline should gain roughly those 82 passes on the next `--write-results` run).
- `AGENTS.md`, `README.md`, `docs/ROADMAP.md`, `docs/ses-alignment.md` — `ShadowRealm` (Stage 2.7) is now the only tracked pre-Stage-4 proposal; ROADMAP's "current set" gains a ShadowRealm bullet in place of the removed joint-iteration one, with a short graduation note.
- `src/runtime/realm.zig`, `tools/bench.zig` — stale example comments that named `Iterator.zip` / graduated flags as the gated-installer examples.

`shadow_realm` is untouched (still Stage 2.7). The historical entry in `docs/test262-upstream-gaps.md` that references the `joint-iteration` frontmatter tag is left as-is — it documents a fixture contribution proposal, not current engine state.

## Verification

Local build verification was not possible in this environment: no Zig toolchain is installed, and the network proxy 403-blocks ziglang.org and its mirrors (anyzig also fetches from ziglang.org, so installing it doesn't help). CI is the verification gate here — the gating `test-fast` and `test262-jit-differential` jobs plus the advisory `test262` sweep. Expected signal: unit tests pass unchanged (they run with `FeatureSet.full`, and the GC zip/zipKeyed tests now exercise the default-installed methods), and the advisory sweep's headline gains the ~82 formerly-feature-phase fixtures.