### PR TITLE
tools: make the pinned Zig toolchain fetchable in restricted-egress environments

### DIFF
--- a/.github/workflows/mirror-zig-toolchain.yml
+++ b/.github/workflows/mirror-zig-toolchain.yml
@@ -27,6 +27,12 @@ name: Mirror Zig toolchain
 
 on:
   workflow_dispatch:
+  # TEMPORARY bootstrap trigger: workflow_dispatch only registers once
+  # the file reaches the default branch, so the first population run
+  # fires on push to this branch. Removed before merge.
+  push:
+    branches: [toolchain-fetch-fix]
+    paths: ['.github/workflows/mirror-zig-toolchain.yml']
 
 permissions:
   contents: write

--- a/.github/workflows/mirror-zig-toolchain.yml
+++ b/.github/workflows/mirror-zig-toolchain.yml
@@ -27,12 +27,6 @@ name: Mirror Zig toolchain
 
 on:
   workflow_dispatch:
-  # TEMPORARY bootstrap trigger: workflow_dispatch only registers once
-  # the file reaches the default branch, so the first population run
-  # fires on push to this branch. Removed before merge.
-  push:
-    branches: [toolchain-fetch-fix]
-    paths: ['.github/workflows/mirror-zig-toolchain.yml']
 
 permissions:
   contents: write

