### PR TITLE
Fix use-after-free in Intl.DateTimeFormat numbering-system resolution

### DIFF
--- a/src/runtime/builtins/intl.zig
+++ b/src/runtime/builtins/intl.zig
@@ -3619,8 +3619,13 @@ fn buildDateTimeFormatSlots(realm: *Realm, locales: Value, options: Value) Nativ
     }
     // §11.1.2 read order: numberingSystem is resolved after the calendar option
     // (both after localeMatcher). Runs unconditionally so a locale's default
-    // system still applies when no options object is supplied.
-    slots.numbering_system = try resolveNumberingSystem(realm, resolved.locale, resolved.locale, opts, true);
+    // system still applies when no options object is supplied. Read the live
+    // `slots.base.locale`, not the local `resolved.locale`: ownership moved to
+    // the slots above, and the stripExtKeyword("ca") call an explicit calendar
+    // option triggers frees-and-replaces that string — the stale local would be
+    // a use-after-free (flaky "latn" fallback for e.g. ar-EG). §9.2.7 also
+    // wants the -u-nu keyword read off the post-strip resolved locale.
+    slots.numbering_system = try resolveNumberingSystem(realm, slots.base.locale, slots.base.locale, opts, true);
     // §9.2.7 — the -u-nu keyword stays in the resolved locale only when it equals
     // the resolved system; an overriding option (or the default) drops it.
     if (intl.unicodeExtensionValue(slots.base.locale, "nu")) |kw| {

--- a/src/runtime/intl_test.zig
+++ b/src/runtime/intl_test.zig
@@ -756,6 +756,28 @@ test "intl: DateTimeFormat renders extreme Temporal years (iso signed, gregory e
     );
 }
 
+test "intl: DateTimeFormat calendar option keeps the locale's numbering system (ar-EG)" {
+    try requireIntlBuild();
+    if (!intl_config.has_locale_data) return error.SkipZigTest;
+    // §11.1.2 CreateDateTimeFormat / §9.2.7 ResolveLocale — the numbering
+    // system resolves from the resolved locale, and an explicit supported
+    // calendar option must not disturb it. Regression: an explicit calendar
+    // triggers stripExtKeyword("ca"), which frees the resolved-locale string;
+    // buildDateTimeFormatSlots then read the stale local through
+    // resolveNumberingSystem (use-after-free), flakily falling back to "latn"
+    // for ar-EG (test262 format/temporal-objects-no-time-clip-non-latin-
+    // numerals). std.testing.allocator poisons freed memory, so the stale
+    // read fails deterministically here.
+    try evalAssert1(
+        \\const withCal = new Intl.DateTimeFormat("ar-EG", { year: "numeric", month: "numeric", day: "numeric", calendar: "iso8601" });
+        \\if (withCal.resolvedOptions().numberingSystem !== "arab") throw 0;
+        \\if (!withCal.format(new Temporal.PlainDate(275760, 9, 13)).includes("١٣")) throw 1; // day 13 in Arabic-Indic digits
+        \\const control = new Intl.DateTimeFormat("ar-EG", { year: "numeric", month: "numeric", day: "numeric" });
+        \\if (control.resolvedOptions().numberingSystem !== "arab") throw 2;
+        \\1
+    );
+}
+
 test "intl: DateTimeFormat reads calendar before numberingSystem (§11.1.2)" {
     try requireIntlBuild();
     // §11.1.2 CreateDateTimeFormat read order: calendar precedes numberingSystem,


### PR DESCRIPTION
## What

`buildDateTimeFormatSlots` (`src/runtime/builtins/intl.zig`) resolved the numbering system through a dangling pointer. The resolved-locale string's ownership moves into `slots.base.locale`; when an explicit supported `calendar:` option is given, §9.2.7 ResolveLocale semantics drop the overridden `-u-ca` keyword via `stripExtKeyword(realm, &slots.base, "ca")` — which unconditionally frees and replaces that string. The subsequent §11.1.2 numbering-system resolution still read the stale local `resolved.locale`:

```zig
slots.numbering_system = try resolveNumberingSystem(realm, resolved.locale, resolved.locale, opts, true);
```

The fix reads the live `slots.base.locale` instead — which is also the spec-correct source, since §9.2.7 reads the `-u-nu` keyword off the post-strip resolved locale. This was the only post-strip use of `resolved.locale` (audited; every other occurrence is the initial ownership-move assignment in the other service builders).

## Before / after (ar-EG repro)

Whether the dangling read misbehaves depends on allocator reuse. On a Debug build (free-poisoning makes it deterministic):

```
$ cynic eval 'new Intl.DateTimeFormat("ar-EG",{year:"numeric",month:"numeric",day:"numeric",calendar:"iso8601"}).format(new Temporal.PlainDate(275760,9,13))'
13/9/275760      # BUG — Latin digits (cldr.numberData on poisoned bytes fails → silent "latn" fallback)
$ # without calendar: (no stripExtKeyword) — control
١٣/٩/٢٧٥٧٦٠      # correct Arabic-Indic digits
```

After the fix, both render Arabic-Indic digits and `resolvedOptions().numberingSystem === "arab"` in both cases.

## Why this explains PR #61's flaky `--max-gaps=0` trip

The gating job in https://github.com/chicoxyzzy/cynic/actions/runs/28961435004/job/85935185214 failed with exactly one unaudited fixture flipped:

```
FAIL intl402/DateTimeFormat/prototype/format/temporal-objects-no-time-clip-non-latin-numerals.js: max date should include day 13 in Arabic-Indic digits, got: 13/9/275760
test262: 1 engine gaps exceed --max-gaps=0
```

That fixture is the rare combination that can observe the bug: an explicit supported `calendar:` option (triggers the strip/free) plus an assertion on non-Latin digits. In ReleaseFast under `--threads=4`, whether the freed block is recycled before the stale read depends on process-wide allocation history, so the failure is layout- and schedule-dependent: PR #61 (shape.zig-only changes) merely perturbed allocator layout. The identical failure reproduces on `main` locally with the exact CI command, and a re-run of the failed job (attempt 2) failed again with the same UAF class (`format/temporal-objects-no-time-clip-non-latin-numerals.js` plus siblings `format/numbering-system.js`, `formatRange/temporal-objects-no-time-clip.js`).

## Verification

- New regression test (`src/runtime/intl_test.zig`): `ar-EG` + `calendar:"iso8601"` must resolve `numberingSystem "arab"` and format `Temporal.PlainDate(275760,9,13)` with Arabic-Indic digits. `std.testing.allocator` poisons frees, so the stale read is deterministic: the test **fails before the fix, passes after**.
- `zig build test-fast -Dintl=full`: 3116 pass / 141 skip / 1 fail — the one failure (`intl: DateTimeFormat formatRange of Temporal objects (§11.5.6)`) reproduces identically on pristine `origin/main` (verified with the fix stashed) and is unrelated; CI's gating `test-fast` builds at the default `-Dintl=off`, so it is latent there. Follow-up candidate.
- Exact CI command, with the fix: `zig build test262 -- --threads=4 --top-rss=20 --min-pass-pct=92.0 --max-gaps=0` → **exit 0**, `passing: 48571 / failing: 1324 / pass%: 97.35%`, zero `--max-gaps` trips, and the flipped fixture passes.
- The fixture in isolation: 5/5 passes; `--filter=intl402/DateTimeFormat` sweep: 240/4 (the 4 known baseline fails only).