### PR TITLE
perf: per-shape key→slot hash index for deep transition chains (string_concat −30%)

### DIFF
--- a/docs/inline-caches.md
+++ b/docs/inline-caches.md
@@ -546,6 +546,68 @@ optional type-system tightening if a coherence regression ever traces
 here. Phased plan + invariants in
 [docs/lazy-property-bag.md](lazy-property-bag.md).
 
+## The shape key index — killing the O(depth) miss walk
+
+`Shape.lookup` resolves an own property by walking the transition
+chain to the root, one `std.mem.eql` per node. That's fine on IC
+hits (the key is never consulted) and on small objects, but the
+megamorphic-miss path pays it in full — and callgrind put the walk
+plus its memcmp at ~16 % of `deltablue` and ~12 % of
+`string_concat` instructions, the exact residue the interned-keys
+post-mortem said future property work must target
+([interned-keys.md](interned-keys.md) §11: kill the walk length;
+atom identity alone was a measured dead-end).
+
+The fix is the standard one — V8 switches DescriptorArray search
+from linear to hash-based past a size threshold, JSC materialises
+a `PropertyTable` on its Structures, SpiderMonkey keeps a
+`PropertyMap` table — adapted to Cynic's substrate in
+`shape.zig`:
+
+- **`KeyIndex`** — an open-addressed key→entry table covering one
+  shape's FULL chain (self → root), built lazily by the first slow
+  lookup that pays for a whole un-indexed walk. Slots hold shape
+  nodes; each node caches its key's Wyhash (`key_hash`) for the
+  build and the probe's early-out. Nearest-node-wins insertion
+  reproduces the linear walk's shadowing order, so
+  `redefineTransition` chains (the SES freeze path) resolve
+  byte-identically.
+- **Depth gate at 16, not V8's 8.** V8's linear cutoff assumes
+  interned Names with a *cached* hash; Cynic hashes the key bytes
+  per probe, which moves the break-even up. Measured: indexing
+  depth-8-12 chains regressed `deltablue` ~9 % (the probe's
+  Wyhash matches the short walk it replaces, and the anchor
+  bookkeeping taxed every lookup); at 16 the sub-threshold path
+  is the exact pre-index walk — one u32 depth compare is the
+  whole feature cost — and the deep-chain machinery lives in a
+  `noinline` `lookupDeep` (the `slowLdaGlobal` i-cache lesson).
+- **Descendants reuse an ancestor's index**: scan the short
+  un-indexed tail linearly first (preserving nearest-wins), then
+  probe the nearest indexed ancestor; a leaf builds its own index
+  once its full-tail walks cross the thresholds, converging hot
+  shapes to a pure probe.
+- **Bounded under hostile input** (the never-unbounded-growth
+  contract, [handbook/host-safety.md](handbook/host-safety.md)):
+  builds draw from a tree-wide slot budget linear in the node
+  count, then fall back to a geometric distance-doubling rule, so
+  an adversarial add-one-property-then-lookup loop gets O(n)
+  total index memory, not O(n²). An OOM during a build just skips
+  the index — `lookup` itself cannot fail.
+- **No GC interaction.** Indexes and keys are `ShapeTree`-arena
+  allocations (realm-lifetime, untraced), same as the shapes
+  themselves. The arena moved behind a stable heap pointer so a
+  bare `*Shape` can reach it for lazy builds.
+
+Measured (interleaved A/B vs the pre-index baseline, with an A/A
+control at ±2-3 %): `string_concat` **−30 %** (its
+`(n).toString()` loop resolves the `Number` ctor through the
+~25-deep global-object shape every iteration — the walk was 252
+Ir/call, now a probe), `deltablue` +0.7 % Ir (neutral — its
+chains sit below the gate by design), every other micro/macro
+within noise. The dictionary-mode bag probes that share the
+`string_concat` cluster (`decl_env` + demoted primordial
+prototypes) are a separate, still-open target.
+
 ## Conformance risks (where IC changes can break test262)
 
 - **§10.1.11 enumeration order** — integer keys ascending, then

--- a/src/runtime/shape.zig
+++ b/src/runtime/shape.zig
@@ -30,10 +30,17 @@ const PropertyFlags = @import("object.zig").PropertyFlags;
 pub const PropKind = enum(u1) { data, accessor };
 
 /// Chains shorter than this stay on the plain linear walk — a
-/// couple of `mem.eql`s beat a hash + probe at low depth. Same
-/// cutoff V8 uses for linear DescriptorArray search (8) and JSC
-/// for Structure lookup before the PropertyTable materialises.
-pub const index_min_depth: u32 = 8;
+/// few `mem.eql`s beat a hash + probe at low depth. V8 cuts over
+/// from linear DescriptorArray search at 8 descriptors, but its
+/// keys are interned Names with a *cached* hash; Cynic hashes the
+/// key bytes on every probe (atom interning was a measured
+/// dead-end — docs/interned-keys.md §11), which moves the
+/// break-even up. Measured on this codebase: indexing depth-8-12
+/// chains regressed deltablue ~9% (the probe's Wyhash matches the
+/// short walk it replaces, and the anchor bookkeeping taxes every
+/// lookup), while the depth-25+ global-object chain won ~30%
+/// (string_concat). 16 keeps both.
+pub const index_min_depth: u32 = 16;
 
 /// Don't bother building a leaf index when the un-indexed tail
 /// above the nearest indexed ancestor is this short — the tail