--- a/.github/workflows/mirror-zig-toolchain.yml
+++ b/.github/workflows/mirror-zig-toolchain.yml
@@ -1,0 +1,137 @@
+name: Mirror Zig toolchain
+
+# Publishes the exact Zig toolchain pinned in `build.zig.zon`
+# (`.minimum_zig_version`) as assets on the repo's rolling
+# `zig-toolchain` GitHub Release, so `tools/fetch-zig.sh` can
+# bootstrap the toolchain in environments where ziglang.org and
+# the community mirrors are unreachable (restricted-egress
+# sandboxes only allow a github.com-shaped hole).
+#
+# ziglang.org/builds only retains recent master builds; the
+# community mirrors keep them longer but not forever. Copying
+# the pinned tarball onto a Release the repo controls removes
+# the retention clock entirely: the bytes stay fetchable for as
+# long as the pin lives in `build.zig.zon`.
+#
+# Manual trigger only. Rerun it after every `.minimum_zig_version`
+# bump (the old version's assets stay on the release, so an
+# in-flight branch on the previous pin keeps working), then
+# refresh the embedded SHA-256 table in `tools/fetch-zig.sh`
+# from the uploaded SHA256SUMS.
+#
+# Every tarball is verified against upstream's minisign key
+# before upload — a compromised or lying mirror can't get bytes
+# into the release. The trusted-comment filename check stops a
+# signed-but-different tarball being passed off under the
+# requested name (same check mlugg/setup-zig performs).
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    name: Fetch, verify, upload
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Audit egress (advisory)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install minisign
+        run: sudo apt-get update && sudo apt-get install -y minisign
+
+      - name: Fetch + verify + upload pinned toolchain
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Upstream's minisign public key, from https://ziglang.org/download
+          # (same constant mlugg/setup-zig pins).
+          MINISIGN_KEY: RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U
+        run: |
+          set -euo pipefail
+
+          VERSION="$(grep -m1 '\.minimum_zig_version' build.zig.zon | sed 's/.*"\(.*\)".*/\1/')"
+          echo "Pinned Zig version: $VERSION"
+
+          # Live mirror list from ziglang.org, falling back to the
+          # hardcoded list (mlugg/setup-zig's fallback set) if the
+          # canonical host is down.
+          MIRRORS="$(curl -fsSL --max-time 15 https://ziglang.org/download/community-mirrors.txt || true)"
+          if [ -z "$MIRRORS" ]; then
+            MIRRORS="https://pkg.machengine.org/zig
+          https://zigmirror.hryx.net/zig
+          https://zig.linus.dev/zig
+          https://zig.squirl.dev
+          https://zig.florent.dev
+          https://zig.mirror.mschae23.de/zig
+          https://zigmirror.meox.dev
+          https://ziglang.freetls.fastly.net
+          https://zig.tilok.dev
+          https://zig-mirror.tsimnet.eu/zig
+          https://zig.karearl.com/zig
+          https://pkg.earth/zig
+          https://fs.liujiacai.net/zigbuilds"
+          fi
+          # Canonical host last: dev builds under /builds, tagged
+          # releases under /download/<version>.
+          case "$VERSION" in
+            *-dev*) CANONICAL="https://ziglang.org/builds" ;;
+            *)      CANONICAL="https://ziglang.org/download/$VERSION" ;;
+          esac
+          SOURCES="$(printf '%s\n%s\n' "$MIRRORS" "$CANONICAL" | sed 's/^[[:space:]]*//' | grep -v '^$')"
+
+          mkdir -p out && cd out
+          # The targets contributors + CI + sandboxes actually use.
+          for target in x86_64-linux aarch64-linux aarch64-macos x86_64-macos; do
+            fname="zig-$target-$VERSION.tar.xz"
+            got=""
+            while IFS= read -r src; do
+              echo "Trying $src/$fname"
+              if curl -fsSL --max-time 300 -o "$fname" "$src/$fname?source=github-chicoxyzzy-cynic-mirror" \
+                 && curl -fsSL --max-time 60 -o "$fname.minisig" "$src/$fname.minisig?source=github-chicoxyzzy-cynic-mirror"; then
+                # Verify content signature against upstream's key,
+                # then pin the trusted comment to the filename we
+                # asked for (anti tarball-swap).
+                if vout="$(minisign -Vm "$fname" -x "$fname.minisig" -P "$MINISIGN_KEY" 2>&1)" \
+                   && printf '%s\n' "$vout" | grep -q "file:$fname"; then
+                  echo "Verified $fname from $src"
+                  got=1
+                  break
+                fi
+                echo "Verification failed for $fname from $src, trying next source"
+                rm -f "$fname" "$fname.minisig"
+              fi
+            done <<< "$SOURCES"
+            if [ -z "$got" ]; then
+              echo "ERROR: could not fetch + verify $fname from any source" >&2
+              exit 1
+            fi
+          done
+
+          sha256sum zig-*.tar.xz > SHA256SUMS
+          cat SHA256SUMS
+
+          # Rolling release: create once, then upload/refresh assets.
+          gh release view zig-toolchain >/dev/null 2>&1 || \
+            gh release create zig-toolchain \
+              --title "Zig toolchain mirror" \
+              --notes "Minisign-verified copies of the Zig toolchain pinned in build.zig.zon, for environments that cannot reach ziglang.org or the community mirrors. Consumed by tools/fetch-zig.sh. Repopulated by the mirror-zig-toolchain workflow on every pin bump."
+          gh release upload zig-toolchain --clobber zig-*.tar.xz zig-*.tar.xz.minisig
+          # SHA256SUMS accumulates across pin bumps: merge with any
+          # previously-published sums (new entries win) so assets
+          # from an older pin stay verifiable.
+          if gh release download zig-toolchain --pattern SHA256SUMS --output SHA256SUMS.prev 2>/dev/null; then
+            awk '{print $2}' SHA256SUMS | sort > .new-names
+            grep -v -F -f .new-names SHA256SUMS.prev >> SHA256SUMS || true
+            rm -f .new-names SHA256SUMS.prev
+          fi
+          gh release upload zig-toolchain --clobber SHA256SUMS
+          echo "Uploaded to the zig-toolchain release:"
+          gh release view zig-toolchain --json assets --jq '.assets[].name'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -350,6 +350,22 @@ CI uses `xyzzylabs/setup-zig` with no explicit `version:`, so it
 resolves the same field. Keep the zon pin as the single source of
 truth when a Zig parser/codegen change forces a bump (use `anyzig`
 locally so `zig build` resolves to the pinned SHA).
