### PR TITLE
Fix Temporal computed-calendar host-abort and unblock the -Dintl=full unit suite

### DIFF
--- a/src/runtime/builtins/temporal/shared.zig
+++ b/src/runtime/builtins/temporal/shared.zig
@@ -1582,17 +1582,29 @@ pub fn calendarFields(cal: temporal.CalendarId, iso_y: i32, iso_m: u32, iso_d: u
         const date = temporal.daysFromCivil(iso_y, iso_m, iso_d);
         const cd = compFromDays(c, date);
         const ev = computedEra(cal, c, cd.year);
+        // §12.5.x — these getters must stay total (host-safety: never trap on a
+        // user-reachable date). The lunisolar pair (chinese/dangi) saturates
+        // `compFromDays` to its tabulated [1850, 2150] window for an ISO year
+        // outside it, so the returned calendar year no longer corresponds to
+        // `date`; the raw `date - yearStart + 1` day-of-year then runs hugely
+        // negative and traps the `u32` cast. Clamp day-of-year into its valid
+        // [1, daysInYear] band — a no-op for every in-range date (the closed-
+        // form islamic/coptic/indian/persian/hebrew families never clamp), and
+        // a saturated-but-total value for the out-of-table lunisolar case.
+        const diy: i64 = compDaysInYear(c.family, cd.year);
+        const doy_raw = date - compToDays(c, cd.year, 1, 1) + 1;
+        const doy = std.math.clamp(doy_raw, 1, diy);
         return .{
-            .year = @intCast(cd.year),
+            .year = std.math.lossyCast(i32, cd.year),
             .month = cd.month,
             .day = cd.day,
             .days_in_month = compDaysInMonth(c.family, cd.year, cd.month),
-            .days_in_year = compDaysInYear(c.family, cd.year),
+            .days_in_year = @intCast(diy),
             .months_in_year = compMonthsInYear(c.family, cd.year),
-            .day_of_year = @intCast(date - compToDays(c, cd.year, 1, 1) + 1),
+            .day_of_year = @intCast(doy),
             .in_leap_year = compLeap(c.family, cd.year),
             .era = if (c.era.len == 0) null else ev.era,
-            .era_year = if (c.era.len == 0) null else @intCast(ev.era_year),
+            .era_year = if (c.era.len == 0) null else std.math.lossyCast(i32, ev.era_year),
         };
     }
     // Japanese: gregorian structure with a date-based era overlay.