@@ -143,17 +150,36 @@ pub const Shape = struct {
         kind: PropKind,
     };
 
-    /// Resolve own property `key`. Shallow chains walk the
-    /// transition chain linearly to the root (nearest node wins,
-    /// which is what makes redefine transitions shadow their
-    /// ancestor entry). Deep chains resolve through the lazily
-    /// built `KeyIndex` — either this shape's own, or the nearest
-    /// indexed ancestor's after a short linear tail scan (the tail
-    /// is scanned FIRST, so nearest-wins shadowing is preserved).
-    /// An inline cache keyed on the shape still collapses the hot
-    /// monomorphic path to O(1) before any of this runs; the index
-    /// is the megamorphic-miss path's rescue.
+    /// Resolve own property `key`. Chains shallower than
+    /// `index_min_depth` take exactly the pre-index linear walk —
+    /// one extra `depth` compare is the whole cost of the feature
+    /// on small shapes (nearest node wins, which is what makes
+    /// redefine transitions shadow their ancestor entry). Deep
+    /// chains route to `lookupDeep`, which resolves through the
+    /// lazily built `KeyIndex`. An inline cache keyed on the shape
+    /// still collapses the hot monomorphic path to O(1) before any
+    /// of this runs; the index is the megamorphic-miss path's
+    /// rescue.
     pub fn lookup(self: *Shape, key: []const u8) ?Entry {
+        if (self.depth >= index_min_depth) return self.lookupDeep(key);
+        var node: *const Shape = self;
+        while (true) {
+            if (node.parent == null) return null; // root adds no property
+            if (std.mem.eql(u8, node.key, key)) {
+                return .{ .slot = node.slot, .attrs = node.attrs, .kind = node.kind };
+            }
+            node = node.parent.?;
+        }
+    }
+
+    /// Deep-chain resolution: probe this shape's own index, else
+    /// scan the un-indexed tail linearly (nearest-wins shadowing
+    /// is preserved because the tail is scanned FIRST) and probe
+    /// the nearest indexed ancestor. A lookup that paid for the
+    /// whole tail tries to materialise a leaf index so the next
+    /// one is a pure probe. Kept out of `lookup` so the shallow
+    /// path stays tight in the i-cache.
+    noinline fn lookupDeep(self: *Shape, key: []const u8) ?Entry {
         if (self.index) |idx| return idx.find(key, hashKey(key));
         var node: *Shape = self;
         var anchor: ?*Shape = null;
@@ -172,32 +198,37 @@ pub const Shape = struct {
             }
             node = node.parent.?;
         }
-        if (anchor) |a| result = a.index.?.find(key, hashKey(key));
         // Only a lookup that paid for the whole un-indexed tail is
-        // evidence this shape is hot enough to index.
-        if (walked_full_tail) self.maybeBuildIndex(if (anchor) |a| a.depth else 0);
+        // evidence this shape is hot enough to index. Build BEFORE
+        // probing the ancestor so the fresh leaf index serves this
+        // resolution too.
+        if (walked_full_tail and self.maybeBuildIndex(if (anchor) |a| a.depth else 0)) {
+            return self.index.?.find(key, hashKey(key));
+        }
+        if (anchor) |a| result = a.index.?.find(key, hashKey(key));
         return result;
     }
 