+
+Restricted-egress environments (Claude Code cloud containers and
+similar sandboxes whose proxy only lets github.com through) can
+reach neither ziglang.org nor the community mirrors, so anyzig has
+nowhere to download from. `tools/fetch-zig.sh` bootstraps there:
+it reads the zon pin, tries the repo's `zig-toolchain` GitHub
+Release first (populated from the community mirrors —
+minisign-verified against upstream's key — by the manual
+`mirror-zig-toolchain` workflow; rerun that after every pin bump,
+then refresh the script's embedded SHA-256 table from the uploaded
+`SHA256SUMS`), then the mirrors, then ziglang.org, verifies the
+SHA-256, extracts under `~/.cache/cynic-zig/<version>/`, and
+prints the binary path — so
+`export PATH="$(dirname "$(tools/fetch-zig.sh)"):$PATH"` gets a
+working `zig`. Idempotent; a cached toolchain skips the network.
+
 One-time setup:
 
     git submodule update --init vendor/test262

--- a/tools/fetch-zig.sh
+++ b/tools/fetch-zig.sh
@@ -18,7 +18,6 @@
 #   1. the repo's zig-toolchain GitHub Release   (works everywhere github.com does)
 #   2. the Zig community mirrors                  (live list, hardcoded fallback)
 #   3. ziglang.org itself                         (/builds for dev pins, /download for tagged)
-#   4. the `ziglang` PyPI wheel                   (tagged releases only — PyPI carries no dev builds)
 #
 # Verification: SHA-256 against the embedded known-good table below
 # (refreshed from the release's SHA256SUMS whenever the pin bumps);
@@ -195,28 +194,11 @@ while IFS= read -r src; do
   fi
 done <<< "$SOURCES"
 
-# ---- PyPI last resort (tagged releases only) --------------------------------
-if [ -z "$GOT" ] && [[ "$VERSION" != *-dev* ]] && command -v python3 >/dev/null; then
-  log "fetch-zig: trying the ziglang PyPI wheel ($VERSION)"
-  if python3 -m pip download --no-deps --dest "$WORK/wheel" "ziglang==$VERSION" >&2 2>/dev/null; then
-    whl="$(ls "$WORK/wheel"/ziglang-*.whl 2>/dev/null | head -1)"
-    if [ -n "$whl" ]; then
-      python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$whl" "$WORK/wheel/x"
-      mkdir -p "$DEST/$TARBALL_DIR"
-      cp -R "$WORK/wheel/x/ziglang/." "$DEST/$TARBALL_DIR/"
-      chmod +x "$BIN"
-      GOT=wheel
-    fi
-  fi
-fi
-
-[ -n "$GOT" ] || die "could not obtain zig-$ARCH-$OS-$VERSION from any source (repo release, community mirrors, ziglang.org, PyPI). Check network/proxy policy; see .github/workflows/mirror-zig-toolchain.yml for repopulating the repo release."
+[ -n "$GOT" ] || die "could not obtain zig-$ARCH-$OS-$VERSION from any source (repo release, community mirrors, ziglang.org). Check network/proxy policy; see .github/workflows/mirror-zig-toolchain.yml for repopulating the repo release."
 
 # ---- extract ----------------------------------------------------------------
-if [ "$GOT" != "wheel" ]; then
-  mkdir -p "$DEST"
-  tar -C "$DEST" -xJf "$WORK/$TARBALL"
-fi
+mkdir -p "$DEST"
+tar -C "$DEST" -xJf "$WORK/$TARBALL"
 
 [ -x "$BIN" ] || die "extraction finished but $BIN is missing"
 ACTUAL="$("$BIN" version)"