--- a/src/runtime/intl_test.zig
+++ b/src/runtime/intl_test.zig
@@ -3199,7 +3199,10 @@ test "intl: DateTimeFormat formatRange of Temporal objects (§11.5.6)" {
         \\const pd1 = new Temporal.PlainDate(2024, 1, 1), pd2 = new Temporal.PlainDate(2024, 1, 5);
         \\const pt = new Temporal.PlainTime(12, 0);
         \\const thrown = (f) => { try { f(); return ''; } catch (e) { return e.constructor.name; } };
-        \\(dtf.formatRange(pd1, pd2) === '1/1/24 – 1/5/24' &&
+        \\// §11.1.7 fallback join: the CLDR `intervalFormatFallback` for "en"
+        \\// separates the two endpoints with U+2009 THIN SPACE + en-dash (U+2013)
+        \\// + U+2009 (not ASCII spaces) — see rangeFallbackSep in intl.zig.
+        \\(dtf.formatRange(pd1, pd2) === '1/1/24\u2009\u2013\u20091/5/24' &&
         \\ // distinct Temporal types, and Temporal mixed with legacy → TypeError
         \\ thrown(() => dtf.formatRange(pd1, pt)) === 'TypeError' &&
         \\ thrown(() => dtf.formatRange(pd1, Date.now())) === 'TypeError') ? 1 : 0

--- a/src/runtime/intl_test.zig
+++ b/src/runtime/intl_test.zig
@@ -168,6 +168,30 @@ test "intl/temporal: roc + buddhist year-offset calendar arithmetic" {
     );
 }
 
+test "intl/temporal: lunisolar getters stay total for out-of-table ISO years (host-safety)" {
+    try requireIntlBuild();
+    // §12.5 host-safety: the chinese/dangi lunisolar calendars saturate
+    // `compFromDays` to their tabulated [1850, 2150] window, so a PlainDate on
+    // an ISO year outside it (here ISO year 1) yields a calendar year that no
+    // longer corresponds to the raw day count. The day-of-year subtraction then
+    // ran hugely negative and trapped the `u32` cast under ReleaseSafe — a
+    // host-abort. The getters must instead produce a total, saturated value.
+    // (Regression for the calendarFields day_of_year / year / eraYear casts.)
+    try evalAssert1(
+        \\for (const cal of ["chinese", "dangi"]) {
+        \\  const d = new Temporal.PlainDate(1, 1, 1, cal);
+        \\  // Reading every getter must not trap; values are saturated-but-total.
+        \\  const y = d.year, m = d.month, day = d.day, doy = d.dayOfYear;
+        \\  const diy = d.daysInYear, dim = d.daysInMonth, miy = d.monthsInYear;
+        \\  if (typeof y !== "number" || typeof m !== "number") throw 0;
+        \\  if (doy < 1 || doy > diy) throw 1;           // day-of-year in band
+        \\  if (day < 1 || day > dim) throw 2;
+        \\  if (d.era !== undefined || d.eraYear !== undefined) throw 3; // era-less
+        \\}
+        \\1
+    );
+}
+
 test "intl/temporal: toLocaleString formats Temporal types via DateTimeFormat" {
     if (!intl_config.has_locale_data) return error.SkipZigTest; // needs CLDR output
     // §13.x — each Temporal type's toLocaleString routes through a transient


### PR DESCRIPTION
## Bug 1 — Temporal computed-calendar getters could abort the host

**Before.** Reading a field getter on a `Temporal.PlainDate` (or any Temporal type) backed by a lunisolar calendar (`chinese` / `dangi`) at an ISO year outside the tabulated [1850, 2150] window trapped the process. `compFromDays` *saturates* the returned calendar year into that window, but `calendarFields` still computed `day_of_year = date - compToDays(cal, cd.year, 1, 1) + 1` from the *unclamped* `date`, so the value ran hugely negative (≈ −675361) and the `@intCast` into the `u32` `day_of_year` field trapped — a SIGABRT under ReleaseSafe on untrusted input. Minimal reproducer: `new Temporal.PlainDate(1, 1, 1, "chinese").year`; reached in-corpus by `intl402/Temporal/PlainDate/from/roundtrip-from-iso.js`, which crashed the ReleaseSafe test262 sweep. (The ReleaseSafe backtrace pointed at `shared.zig:648` in `japaneseEraInfo`, but that was an inlining artifact; the Debug build gives the true site, `shared.zig:1592`.)

**After.** Every computed-calendar getter stays total: an out-of-table lunisolar date now yields a saturated-but-valid result, and every in-range date is unchanged. No input can abort the host — the never-abort-the-host contract (host-safety §1) holds.

## Bug 2 — `zig build test-fast -Dintl=full` was red

**Before.** The suite failed for two independent reasons. First, it did not even compile in *either* intl tier: the recent shape key-index work added `key_hash` / `depth` / `ctx` / `index` fields to `Shape`, but the snapshot restore path still built the pre-index field set, so the test binaries errored with `missing struct field: key_hash` (+3). Second, once compiling, the `DateTimeFormat` `formatRange` test (§11.5.6) compared the rendered range against `'1/1/24 – 1/5/24'` written with ASCII spaces, while the §11.1.7 fallback join correctly emits the CLDR `intervalFormatFallback` separator, which for `en` is U+2009 THIN SPACE + en-dash (U+2013) + U+2009. The engine was right; the test literal was wrong.

**After.** `zig build test-fast` and `zig build test-fast -Dintl=full` are both green. Snapshot round-trips restore shapes with the full current field set, and the formatRange test asserts the real CLDR thin-space separator.

## How

- **`src/runtime/builtins/temporal/shared.zig`** (`calendarFields`, §12.5): clamp `day_of_year` into its valid `[1, daysInYear]` band (a no-op for the closed-form islamic/coptic/indian/persian/hebrew families, a saturation for the out-of-table lunisolar case) and route the `year` / `eraYear` casts through `std.math.lossyCast(i32, …)`.
- **`src/runtime/intl_test.zig`**: adds a host-safety regression driving `chinese` + `dangi` at an out-of-table ISO year; corrects the formatRange literal to the CLDR U+2009 / U+2013 separator using explicit escapes.
- **`src/runtime/snapshot.zig`** (`restoreShapes`): populate the restored `Shape` exactly as the creation path does — `key_hash = hashKey(owned_key)`, `depth = parent.depth + 1`, `ctx = heap.shapes.ctx`, `index = null`, and bump `ctx.node_count`; snapshot-supplied `slot` / `property_count` are kept so redefine nodes round-trip.
- **`src/runtime/shape.zig`**: expose `hashKey` (`pub`) so the restore path reproduces a node's `key_hash` identically.

## Verification

- `zig build test-fast` — 9/9 steps succeeded.
- `zig build test-fast -Dintl=full` — green (formatRange test passes; 25/25 snapshot round-trip tests pass).
- `zig build test262` (full sweep) — 48653 passing / 1324 failing / 97.35%, completed cleanly (matches baseline; no regression).
- `cynic-test262-safe` (ReleaseSafe, GC verifiers + poison armed) — `intl402/Temporal/PlainDate/from/roundtrip-from-iso.js` passes; full `--filter=Temporal` is 6639 passing with no panic (the lone remaining failure is a pre-existing, unrelated `Instant.prototype.toString` timezone case).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Keir4fGV4jxoLzGczrmYKE)_