### PR TITLE
runtime: restore Shape key_hash/depth/ctx/index in CYSN snapshot decode

### DIFF
--- a/src/runtime/shape.zig
+++ b/src/runtime/shape.zig
@@ -63,7 +63,7 @@ pub const index_budget_per_node: u64 = 8;
 /// caller should have demoted to dictionary mode anyway).
 const index_max_indexed_props: u32 = 1 << 20;
 
-inline fn hashKey(key: []const u8) u32 {
+pub inline fn hashKey(key: []const u8) u32 {
     return @truncate(std.hash.Wyhash.hash(0, key));
 }
 

--- a/src/runtime/snapshot.zig
+++ b/src/runtime/snapshot.zig
@@ -1404,12 +1404,20 @@ const Restore = struct {
             child.* = .{
                 .parent = parent,
                 .key = owned_key,
+                .key_hash = shape_mod.hashKey(owned_key),
                 .attrs = attrs,
                 .kind = kind,
                 .slot = slot,
                 .property_count = property_count,
+                .depth = parent.depth + 1,
+                .ctx = parent.ctx,
+                .index = null,
                 .transitions = .empty,
             };
+            // Mirror the live transition path's node accounting so
+            // the lazy KeyIndex budget (§ shape.zig maybeBuildIndex)
+            // stays linear in the restored tree's node count.
+            parent.ctx.node_count += 1;
             // Register the transition edge so post-restore
             // transitions dedupe against this tree exactly as
             // against the original (doc §5.4).


### PR DESCRIPTION
## What

Fixes the `main` branch CI failure — the gating **`zig build test-fast`** job fails to compile:

```
src/runtime/snapshot.zig:1404:24: error: missing struct field: key_hash
  note: missing struct field: depth
  note: missing struct field: ctx
  note: missing struct field: index
src/runtime/shape.zig:107:19: note: struct declared here
error: 1 compilation errors
```

## Root cause — a semantic merge conflict between two independently-green changes

- The per-shape key→slot hash index work (`c386fa6`, `06d4311`) added four fields to the `Shape` struct in `src/runtime/shape.zig`: `key_hash`, `depth`, `ctx`, `index`.
- The CYSN realm-snapshot restore path (`77aac54`) builds `Shape` nodes directly with a struct literal in `restoreShapes` and predates those fields.

Each landed green on its own branch; combined on `main` the snapshot struct literal no longer names every `Shape` field, so the build stops with the compile error above. It is deterministic — a type error, not a flake.

## Change

**Before:** `restoreShapes` initialised only `parent, key, attrs, kind, slot, property_count, transitions` — missing the four index fields, so the struct literal was incomplete and the module would not compile.

**After:** the restored child is populated exactly like the live `ShapeTree.transition` path:

- `key_hash = shape.hashKey(owned_key)` (`hashKey` is now `pub` so the snapshot decoder reuses the identical Wyhash, instead of duplicating the hashing and risking silent index-probe corruption if it ever diverges)
- `depth = parent.depth + 1`
- `ctx = parent.ctx` (all nodes in a tree share one `ShapeCtx`)
- `index = null` (the `KeyIndex` is built lazily on a hot deep lookup)
- `parent.ctx.node_count += 1`, mirroring `transition`, so the lazy-index budget stays linear in the restored tree's node count.

## Verification

`zig build test-fast` (Zig `0.17.0-dev.1275+59a628c6d`, the pinned toolchain):

```
Build Summary: 9/9 steps succeeded
test-fast success
```

(vs. the failing CI run's `6/9 steps succeeded (1 failed); compile test ReleaseSafe native 1 errors`.)

No new Shape struct-literal construction sites exist outside `shape.zig` and this one, so no other decode path needs the same treatment.