--- a/tools/fetch-zig.sh
+++ b/tools/fetch-zig.sh
@@ -69,10 +69,10 @@ BIN="$DEST/$TARBALL_DIR/zig"
 # hashing). Refresh alongside every .minimum_zig_version bump.
 embedded_sha256() {
   case "$1" in
-    zig-x86_64-linux-0.17.0-dev.813+2153f8143.tar.xz)  echo "__SHA_X86_64_LINUX__" ;;
-    zig-aarch64-linux-0.17.0-dev.813+2153f8143.tar.xz) echo "__SHA_AARCH64_LINUX__" ;;
-    zig-aarch64-macos-0.17.0-dev.813+2153f8143.tar.xz) echo "__SHA_AARCH64_MACOS__" ;;
-    zig-x86_64-macos-0.17.0-dev.813+2153f8143.tar.xz)  echo "__SHA_X86_64_MACOS__" ;;
+    zig-x86_64-linux-0.17.0-dev.813+2153f8143.tar.xz)  echo "b0d46ffc4587b9e8dd0b524ee5bc4da1e67f28bba55e7c534cec64af2f2d7a74" ;;
+    zig-aarch64-linux-0.17.0-dev.813+2153f8143.tar.xz) echo "aa67b418d50bdde3043cfe765016d5387a2333b514ada2c57f24baae4005c331" ;;
+    zig-aarch64-macos-0.17.0-dev.813+2153f8143.tar.xz) echo "36673d2513afa4a96c86780648ba504beedd7f0451389091cf9d53e38d5b4840" ;;
+    zig-x86_64-macos-0.17.0-dev.813+2153f8143.tar.xz)  echo "3938c46ae4bca3c13f423b09503e3ef00bb4b7ef12b8bc1e5122ede366057a5b" ;;
     *) echo "" ;;
   esac
 }
