### PR TITLE
zig: bump pin to latest master 0.17.0-dev.1275+59a628c6d

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,7 +7,7 @@
     // CI's setup-zig action resolves the same field, so keep this
     // pin as the single source of truth when a Zig parser/codegen
     // change forces a bump.
-    .minimum_zig_version = "0.17.0-dev.813+2153f8143",
+    .minimum_zig_version = "0.17.0-dev.1275+59a628c6d",
     .dependencies = .{},
     .paths = .{
         "build.zig",

--- a/tools/fetch-zig.sh
+++ b/tools/fetch-zig.sh
@@ -68,6 +68,10 @@ BIN="$DEST/$TARBALL_DIR/zig"
 # hashing). Refresh alongside every .minimum_zig_version bump.
 embedded_sha256() {
   case "$1" in
+    zig-x86_64-linux-0.17.0-dev.1275+59a628c6d.tar.xz)  echo "04e8baddd0497042889d3ee9ae53238e0655c2b9777039827b131487a7465d16" ;;
+    zig-aarch64-linux-0.17.0-dev.1275+59a628c6d.tar.xz) echo "8416c149489e644f81fcb517e9cf0a1e2975fbcc0e05639671054beddbbefcbb" ;;
+    zig-aarch64-macos-0.17.0-dev.1275+59a628c6d.tar.xz) echo "cabf8db92c381bda5a160fda8fa54ffa64f0964316c0d5b1dc385a7437e1691b" ;;
+    zig-x86_64-macos-0.17.0-dev.1275+59a628c6d.tar.xz)  echo "a4f73cfbdee89168eb493eb5df1fba4f1b7eead376d56a9f2a4c242ac13cc725" ;;
     zig-x86_64-linux-0.17.0-dev.813+2153f8143.tar.xz)  echo "b0d46ffc4587b9e8dd0b524ee5bc4da1e67f28bba55e7c534cec64af2f2d7a74" ;;
     zig-aarch64-linux-0.17.0-dev.813+2153f8143.tar.xz) echo "aa67b418d50bdde3043cfe765016d5387a2333b514ada2c57f24baae4005c331" ;;
     zig-aarch64-macos-0.17.0-dev.813+2153f8143.tar.xz) echo "36673d2513afa4a96c86780648ba504beedd7f0451389091cf9d53e38d5b4840" ;;


### PR DESCRIPTION
Bumps `.minimum_zig_version` from `0.17.0-dev.813+2153f8143` to `0.17.0-dev.1275+59a628c6d` (the latest master build, published 2026-07-07).

Builds on #59's toolchain-mirror infrastructure (`tools/fetch-zig.sh` + the `mirror-zig-toolchain` workflow) — this branch includes #59's commits and rebases to a two-file diff once #59 merges.

## What changed

- `build.zig.zon`: `.minimum_zig_version` → `0.17.0-dev.1275+59a628c6d` (anyzig locally and setup-zig in CI both resolve this field, so no workflow edits needed).
- `tools/fetch-zig.sh`: embedded SHA-256 table extended with the four new tarballs (x86_64-linux, aarch64-linux, aarch64-macos, x86_64-macos). Old-pin entries kept so in-flight branches on the previous pin keep bootstrapping.

## Toolchain mirror

The `mirror-zig-toolchain` workflow was dispatched against this branch ([run 28954665187](https://github.com/chicoxyzzy/cynic/actions/runs/28954665187), success) — the new tarballs are already minisign-verified and uploaded to the `zig-toolchain` release, and the release `SHA256SUMS` is refreshed. The embedded hashes were sourced from the zig-overlay nightly tracker and independently confirmed by the workflow's minisign-verified SHA256SUMS — the two chains agree byte-for-byte on all four tarballs.

## API drift

None. The ~460-commit window (dev.813 → dev.1275) required zero source changes: `zig build` compiles clean with the new toolchain, no stdlib or language-level breakage anywhere in `src/`, `tools/`, or the test suites.

## Verification

- `zig build` (default, `-Dintl=off`): clean.
- `zig build test-fast` (ReleaseSafe unit suite): green, exit 0, run twice for seed stability. (One initial run had a non-reproducible test-binary abort that did not recur across two subsequent full runs with different seeds; noting it for the record.)
- Full `zig build test262 -- --quiet` sweep:
  ```
  passing:  48571
  failing:  1324
  pass%:    97.35% — passing / (passing + failing)
  ```
  Identical to the recorded baseline in `test262-results.md` (48571 / 1324 / 97.35 %) — zero conformance regressions.

The JIT differential (`test262-jit-differential`) is aarch64-only and could not be exercised on this x86_64 container; CI covers it.