### PR TITLE
Fix Temporal.Instant.prototype.toString option validation order

### DIFF
--- a/src/runtime/builtins/temporal/instant.zig
+++ b/src/runtime/builtins/temporal/instant.zig
@@ -292,12 +292,20 @@ fn instantToString(realm: *Realm, this_value: Value, args: []const Value) Native
     const opts_obj = try getOptionsObject(realm, options);
     const mode = try getRoundingModeOption(realm, opts_obj, .trunc);
     const smallest = try getTemporalUnitOption(realm, opts_obj, "smallestUnit");
-    var time_zone: ?temporal.TimeZone = null;
-    if (opts_obj) |o| {
-        const tz_val = try getPropertyChain(realm, o, "timeZone");
-        if (!tz_val.isUndefined()) time_zone = try toTimeZoneArg(realm, tz_val);
-    }
+    // §8.4.10: read "timeZone" (a raw Get) with the other options, before
+    // any validation — the order-of-operations fixtures observe this Get
+    // even when smallestUnit is an invalid date unit. The coercion via
+    // ToTemporalTimeZoneIdentifier is deferred until after the smallestUnit
+    // range check below.
+    var tz_val: Value = Value.undefined_;
+    if (opts_obj) |o| tz_val = try getPropertyChain(realm, o, "timeZone");
+    // §8.4.10: validate smallestUnit (RangeError for "hour" and date units)
+    // BEFORE ToTemporalTimeZoneIdentifier coerces the timeZone value, so a
+    // coarse smallestUnit with a non-string timeZone surfaces this
+    // RangeError rather than the timeZone-coercion TypeError.
     try requireToStringSmallestUnit(realm, smallest);
+    var time_zone: ?temporal.TimeZone = null;
+    if (!tz_val.isUndefined()) time_zone = try toTimeZoneArg(realm, tz_val);
 
     const prec = toSecondsStringPrecision(smallest, frac);
     const inc_ns = prec.increment * temporal.unitNanoseconds(prec.unit);

--- a/src/runtime/builtins/temporal/shared.zig
+++ b/src/runtime/builtins/temporal/shared.zig
@@ -2231,10 +2231,17 @@ pub fn pow10(e: u4) i128 {
 }
 
 /// Reject a `smallestUnit` toString option coarser than `minute`
-/// (year..hour). Per GetTemporalUnitValuedOption's read-then-validate
-/// ordering this must run only after every other option has been read and
-/// cast — the order-of-operations fixtures observe `timeZoneName` /
-/// `timeZone` being read even when `smallestUnit` is an invalid date unit.
+/// (year..hour). Ordering (per Temporal.Instant/ZonedDateTime.prototype
+/// .toString): every option is first read and cast — including the raw
+/// `Get` of `timeZone` / `timeZoneName`, which the order-of-operations
+/// fixtures observe even when `smallestUnit` is an invalid date unit — and
+/// only then is this range check applied. But it must precede the timeZone
+/// *coercion* (ToTemporalTimeZoneIdentifier): the spec sequences the
+/// smallestUnit RangeError (GetTemporalUnitValuedOption's TIME group
+/// rejecting date units, plus the explicit "hour" rejection) ahead of the
+/// timeZone coercion, so a coarse `smallestUnit` paired with a non-string
+/// `timeZone` surfaces this RangeError rather than a coercion TypeError.
+/// Call it after the raw `timeZone` read but before the coercion.
 pub fn requireToStringSmallestUnit(realm: *Realm, unit: ?temporal.LargestUnit) NativeError!void {
     const u = unit orelse return;
     if (@intFromEnum(u) < @intFromEnum(temporal.LargestUnit.minute)) {

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1207,6 +1207,23 @@ test "native reentry: recursive accessor is catchable" {
     , "RangeError");
 }
 
+test "Temporal.Instant toString: smallestUnit range check precedes timeZone coercion" {
+    // §8.4.10 Temporal.Instant.prototype.toString reads the options in
+    // order (fractionalSecondDigits, roundingMode, smallestUnit, then a raw
+    // Get of "timeZone") and only then validates: the smallestUnit range
+    // check (RangeError for "hour" and date units) runs BEFORE
+    // ToTemporalTimeZoneIdentifier coerces the timeZone value. So a coarse
+    // smallestUnit paired with a non-string timeZone must surface the
+    // smallestUnit RangeError, not the TypeError from the timeZone coercion.
+    try expectScriptStringWithBuiltins(
+        \\function cls(u) {
+        \\  try { new Temporal.Instant(0n).toString({ smallestUnit: u, timeZone: 5 }); return 'no throw'; }
+        \\  catch (e) { return e.constructor.name; }
+        \\}
+        \\cls('hour') + ',' + cls('day') + ',' + cls('month');
+    , "RangeError,RangeError,RangeError");
+}
+
 test "native reentry: recursive Array.prototype.map callback throws" {
     // `map`'s callback re-enters JS per element via the native
     // dispatch; an unbounded self-recursion through it must throw.


### PR DESCRIPTION
**Before:** `Temporal.Instant.prototype.toString({ smallestUnit: "hour", timeZone: 5 })` threw a `TypeError` ("time zone must be a string…") from coercing the `timeZone` option. The same happened for a date-unit `smallestUnit` (`"day"`, `"month"`) combined with a non-string `timeZone`.

**After:** it throws the spec-required `RangeError` from validating `smallestUnit`, which the spec sequences before the `timeZone` value is coerced.

**How:** In `instantToString` (`src/runtime/builtins/temporal/instant.zig`), the combined timeZone block was split into three ordered steps that follow the Temporal spec for `Temporal.Instant.prototype.toString`: (1) the raw `Get(options, "timeZone")`, (2) `requireToStringSmallestUnit` range validation (`RangeError` for units below minute — hour and date units), (3) `ToTemporalTimeZoneIdentifier` coercion of the timeZone value. This preserves the observable raw-read order the test262 order-of-operations fixtures assert (`options-read-before-algorithmic-validation.js` requires `get options.timeZone` to be observed before the smallestUnit RangeError), while ensuring the smallestUnit `RangeError` precedes the timeZone-coercion `TypeError`. The misleading doc-comment on `requireToStringSmallestUnit` in `shared.zig` was corrected to describe read-before-validation / validate-before-coercion. A regression test was added in `src/runtime/lantern/tests.zig`.

**Verification:** `zig build test-fast` green; `built-ins/Temporal/Instant/prototype/toString` 55/55; full `Temporal` sweep unchanged at 6639 passing / 1 failing (the single fail is a by-design Annex B `String.prototype.substr` decline, unrelated to this change); no `--only-failing` regressions.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BrNfRKLYCWJWKVJVwXYsL)_