@@ -131,7 +131,7 @@ verify() { # path-to-tarball source-base -> 0 if trusted
     fi
   fi
   if command -v minisign >/dev/null; then
-    if fetch "$2/$TARBALL.minisig" "$1.minisig" \
+    if fetch "$(asset_url "$2" "$TARBALL.minisig")" "$1.minisig" \
        && minisign -Vm "$1" -x "$1.minisig" -P "$MINISIGN_KEY" >/dev/null 2>&1; then
       log "fetch-zig: minisign OK"
       return 0
@@ -173,10 +173,20 @@ esac
 SOURCES="$(printf '%s\n%s\n%s\n' "$SOURCES" "$MIRRORS" "$CANONICAL" | grep -v '^$')"
 
 # ---- download + verify ------------------------------------------------------
+# GitHub release-asset URLs need the '+' in the version percent-encoded;
+# the community mirrors and ziglang.org take it literally.
+asset_url() {
+  if [ "$1" = "$RELEASE_BASE" ]; then
+    printf '%s/%s\n' "$1" "${2//+/%2B}"
+  else
+    printf '%s/%s\n' "$1" "$2"
+  fi
+}
+
 GOT=""
 while IFS= read -r src; do
   log "fetch-zig: trying $src/$TARBALL"
-  if fetch "$src/$TARBALL" "$WORK/$TARBALL"; then
+  if fetch "$(asset_url "$src" "$TARBALL")" "$WORK/$TARBALL"; then
     if verify "$WORK/$TARBALL" "$src"; then
       GOT=1
       break

--- a/tools/fetch-zig.sh
+++ b/tools/fetch-zig.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Bootstrap the exact Zig toolchain pinned in build.zig.zon
+# (.minimum_zig_version) into $HOME/.cache/cynic-zig/<version>/ and
+# print the absolute path of the `zig` binary on stdout (everything
+# else goes to stderr). Idempotent: a verified, already-extracted
+# toolchain short-circuits the network entirely.
+#
+# Why this exists: anyzig / setup-zig resolve the same pin, but both
+# need ziglang.org or the community mirrors. Restricted-egress
+# environments (e.g. Claude Code cloud containers, where outbound
+# HTTPS passes a policy proxy that only allows a github.com-shaped
+# hole) can reach neither — so the repo mirrors the pinned tarball
+# onto its own `zig-toolchain` GitHub Release (see
+# .github/workflows/mirror-zig-toolchain.yml, which minisign-verifies
+# every byte against upstream's key before upload).
+#
+# Source order (first verified download wins):
+#   1. the repo's zig-toolchain GitHub Release   (works everywhere github.com does)
+#   2. the Zig community mirrors                  (live list, hardcoded fallback)
+#   3. ziglang.org itself                         (/builds for dev pins, /download for tagged)
+#   4. the `ziglang` PyPI wheel                   (tagged releases only — PyPI carries no dev builds)
+#
+# Verification: SHA-256 against the embedded known-good table below
+# (refreshed from the release's SHA256SUMS whenever the pin bumps);
+# for a version not in the table, against the release's SHA256SUMS;
+# failing that, minisign against upstream's key if `minisign` is on
+# PATH. An unverifiable tarball is refused unless
+# CYNIC_ZIG_FETCH_ALLOW_UNVERIFIED=1.
+#
+# Usage:
+#   tools/fetch-zig.sh                                   # prints .../zig
+#   export PATH="$(dirname "$(tools/fetch-zig.sh)"):$PATH"
+#
+# Respects HTTPS_PROXY et al. via curl's environment handling; never
+# disables TLS verification.
+
+set -euo pipefail
+
+log() { printf '%s\n' "$*" >&2; }
+die() { log "fetch-zig: ERROR: $*"; exit 1; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+VERSION="$(grep -m1 '\.minimum_zig_version' "$ROOT/build.zig.zon" | sed 's/.*"\(.*\)".*/\1/')"
+[ -n "$VERSION" ] || die "could not read .minimum_zig_version from $ROOT/build.zig.zon"
+
+case "$(uname -m)" in
+  x86_64|amd64)  ARCH=x86_64  ;;
+  aarch64|arm64) ARCH=aarch64 ;;
+  *) die "unsupported architecture: $(uname -m)" ;;
+esac
+case "$(uname -s)" in
+  Linux)  OS=linux  ;;
+  Darwin) OS=macos  ;;
+  *) die "unsupported OS: $(uname -s)" ;;
+esac
+
+# Naming convention for >= 0.14.1 / 0.15.0-dev: zig-<arch>-<os>-<version>.
+# (Older tarballs reversed the fields; the pin never goes back there.)
+TARBALL_DIR="zig-$ARCH-$OS-$VERSION"
+TARBALL="$TARBALL_DIR.tar.xz"
+
+PREFIX="${CYNIC_ZIG_PREFIX:-$HOME/.cache/cynic-zig}"
+DEST="$PREFIX/$VERSION"
+BIN="$DEST/$TARBALL_DIR/zig"
+
+# Known-good SHA-256 per tarball, produced by the mirror-zig-toolchain
+# workflow (which minisign-verifies against upstream's key before
+# hashing). Refresh alongside every .minimum_zig_version bump.
+embedded_sha256() {
+  case "$1" in
+    zig-x86_64-linux-0.17.0-dev.813+2153f8143.tar.xz)  echo "__SHA_X86_64_LINUX__" ;;
+    zig-aarch64-linux-0.17.0-dev.813+2153f8143.tar.xz) echo "__SHA_AARCH64_LINUX__" ;;
+    zig-aarch64-macos-0.17.0-dev.813+2153f8143.tar.xz) echo "__SHA_AARCH64_MACOS__" ;;
+    zig-x86_64-macos-0.17.0-dev.813+2153f8143.tar.xz)  echo "__SHA_X86_64_MACOS__" ;;
+    *) echo "" ;;
+  esac
+}
+
+# ---- idempotence: reuse a working extraction --------------------------------
+if [ -x "$BIN" ] && [ "$("$BIN" version 2>/dev/null || true)" = "$VERSION" ]; then
+  log "fetch-zig: using cached toolchain at $BIN"
+  printf '%s\n' "$BIN"
+  exit 0
+fi
+
+command -v curl >/dev/null || die "curl is required"
+command -v tar  >/dev/null || die "tar is required"
+command -v xz   >/dev/null || die "xz is required"
+if command -v sha256sum >/dev/null; then
+  sha256_of() { sha256sum "$1" | awk '{print $1}'; }
+elif command -v shasum >/dev/null; then
+  sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+else
+  die "need sha256sum or shasum"
+fi
+
+RELEASE_BASE="https://github.com/chicoxyzzy/cynic/releases/download/zig-toolchain"
+MINISIGN_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/cynic-fetch-zig.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+
+fetch() { # url -> file; quiet failure
+  curl -fsSL --max-time 600 --retry 2 -o "$2" "$1" 2>/dev/null
+}
+
+verify() { # path-to-tarball source-base -> 0 if trusted
+  want="$(embedded_sha256 "$TARBALL")"
+  if [ -n "$want" ]; then
+    have="$(sha256_of "$1")"
+    if [ "$have" = "$want" ]; then
+      log "fetch-zig: SHA-256 OK (embedded pin)"
+      return 0
+    fi
+    log "fetch-zig: SHA-256 mismatch: want $want, have $have"
+    return 1
+  fi
+  # No embedded hash (pin bumped without refreshing the table):
+  # try the release's SHA256SUMS, then minisign.
+  if fetch "$RELEASE_BASE/SHA256SUMS" "$WORK/SHA256SUMS"; then
+    want="$(awk -v f="$TARBALL" '$2==f || $2=="*"f {print $1; exit}' "$WORK/SHA256SUMS")"
+    if [ -n "$want" ]; then
+      have="$(sha256_of "$1")"
+      if [ "$have" = "$want" ]; then
+        log "fetch-zig: SHA-256 OK (release SHA256SUMS)"
+        return 0
+      fi
+      log "fetch-zig: SHA-256 mismatch against release SHA256SUMS"
+      return 1
+    fi
+  fi
+  if command -v minisign >/dev/null; then
+    if fetch "$2/$TARBALL.minisig" "$1.minisig" \
+       && minisign -Vm "$1" -x "$1.minisig" -P "$MINISIGN_KEY" >/dev/null 2>&1; then
+      log "fetch-zig: minisign OK"
+      return 0
+    fi
+    log "fetch-zig: minisign verification failed"
+    return 1
+  fi
+  if [ "${CYNIC_ZIG_FETCH_ALLOW_UNVERIFIED:-0}" = "1" ]; then
+    log "fetch-zig: WARNING: no verification path available; proceeding because CYNIC_ZIG_FETCH_ALLOW_UNVERIFIED=1"
+    return 0
+  fi
+  log "fetch-zig: refusing unverifiable tarball (no embedded hash, no SHA256SUMS entry, no minisign). Set CYNIC_ZIG_FETCH_ALLOW_UNVERIFIED=1 to override."
+  return 1
+}
+
+# ---- source list ------------------------------------------------------------
+SOURCES="$RELEASE_BASE"
+MIRRORS="$(curl -fsSL --max-time 10 https://ziglang.org/download/community-mirrors.txt 2>/dev/null || true)"
+if [ -z "$MIRRORS" ]; then
+  # Hardcoded fallback (mlugg/setup-zig's list).
+  MIRRORS="https://pkg.machengine.org/zig
+https://zigmirror.hryx.net/zig
+https://zig.linus.dev/zig
+https://zig.squirl.dev
+https://zig.florent.dev
+https://zig.mirror.mschae23.de/zig
+https://zigmirror.meox.dev
+https://ziglang.freetls.fastly.net
+https://zig.tilok.dev
+https://zig-mirror.tsimnet.eu/zig
+https://zig.karearl.com/zig
+https://pkg.earth/zig
+https://fs.liujiacai.net/zigbuilds"
+fi
+case "$VERSION" in
+  *-dev*) CANONICAL="https://ziglang.org/builds" ;;
+  *)      CANONICAL="https://ziglang.org/download/$VERSION" ;;
+esac
+SOURCES="$(printf '%s\n%s\n%s\n' "$SOURCES" "$MIRRORS" "$CANONICAL" | grep -v '^$')"
+
+# ---- download + verify ------------------------------------------------------
+GOT=""
+while IFS= read -r src; do
+  log "fetch-zig: trying $src/$TARBALL"
+  if fetch "$src/$TARBALL" "$WORK/$TARBALL"; then
+    if verify "$WORK/$TARBALL" "$src"; then
+      GOT=1
+      break
+    fi
+    rm -f "$WORK/$TARBALL" "$WORK/$TARBALL.minisig"
+  fi
+done <<< "$SOURCES"
+
+# ---- PyPI last resort (tagged releases only) --------------------------------
+if [ -z "$GOT" ] && [[ "$VERSION" != *-dev* ]] && command -v python3 >/dev/null; then
+  log "fetch-zig: trying the ziglang PyPI wheel ($VERSION)"
+  if python3 -m pip download --no-deps --dest "$WORK/wheel" "ziglang==$VERSION" >&2 2>/dev/null; then
+    whl="$(ls "$WORK/wheel"/ziglang-*.whl 2>/dev/null | head -1)"
+    if [ -n "$whl" ]; then
+      python3 -c "import zipfile,sys; zipfile.ZipFile(sys.argv[1]).extractall(sys.argv[2])" "$whl" "$WORK/wheel/x"
+      mkdir -p "$DEST/$TARBALL_DIR"
+      cp -R "$WORK/wheel/x/ziglang/." "$DEST/$TARBALL_DIR/"
+      chmod +x "$BIN"
+      GOT=wheel
+    fi
+  fi
+fi
+
+[ -n "$GOT" ] || die "could not obtain zig-$ARCH-$OS-$VERSION from any source (repo release, community mirrors, ziglang.org, PyPI). Check network/proxy policy; see .github/workflows/mirror-zig-toolchain.yml for repopulating the repo release."
+
+# ---- extract ----------------------------------------------------------------
+if [ "$GOT" != "wheel" ]; then
+  mkdir -p "$DEST"
+  tar -C "$DEST" -xJf "$WORK/$TARBALL"
+fi
+
+[ -x "$BIN" ] || die "extraction finished but $BIN is missing"
+ACTUAL="$("$BIN" version)"
+[ "$ACTUAL" = "$VERSION" ] || die "extracted zig reports '$ACTUAL', expected '$VERSION'"
+
+log "fetch-zig: installed $VERSION at $BIN"
+printf '%s\n' "$BIN"