-    /// Decide whether the walk `lookup` just paid justifies
-    /// materialising an index at this shape. Two throttles keep
-    /// index memory O(node_count) under adversarial
-    /// add-then-lookup loops (never-unbounded-growth,
-    /// docs/handbook/host-safety.md): a tree-wide slot budget
-    /// linear in the node count, and past it a geometric rule —
-    /// only build when the un-indexed tail is more than half the
-    /// chain, so index depths at least double along any path.
-    fn maybeBuildIndex(self: *Shape, anchor_depth: u32) void {
-        if (self.depth < index_min_depth) return;
+    /// Decide whether the walk `lookupDeep` just paid justifies
+    /// materialising an index at this shape; returns true when one
+    /// was built. Two throttles keep index memory O(node_count)
+    /// under adversarial add-then-lookup loops
+    /// (never-unbounded-growth, docs/handbook/host-safety.md): a
+    /// tree-wide slot budget linear in the node count, and past it
+    /// a geometric rule — only build when the un-indexed tail is
+    /// more than half the chain, so index depths at least double
+    /// along any path.
+    fn maybeBuildIndex(self: *Shape, anchor_depth: u32) bool {
         const tail = self.depth - anchor_depth;
-        if (tail < index_min_tail) return;
-        const cap = indexCapacity(self.property_count) orelse return;
+        if (tail < index_min_tail) return false;
+        const cap = indexCapacity(self.property_count) orelse return false;
         const under_budget = self.ctx.index_slots_total + cap <=
             index_budget_base + index_budget_per_node * self.ctx.node_count;
         const geometric = 2 * @as(u64, tail) > self.depth;
-        if (!under_budget and !geometric) return;
+        if (!under_budget and !geometric) return false;
         // OOM → skip the index; the linear walk stays correct.
-        self.buildIndex(cap) catch return;
+        self.buildIndex(cap) catch return false;
+        return self.index != null;
     }
 
     /// Power-of-two table size with load factor ≤ ~0.5. The chain
@@ -557,7 +588,7 @@ test "redefine transition shadows correctly through the index" {
     // Redefine BELOW the index build point: freeze p3, then look up
     // at the leaf — the index must carry the redefined attrs, not
     // the original ancestor entry.
-    const base = try buildChain(&tree, 10);
+    const base = try buildChain(&tree, 18);
     const frozen: PropertyFlags = .{ .writable = false, .enumerable = true, .configurable = false };
     const leaf = try tree.redefineTransition(base, "p3", frozen);
 
@@ -578,8 +609,8 @@ test "descendant reuses an ancestor's index through the tail walk" {
     var tree = try ShapeTree.init(testing.allocator);
     defer tree.deinit();
 
-    const mid = try buildChain(&tree, 12);
-    try testing.expect(mid.lookup("absent") == null); // builds at depth 12
+    const mid = try buildChain(&tree, 20);
+    try testing.expect(mid.lookup("absent") == null); // builds at depth 20
     try testing.expect(mid.index != null);
 
     // Two more appends + one redefine: short tail above the anchor.
@@ -589,7 +620,7 @@ test "descendant reuses an ancestor's index through the tail walk" {
     leaf = try tree.redefineTransition(leaf, "p5", frozen);
 
     // Tail keys (nearest) win; anchored keys resolve via the probe.
-    try testing.expectEqual(@as(u32, 12), leaf.lookup("q0").?.slot);
+    try testing.expectEqual(@as(u32, 20), leaf.lookup("q0").?.slot);
     try testing.expect(!leaf.lookup("q1").?.attrs.enumerable);
     try testing.expect(!leaf.lookup("p5").?.attrs.writable); // tail redefine shadows index
     try testing.expectEqual(@as(u32, 0), leaf.lookup("p0").?.slot); // via ancestor index
@@ -602,7 +633,7 @@ test "accessor kind survives the index" {
     var tree = try ShapeTree.init(testing.allocator);
     defer tree.deinit();
 
-    var s = try buildChain(&tree, 9);
+    var s = try buildChain(&tree, 17);
     s = try tree.transition(s, "getterProp", .{ .enumerable = false }, .accessor);
     try testing.expect(s.lookup("absent") == null); // builds
     const e = s.lookup("getterProp").?;

--- a/src/runtime/shape.zig
+++ b/src/runtime/shape.zig
@@ -29,6 +29,70 @@ const PropertyFlags = @import("object.zig").PropertyFlags;
 /// keeps a data-property inline cache from firing on an accessor.
 pub const PropKind = enum(u1) { data, accessor };
 
+/// Chains shorter than this stay on the plain linear walk — a
+/// couple of `mem.eql`s beat a hash + probe at low depth. Same
+/// cutoff V8 uses for linear DescriptorArray search (8) and JSC
+/// for Structure lookup before the PropertyTable materialises.
+pub const index_min_depth: u32 = 8;
+
+/// Don't bother building a leaf index when the un-indexed tail
+/// above the nearest indexed ancestor is this short — the tail
+/// scan is already cheap and the ancestor probe does the rest.
+pub const index_min_tail: u32 = 4;
+
+/// Index-memory budget (in table slots) that lazy builds may
+/// consume freely: `base + per_node × node_count`. Within the
+/// budget every slow-lookup-hit shape gets its own index (tail
+/// collapses to zero); past it, only the geometric
+/// distance-doubling rule below builds, so total index memory
+/// stays O(node_count) even under an adversarial
+/// add-one-property-then-lookup loop (the never-unbounded-growth
+/// contract, docs/handbook/host-safety.md).
+pub const index_budget_base: u64 = 64;
+pub const index_budget_per_node: u64 = 8;
+
+/// Shapes wider than this never get an index (the table would be
+/// multi-MiB; a linear walk that long is a degenerate object the
+/// caller should have demoted to dictionary mode anyway).
+const index_max_indexed_props: u32 = 1 << 20;
+
+inline fn hashKey(key: []const u8) u32 {
+    return @truncate(std.hash.Wyhash.hash(0, key));
+}
+
+/// Tree-wide shared state: the (pointer-stable) arena every shape
+/// and index is allocated from, plus the counters the index-budget
+/// rule reads. One per `ShapeTree`, allocated from its own arena.
+pub const ShapeCtx = struct {
+    arena: *std.heap.ArenaAllocator,
+    node_count: u64 = 0,
+    index_slots_total: u64 = 0,
+};
+
+/// Open-addressed key→entry hash table over one shape's full
+/// chain (self → root), replacing the O(depth) parent walk with
+/// O(1) probes. Analogue of V8's hash-mode descriptor lookup /
+/// JSC's `PropertyTable` / SpiderMonkey's `PropertyMap` table.
+/// Immutable once published on the shape (shapes never change
+/// after creation; descendants layer a linear tail on top).
+/// Slots hold shape nodes — key, cached hash, slot, attrs, kind
+/// all live on the node. Load factor ≤ ~0.5, so a probe always
+/// terminates on an empty slot.
+pub const KeyIndex = struct {
+    slots: []?*const Shape,
+    mask: u32,
+
+    fn find(self: *const KeyIndex, key: []const u8, hash: u32) ?Shape.Entry {
+        var i: u32 = hash & self.mask;
+        while (self.slots[i]) |n| : (i = (i +% 1) & self.mask) {
+            if (n.key_hash == hash and std.mem.eql(u8, n.key, key)) {
+                return .{ .slot = n.slot, .attrs = n.attrs, .kind = n.kind };
+            }
+        }
+        return null;
+    }
+};
+
 /// A node in the transition tree. The root (`parent == null`)
 /// describes the empty object; every other node adds exactly one
 /// property — `key` with `attrs`/`kind` — at index `slot` to its
@@ -39,6 +103,9 @@ pub const Shape = struct {
     /// root. Owned by the `ShapeTree` arena (duped on transition)
     /// so it outlives any caller's key buffer.
     key: []const u8,
+    /// Wyhash of `key`, computed once at creation — feeds the
+    /// `KeyIndex` build and the probe's early-out compare.
+    key_hash: u32,
     attrs: PropertyFlags,
     kind: PropKind,
     /// Index into `JSObject.slots` where this property's value
@@ -47,6 +114,15 @@ pub const Shape = struct {
     /// Number of own properties this shape describes — also the
     /// slot count an object of this shape needs.
     property_count: u32,
+    /// Chain length from the root (root = 0). Counts redefine
+    /// nodes too, so it can exceed `property_count`.
+    depth: u32,
+    /// Tree-shared arena + index-budget counters (see `ShapeCtx`).
+    ctx: *ShapeCtx,
+    /// Lazily-built key→entry hash table covering the FULL chain
+    /// (this shape → root). Null until a slow lookup at this shape
+    /// crosses the build thresholds; immutable once set.
+    index: ?*KeyIndex,
     /// Forward-transition cache: the shapes reached by adding one
     /// more property to THIS shape. Append-only; scanned linearly
     /// — a given key is almost always added with a single
@@ -67,18 +143,103 @@ pub const Shape = struct {
         kind: PropKind,
     };
 
-    /// Resolve own property `key` by walking the transition chain
-    /// to the root. O(depth in the chain); an inline cache keyed
-    /// on the shape collapses the hot path to O(1).
-    pub fn lookup(self: *const Shape, key: []const u8) ?Entry {
-        var node: ?*const Shape = self;
-        while (node) |n| : (node = n.parent) {
-            if (n.parent == null) break; // root adds no property
-            if (std.mem.eql(u8, n.key, key)) {
-                return .{ .slot = n.slot, .attrs = n.attrs, .kind = n.kind };
+    /// Resolve own property `key`. Shallow chains walk the
+    /// transition chain linearly to the root (nearest node wins,
+    /// which is what makes redefine transitions shadow their
+    /// ancestor entry). Deep chains resolve through the lazily
+    /// built `KeyIndex` — either this shape's own, or the nearest
+    /// indexed ancestor's after a short linear tail scan (the tail
+    /// is scanned FIRST, so nearest-wins shadowing is preserved).
+    /// An inline cache keyed on the shape still collapses the hot
+    /// monomorphic path to O(1) before any of this runs; the index
+    /// is the megamorphic-miss path's rescue.
+    pub fn lookup(self: *Shape, key: []const u8) ?Entry {
+        if (self.index) |idx| return idx.find(key, hashKey(key));
+        var node: *Shape = self;
+        var anchor: ?*Shape = null;
+        var result: ?Entry = null;
+        var walked_full_tail = true;
+        while (true) {
+            if (node.parent == null) break; // root adds no property
+            if (node.index != null) {
+                anchor = node;
+                break;
             }
+            if (std.mem.eql(u8, node.key, key)) {
+                result = .{ .slot = node.slot, .attrs = node.attrs, .kind = node.kind };
+                walked_full_tail = false;
+                break;
+            }
+            node = node.parent.?;
         }
-        return null;
+        if (anchor) |a| result = a.index.?.find(key, hashKey(key));
+        // Only a lookup that paid for the whole un-indexed tail is
+        // evidence this shape is hot enough to index.
+        if (walked_full_tail) self.maybeBuildIndex(if (anchor) |a| a.depth else 0);
+        return result;
+    }
+
+    /// Decide whether the walk `lookup` just paid justifies
+    /// materialising an index at this shape. Two throttles keep
+    /// index memory O(node_count) under adversarial
+    /// add-then-lookup loops (never-unbounded-growth,
+    /// docs/handbook/host-safety.md): a tree-wide slot budget
+    /// linear in the node count, and past it a geometric rule —
+    /// only build when the un-indexed tail is more than half the
+    /// chain, so index depths at least double along any path.
+    fn maybeBuildIndex(self: *Shape, anchor_depth: u32) void {
+        if (self.depth < index_min_depth) return;
+        const tail = self.depth - anchor_depth;
+        if (tail < index_min_tail) return;
+        const cap = indexCapacity(self.property_count) orelse return;
+        const under_budget = self.ctx.index_slots_total + cap <=
+            index_budget_base + index_budget_per_node * self.ctx.node_count;
+        const geometric = 2 * @as(u64, tail) > self.depth;
+        if (!under_budget and !geometric) return;
+        // OOM → skip the index; the linear walk stays correct.
+        self.buildIndex(cap) catch return;
+    }
+
+    /// Power-of-two table size with load factor ≤ ~0.5. The chain
+    /// holds exactly `property_count` distinct keys (appends add a
+    /// new key; redefines re-add an existing one), so the table
+    /// always keeps empty slots and probes terminate.
+    fn indexCapacity(property_count: u32) ?u32 {
+        if (property_count >= index_max_indexed_props) return null;
+        const want = @max(16, (@as(u64, property_count) + 1) * 2);
+        return @intCast(std.math.ceilPowerOfTwoAssert(u64, want));
+    }
+
+    fn buildIndex(self: *Shape, cap: u32) !void {
+        const a = self.ctx.arena.allocator();
+        const slots = try a.alloc(?*const Shape, cap);
+        @memset(slots, null);
+        const mask: u32 = cap - 1;
+        var inserted: u32 = 0;
+        // Walk self → root inserting each key once; the FIRST
+        // (nearest) node wins, mirroring the linear walk's
+        // shadowing order for redefine transitions.
+        var node: ?*Shape = self;
+        walk: while (node) |n| : (node = n.parent) {
+            if (n.parent == null) break; // root adds no property
+            var i: u32 = n.key_hash & mask;
+            while (slots[i]) |occ| : (i = (i +% 1) & mask) {
+                if (occ.key_hash == n.key_hash and std.mem.eql(u8, occ.key, n.key)) {
+                    continue :walk; // nearer node already inserted
+                }
+            }
+            // Defensive load-factor guard — unreachable while the
+            // distinct-keys == property_count invariant holds, but
+            // a full table would make `find` spin, so bail to the
+            // linear walk instead.
+            if (2 * (@as(u64, inserted) + 1) > cap) return;
+            slots[i] = n;
+            inserted += 1;
+        }
+        const idx = try a.create(KeyIndex);
+        idx.* = .{ .slots = slots, .mask = mask };
+        self.index = idx;
+        self.ctx.index_slots_total += cap;
     }
 };
 
@@ -89,29 +250,44 @@ fn flagsEql(a: PropertyFlags, b: PropertyFlags) bool {
 }
 
 /// Owns one realm's transition tree: the root shape plus the arena
-/// every `Shape` (and its duped key bytes) is allocated from.
+/// every `Shape` (and its duped key bytes) is allocated from. The
+/// arena lives behind a stable heap pointer (not by value) so each
+/// `Shape.ctx` can reach it for lazy `KeyIndex` builds even though
+/// the `ShapeTree` struct itself moves by value into `Heap`.
 pub const ShapeTree = struct {
-    arena: std.heap.ArenaAllocator,
+    backing: std.mem.Allocator,
+    arena: *std.heap.ArenaAllocator,
+    ctx: *ShapeCtx,
     root: *Shape,
 
     pub fn init(backing: std.mem.Allocator) !ShapeTree {
-        var arena = std.heap.ArenaAllocator.init(backing);
+        const arena = try backing.create(std.heap.ArenaAllocator);
+        errdefer backing.destroy(arena);
+        arena.* = std.heap.ArenaAllocator.init(backing);
         errdefer arena.deinit();
-        const root = try arena.allocator().create(Shape);
+        const a = arena.allocator();
+        const ctx = try a.create(ShapeCtx);
+        ctx.* = .{ .arena = arena };
+        const root = try a.create(Shape);
         root.* = .{
             .parent = null,
             .key = "",
+            .key_hash = 0,
             .attrs = .{},
             .kind = .data,
             .slot = 0,
             .property_count = 0,
+            .depth = 0,
+            .ctx = ctx,
+            .index = null,
             .transitions = .empty,
         };
-        return .{ .arena = arena, .root = root };
+        return .{ .backing = backing, .arena = arena, .ctx = ctx, .root = root };
     }
 
     pub fn deinit(self: *ShapeTree) void {
         self.arena.deinit();
+        self.backing.destroy(self.arena);
     }
 
     /// Return the shape reached by adding (`key`, `attrs`, `kind`)
@@ -138,10 +314,14 @@ pub const ShapeTree = struct {
         child.* = .{
             .parent = from,
             .key = owned_key,
+            .key_hash = hashKey(owned_key),
             .attrs = attrs,
             .kind = kind,
             .slot = from.property_count,
             .property_count = from.property_count + 1,
+            .depth = from.depth + 1,
+            .ctx = self.ctx,
+            .index = null,
             .transitions = .empty,
         };
         try from.transitions.append(a, .{
@@ -150,6 +330,7 @@ pub const ShapeTree = struct {
             .kind = kind,
             .child = child,
         });
+        self.ctx.node_count += 1;
         return child;
     }
 
@@ -189,10 +370,14 @@ pub const ShapeTree = struct {
         child.* = .{
             .parent = from,
             .key = owned_key,
+            .key_hash = hashKey(owned_key),
             .attrs = attrs,
             .kind = .data,
             .slot = existing.slot,
             .property_count = from.property_count,
+            .depth = from.depth + 1,
+            .ctx = self.ctx,
+            .index = null,
             .transitions = .empty,
         };
         try from.transitions.append(a, .{
@@ -201,6 +386,7 @@ pub const ShapeTree = struct {
             .kind = .data,
             .child = child,
         });
+        self.ctx.node_count += 1;
         return child;
     }
 };
@@ -309,4 +495,160 @@ test "lookup resolves attributes and kind, not just the slot" {
     try testing.expectEqual(@as(u32, 0), e.slot);
     try testing.expect(!e.attrs.enumerable);
     try testing.expectEqual(PropKind.accessor, e.kind);
+}
+
+// —— key→slot hash index (the O(depth)-walk killer) ——————————————
+
+/// Build a linear chain of `n` data properties "p0" … "p{n-1}"
+/// off the root, returning the leaf shape.
+fn buildChain(tree: *ShapeTree, n: u32) !*Shape {
+    var s = tree.root;
+    var buf: [16]u8 = undefined;
+    var i: u32 = 0;
+    while (i < n) : (i += 1) {
+        const key = try std.fmt.bufPrint(&buf, "p{d}", .{i});
+        s = try tree.transition(s, key, .{}, .data);
+    }
+    return s;
+}
+
+test "deep shape builds a hash index on lookup and resolves through it" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    const leaf = try buildChain(&tree, 20);
+    try testing.expect(leaf.index == null);
+
+    // A full-walk lookup (miss) at an index-eligible depth builds
+    // the index lazily.
+    try testing.expect(leaf.lookup("absent") == null);
+    try testing.expect(leaf.index != null);
+
+    // Every key resolves to the same slot the linear walk gave,
+    // now via the index probe.
+    var buf: [16]u8 = undefined;
+    var i: u32 = 0;
+    while (i < 20) : (i += 1) {
+        const key = try std.fmt.bufPrint(&buf, "p{d}", .{i});
+        const e = leaf.lookup(key).?;
+        try testing.expectEqual(i, e.slot);
+        try testing.expectEqual(PropKind.data, e.kind);
+    }
+    try testing.expect(leaf.lookup("still-absent") == null);
+    try testing.expect(leaf.lookup("") == null);
+}
+
+test "shallow shapes never build an index" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    const leaf = try buildChain(&tree, index_min_depth - 1);
+    try testing.expect(leaf.lookup("absent") == null);
+    try testing.expect(leaf.lookup("p0") != null);
+    try testing.expect(leaf.index == null);
+    try testing.expect(tree.root.lookup("x") == null);
+    try testing.expect(tree.root.index == null);
+}
+
+test "redefine transition shadows correctly through the index" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    // Redefine BELOW the index build point: freeze p3, then look up
+    // at the leaf — the index must carry the redefined attrs, not
+    // the original ancestor entry.
+    const base = try buildChain(&tree, 10);
+    const frozen: PropertyFlags = .{ .writable = false, .enumerable = true, .configurable = false };
+    const leaf = try tree.redefineTransition(base, "p3", frozen);
+
+    try testing.expect(leaf.lookup("absent") == null); // builds index
+    try testing.expect(leaf.index != null);
+    const e = leaf.lookup("p3").?;
+    try testing.expectEqual(@as(u32, 3), e.slot);
+    try testing.expect(!e.attrs.writable);
+    try testing.expect(!e.attrs.configurable);
+    // A sibling key is untouched.
+    try testing.expect(leaf.lookup("p4").?.attrs.writable);
+    // The ancestor's own index (if any) still answers the ORIGINAL
+    // attrs at `base`.
+    try testing.expect(base.lookup("p3").?.attrs.writable);
+}
+
+test "descendant reuses an ancestor's index through the tail walk" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    const mid = try buildChain(&tree, 12);
+    try testing.expect(mid.lookup("absent") == null); // builds at depth 12
+    try testing.expect(mid.index != null);
+
+    // Two more appends + one redefine: short tail above the anchor.
+    var leaf = try tree.transition(mid, "q0", .{}, .data);
+    leaf = try tree.transition(leaf, "q1", .{ .enumerable = false }, .data);
+    const frozen: PropertyFlags = .{ .writable = false, .enumerable = true, .configurable = false };
+    leaf = try tree.redefineTransition(leaf, "p5", frozen);
+
+    // Tail keys (nearest) win; anchored keys resolve via the probe.
+    try testing.expectEqual(@as(u32, 12), leaf.lookup("q0").?.slot);
+    try testing.expect(!leaf.lookup("q1").?.attrs.enumerable);
+    try testing.expect(!leaf.lookup("p5").?.attrs.writable); // tail redefine shadows index
+    try testing.expectEqual(@as(u32, 0), leaf.lookup("p0").?.slot); // via ancestor index
+    try testing.expect(leaf.lookup("absent") == null);
+    // The short tail must NOT have built a fresh index at the leaf.
+    try testing.expect(leaf.index == null);
+}
+
+test "accessor kind survives the index" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    var s = try buildChain(&tree, 9);
+    s = try tree.transition(s, "getterProp", .{ .enumerable = false }, .accessor);
+    try testing.expect(s.lookup("absent") == null); // builds
+    const e = s.lookup("getterProp").?;
+    try testing.expectEqual(PropKind.accessor, e.kind);
+    try testing.expect(!e.attrs.enumerable);
+}
+
+test "index memory stays linearly bounded under add+lookup alternation" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    // Adversarial pattern from docs/handbook/host-safety.md's
+    // never-unbounded-growth contract: interleave one property add
+    // with one full-walk lookup, which would build an index at
+    // EVERY shape without the budget + geometric throttles
+    // (O(n²) slots). Pin the linear bound.
+    var s = tree.root;
+    var buf: [16]u8 = undefined;
+    var i: u32 = 0;
+    while (i < 400) : (i += 1) {
+        const key = try std.fmt.bufPrint(&buf, "k{d}", .{i});
+        s = try tree.transition(s, key, .{}, .data);
+        try testing.expect(s.lookup("absent") == null);
+        try testing.expect(s.lookup("k0") != null);
+    }
+    const bound = index_budget_base + (index_budget_per_node + 8) * tree.ctx.node_count;
+    try testing.expect(tree.ctx.index_slots_total <= bound);
+    // …and the index still answers correctly at the leaf.
+    try testing.expectEqual(@as(u32, 399), s.lookup("k399").?.slot);
+    try testing.expectEqual(@as(u32, 17), s.lookup("k17").?.slot);
+}
+
+test "hash collisions in the index still resolve by key bytes" {
+    var tree = try ShapeTree.init(testing.allocator);
+    defer tree.deinit();
+
+    // With a 400-key chain the table has plenty of same-bucket
+    // (masked) collisions; every key must still resolve to its own
+    // slot via the linear probe + byte-compare confirm.
+    const leaf = try buildChain(&tree, 400);
+    try testing.expect(leaf.lookup("absent") == null); // builds
+    try testing.expect(leaf.index != null);
+    var buf: [16]u8 = undefined;
+    var i: u32 = 0;
+    while (i < 400) : (i += 1) {
+        const key = try std.fmt.bufPrint(&buf, "p{d}", .{i});
+        try testing.expectEqual(i, leaf.lookup(key).?.slot);
+    }
 }


### PR DESCRIPTION
# Per-shape key→slot hash index

Phase 2 of the profile-driven perf effort: attack the slow-path property-lookup cluster callgrind flagged in phase 1 — `Shape.lookup`'s O(depth) parent-chain walk (one `std.mem.eql` per node) plus its memcmp was ~16% of `deltablue` and ~12% of `string_concat` instructions. This is the exact follow-up `docs/interned-keys.md` §11 names: kill the walk *length* (atom interning alone was the measured dead-end).

## Design

`src/runtime/shape.zig` grows a lazily-built `KeyIndex` — an open-addressed key→entry hash table covering a shape's full chain (self → root):

- **Depth gate at 16, calibrated by measurement, not V8's 8.** V8 switches DescriptorArray search from linear to hash past 8 descriptors, but its keys are interned `Name`s with a *cached* hash; Cynic hashes key bytes per probe (no atom table — measured dead-end, `docs/interned-keys.md` §11), which moves the break-even up. A first cut at depth ≥ 8 regressed deltablue +9% wall / +9% Ir (probe Wyhash ≈ the short walk it replaced, plus bookkeeping tax on every lookup); the shipped cut keeps chains < 16 on the **exact pre-index linear walk** — one u32 depth compare is the entire feature cost there — and quarantines deep-chain machinery in a `noinline lookupDeep` (the `slowLdaGlobal` i-cache lesson from `docs/inline-caches.md`).
- **Lazy build, nearest-wins.** The first slow lookup that pays for a full un-indexed walk materialises the table. Insertion walks self → root inserting each key once, so `redefineTransition` shadowing (the SES freeze path) resolves byte-identically. Descendants scan their short tail linearly first (shadowing preserved), then probe the nearest indexed ancestor; a hot leaf converges to a pure probe.
- **Bounded under hostile input** (never-unbounded-growth, `docs/handbook/host-safety.md`): builds draw from a tree-wide slot budget linear in the node count, then fall back to a geometric distance-doubling rule — an adversarial add-one-property-then-lookup loop gets O(n) total index memory, not O(n²). Unit test pins the bound. OOM during a build skips the index; `lookup` cannot fail.
- **No GC interaction.** Indexes and keys are `ShapeTree`-arena allocations (realm-lifetime, untraced), like the shapes themselves. The arena moved behind a stable heap pointer so a bare `*Shape` reaches it for lazy builds; `ShapeTree` still embeds by value in `Heap`.

**Prior art:** V8 DescriptorArray linear→hash switchover + key lookup caches; JSC `Structure`/`PropertyTable`; SpiderMonkey `PropertyMap` table. All three engines pair the linear-scan-small / hash-large split with interned keys carrying cached hashes — Cynic adapts the split without the atom table, hence the higher cutoff.

## Why string_concat moves

Its loop resolves `(i & 0xff).toString()` through `slowLookupForCallProperty` → `globals.get("Number")` → the global object's ~25-deep shape chain, **every iteration** (primitive receivers can't IC on shape). Callgrind: 252 Ir per walk, 300k walks = 11.6% of the fixture. Now one probe.

## Measurements

Interleaved A/B (`zig build bench -- --ab-baseline=…`, head/base alternating per iteration so host drift cancels), 20 runs micros / 15 runs macros, plus an **A/A control** (base vs itself) that put the noise floor at ±2-3% (deltablue read 1.021x against *itself*).

Three independent A/B runs, micros (ratio = head/base, <1 is faster):

| fixture | run 1 | run 2 | run 3 |
|---|---:|---:|---:|
| string_concat | **0.686x** | **0.710x** | **0.698x** |
| arith_loop | 1.016 | 1.003 | 0.991 |
| prop_access | 0.991 | 1.006 | 1.006 |
| prop_write | 1.016 | 1.011 | 1.143* |
| array_iter | 0.965 | 1.029 | 1.036 |
| promise_chain | 0.986 | 1.035 | 1.004 |
| object_alloc | 1.005 | 0.973 | 1.004 |
| method_call | 0.984 | 1.023 | 0.999 |
| class_instantiate | 1.008 | 1.042 | 1.004 |
| ctor_array_build | 0.991 | 1.026 | 0.992 |
| json_stringify | 1.037 | 1.019 | 1.009 |
| tail_recursion | 1.030 | 0.976 | 0.989 |

\* run-3 prop_write had 72% in-run spread; a dedicated 8×8 interleaved re-check measured head 26.0 ms avg vs base 27.0 ms (equal mins) — noise.

Macros (run 2 / run 3 after restructure, vs A/A control): richards 1.010/1.009, **deltablue 1.029 vs A/A 1.021**, crypto 0.995, raytrace 0.999, navier_stokes 1.037 vs A/A 0.976, splay 0.971.

**Honest summary:** `string_concat` −30% is real and stable across three drift-cancelled runs. Everything else is inside the ±2-3% A/A noise floor on this shared 4-vCPU host. deltablue — the other profiled target — is **neutral, not improved**: its hot chains are depth 8-12, deliberately below the gate because indexing them measured *worse* (see design). Its 16% cluster needs optimizing-tier polymorphic dispatch, per the poly-IC post-mortem.

**Callgrind (deterministic Ir, `-Dcpu=x86_64_v2` builds):**

| fixture | base Ir | head Ir | Δ |
|---|---:|---:|---:|
| string_concat | 652.0M | 617.1M | −5.4% |
| deltablue | 4.981G | 5.016G | +0.7% |

On string_concat `Shape.lookup` (75.6M Ir, 11.6%) disappears from the profile, replaced by `KeyIndex.find` at 19.5M (3.2%). The wall win (−30%) exceeds the Ir win because the 25-node walk was a serialized pointer-chase (latency-bound), while the probe is 1-2 loads. Note x86_64 host: all numbers are the Lantern interpreter tier (Bistromath is a comptime no-op here).

## Verification

- `zig build test-fast` (ReleaseSafe, full unit suite): **2869 passed / 395 skipped / 0 failed** — includes 8 new `shape.zig` tests written first (index build/hit/miss, redefine shadowing above and below the index, ancestor-index reuse through the tail, accessor kind, hash-collision resolution, and the adversarial add+lookup memory bound).
- **Full test262 sweep** (no `--filter`, no `--only-failing`, per `docs/handbook/agent-checks.md`): **48571 passing / 1324 failing / 97.35%** — exact match with the `test262-results.md` baseline. `--write-results` not used.
- Leak sanity check (`--filter=language/expressions --top-rss=10`): top per-fixture RSS deltas 8-9 MiB, inside the healthy ≤20 MiB band.
- GC-stress spot check (`--gc-threshold=1 --filter=built-ins/Object/`): clean (expected — the index is arena memory, no GC-heap pointers).

## Not addressed (follow-ups)

- The dictionary-mode bag probes sharing the string_concat cluster (~21% of the fixture): `decl_env` Wyhash miss per `globals.get`, and `hasOwn`/`get` probes on the demoted `Number.prototype`. A shape-first / intrinsic-pointer fix is a separate change (touches `primitiveProtoLookupForCall` semantics).
- deltablue's megamorphic sites — out of interpreter-tier reach per the Tier-3 poly-IC post-mortem.

---
_Generated by [Claude Code](https://claude.ai/code)_