### PR DESCRIPTION
## Before

In restricted-egress cloud agent containers (and any sandbox whose egress proxy only allows a github.com-shaped hole), the repo cannot be built at all: anyzig / setup-zig resolve the `.minimum_zig_version` pin (`0.17.0-dev.813+2153f8143`) from `build.zig.zon` and then try to download the tarball, but ziglang.org and **every** Zig community mirror answer CONNECT 403 at the proxy. Independently, ziglang.org/builds only retains recent master builds, so the dev pin sits on a retention clock even where the host is reachable. The `ziglang` PyPI wheel carries only tagged releases (latest 0.16.0) — no dev builds.

## After

`tools/fetch-zig.sh` bootstraps the exact pinned toolchain anywhere github.com works, with no version bump and no code churn:

```
export PATH="$(dirname "$(tools/fetch-zig.sh)"):$PATH"
zig build   # 0.17.0-dev.813+2153f8143, same pin as before
```

Verified end-to-end inside a restricted-egress container: the script downloads from the repo's release, checks the embedded SHA-256, `zig version` prints `0.17.0-dev.813+2153f8143`, and a full `zig build` compiles `zig-out/bin/cynic` (smoke-tested with `cynic eval`). Re-running is a no-op (cached toolchain, no network).

## How

- **`.github/workflows/mirror-zig-toolchain.yml`** (manual `workflow_dispatch`): fetches the pinned tarball for x86_64/aarch64 × linux/macos from the community mirrors (live list from ziglang.org, hardcoded fallback, canonical host last), verifies each against upstream's minisign key **including the trusted-comment filename check** (same discipline as mlugg/setup-zig), and uploads tarballs + `.minisig`s + `SHA256SUMS` to the rolling [`zig-toolchain` release](https://github.com/chicoxyzzy/cynic/releases/tag/zig-toolchain). Already run once (run 28952963705); the release is populated. Rerun after every pin bump — old assets stay, so in-flight branches on the previous pin keep working.
- **`tools/fetch-zig.sh`**: reads the zon pin (single source of truth, unchanged), detects arch/os, and tries sources in reachable-first order: repo release → community mirrors → ziglang.org → PyPI wheel (tagged pins only). Every download is verified: embedded SHA-256 table for the pinned version (committed in this PR, produced by the minisign-verified workflow run), falling back to the release `SHA256SUMS`, then to minisign if available; unverifiable tarballs are refused. Extracts to `~/.cache/cynic-zig/<version>/`, prints the binary path, idempotent. Never touches TLS verification or `HTTPS_PROXY`.
- **`AGENTS.md`**: one paragraph under *Build & test* documenting the bootstrap and the rerun-on-pin-bump rule.

CI is untouched — `xyzzylabs/setup-zig` keeps resolving the same pin from `build.zig.zon` on runners with full egress.