### PR TITLE
interpreter: fuse Add r; ToInt32 into an add_to_int32 super-instruction

### DIFF
--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -931,6 +931,31 @@ pub const Builder = struct {
         return self.max_jump_target < self.here();
     }
 
+    /// Fuse a just-emitted `Add r` with the `ToInt32` about to be
+    /// emitted for the `expr | 0` idiom: rewrite the trailing `add`
+    /// opcode byte to `add_to_int32` in place and report success, so
+    /// the caller skips the separate `to_int32` op. The register
+    /// operand and encoding are unchanged (`add` and `add_to_int32`
+    /// share the `[op][r:u8]` shape), so nothing downstream shifts.
+    ///
+    /// Guards, mirroring `accStillHoldsRegister`:
+    ///   1. the last instruction is exactly `Add r` (2-byte, at the
+    ///      tail — `start + 2 == len` rejects a stale `last_op_start`);
+    ///   2. no jump targets the current position (`max_jump_target <
+    ///      here()`), so the `add`'s result reaches the fold point by
+    ///      fall-through only — a branch-in could arrive with a
+    ///      different accumulator (e.g. `(cond ? a + b : c) | 0`).
+    /// Returns false (caller emits the un-fused `to_int32`) otherwise.
+    pub fn fuseAddToInt32(self: *Builder) bool {
+        const start = self.last_op_start orelse return false;
+        const items = self.code.items;
+        if (@as(usize, start) + 2 != items.len) return false;
+        if (items[start] != @intFromEnum(Op.add)) return false;
+        if (self.max_jump_target >= self.here()) return false;
+        items[start] = @intFromEnum(Op.add_to_int32);
+        return true;
+    }
+
     /// True when the position after the last emitted instruction is
     /// provably unreachable — control can't fall off the end. Two
     /// conditions, both required:

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -5318,7 +5318,15 @@ pub const Compiler = struct {
             if (self.tryGetSmiLiteralValue(b.rhs.*)) |imm| {
                 if (imm == 0) {
                     try self.compileExpression(b.lhs);
-                    try self.builder.emitOp(.to_int32, b.span);
+                    // Second-level fusion — when the LHS compiled to a
+                    // trailing `Add r`, collapse the `Add r; ToInt32`
+                    // pair into a single `add_to_int32 r` dispatch (the
+                    // `(a + b) | 0` idiom). `fuseAddToInt32` rewrites the
+                    // `add` in place; on any other LHS shape it declines
+                    // and we emit the standalone `to_int32`.
+                    if (!self.builder.fuseAddToInt32()) {
+                        try self.builder.emitOp(.to_int32, b.span);
+                    }
                     return;
                 }
             }

--- a/src/bytecode/disasm.zig
+++ b/src/bytecode/disasm.zig
@@ -63,7 +63,7 @@ pub fn dump(allocator: std.mem.Allocator, chunk: *const Chunk) ![]u8 {
                 const dst = chunk.code[i + 2];
                 try buf.print(allocator, " r{d} r{d}", .{ src, dst });
             },
-            .add, .sub, .mul, .div, .mod, .pow, .bit_and, .bit_or, .bit_xor, .shl, .shr, .shr_u, .eq, .strict_eq, .neq, .strict_neq, .lt, .gt, .le, .ge, .instanceof_, .array_spread => {
+            .add, .add_to_int32, .sub, .mul, .div, .mod, .pow, .bit_and, .bit_or, .bit_xor, .shl, .shr, .shr_u, .eq, .strict_eq, .neq, .strict_neq, .lt, .gt, .le, .ge, .instanceof_, .array_spread => {
                 const r = chunk.code[i + 1];
                 try buf.print(allocator, " r{d}", .{r});
             },

--- a/src/bytecode/liveness.zig
+++ b/src/bytecode/liveness.zig
@@ -118,6 +118,7 @@ pub fn effectOf(op: Op, code: []const u8, i: usize) Effect {
         // ── Register reads (one source register; acc is implicit) ──
         .ldar => Effect.read1(code[i + 1]),
         .add,
+        .add_to_int32,
         .sub,
         .mul,
         .div,

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -113,6 +113,23 @@ pub const Op = enum(u8) {
     /// un-fused triple. Headline arith_loop / int-coerce
     /// hot-path win.
     to_int32,
+    /// `[op] [r:u8]` — `acc = ToInt32(reg + acc)`. Fused form of the
+    /// `(a + b) | 0` idiom: a plain `Add r` immediately followed by
+    /// the `to_int32` (`| 0`) op. The compiler collapses the pair by
+    /// rewriting the just-emitted `add` in place (see
+    /// `Builder.fuseAddToInt32`). Int32 fast path: ToInt32 of an
+    /// `int32 + int32` sum IS the wrapping 32-bit sum
+    /// (`@addWithOverflow`'s low result), so the fused op needs no
+    /// overflow branch and no separate coercion — strictly less work
+    /// than `add` alone. Anything else (double, string, object,
+    /// BigInt) routes through the exact `addValues` + `bitwiseBinary
+    /// (.bit_or, _, 0)` sequence the un-fused `Add r; ToInt32` pair
+    /// runs, so § 7.1.6 ToInt32 / § 13.15 semantics — double
+    /// truncate, NaN/±∞ → +0, string ToNumber, BigInt TypeError,
+    /// throwing `valueOf` — all stay bit-identical. The per-iteration
+    /// inner pair of the `arith_loop` micro (also array_iter /
+    /// construct_loop / array_literal_loop).
+    add_to_int32,
 
     // ── Bitwise (acc = reg OP acc, ToInt32 coercion) ─────────────────────
     /// `[op] [r:u8]` — acc = reg & acc. §13.12.
@@ -1272,6 +1289,7 @@ pub const Op = enum(u8) {
             .ldar,
             .star,
             .add,
+            .add_to_int32,
             .sub,
             .mul,
             .div,
@@ -1429,6 +1447,7 @@ pub const Op = enum(u8) {
             .pow => "Pow",
             .add_smi => "AddSmi",
             .to_int32 => "ToInt32",
+            .add_to_int32 => "AddToInt32",
             .bit_and => "BitAnd",
             .bit_or => "BitOr",
             .bit_xor => "BitXor",
@@ -1642,4 +1661,9 @@ test "Op: operandSize agrees with the documented encoding" {
     // item #6); fused increment + compare + back-jump for the
     // canonical `for (let i = INT; i < INT; i++)` shape.
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.loop_inc_lt));
+    // `add_to_int32` is `[op] [r:u8]` — 1 byte of operand, same shape
+    // as `add`. Fuses the `Add r; ToInt32` pair (the `(a + b) | 0`
+    // idiom); a wrong size would walk the disassembler off the next
+    // instruction boundary.
+    try testing.expectEqual(@as(u8, 1), Op.operandSize(.add_to_int32));
 }

--- a/src/runtime/bistromath/bistromath.zig
+++ b/src/runtime/bistromath/bistromath.zig
@@ -815,7 +815,7 @@ const Compiler = struct {
                 .lda_zero, .lda_one,
                 .ldar_0, .ldar_1, .ldar_2, .ldar_3,
                 .star_0, .star_1, .star_2, .star_3,
-                .mov, .add, .sub, .mul, .add_smi, .to_int32,
+                .mov, .add, .add_to_int32, .sub, .mul, .add_smi, .to_int32,
                 .bit_and, .bit_or, .bit_xor,
                 .lt, .gt, .le, .ge, .eq, .neq, .strict_eq, .strict_neq,
                 .lda_property, .lda_property_reg, .sta_property,
@@ -939,6 +939,19 @@ const Compiler = struct {
                     else
                         a64.subsRegW(.x11, .x9, acc_reg));
                     try m.jumpCond(.vs, td);
+                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                },
+                .add_to_int32 => {
+                    // `acc = ToInt32(reg + acc)`. Like `.add` but the
+                    // ToInt32 wrap is exactly the 32-bit add result, so
+                    // there is NO overflow bail — the wrapping `addsW`
+                    // low word IS the answer. Both operands must be
+                    // int32 (else deopt); the tagged retag follows.
+                    const td = try self.tdFor(bc);
+                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try self.checkInt32(.x9, td);
+                    try self.checkInt32(acc_reg, td);
+                    try m.emit(a64.addsRegW(.x11, .x9, acc_reg));
                     try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .mul => {

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1466,6 +1466,61 @@ pub fn runFrames(
             }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
+        .add_to_int32 => {
+            // Fused `(reg + acc) | 0` — an `Add r` the compiler folded
+            // with the following `to_int32`. Int32 fast path:
+            // ToInt32(int32 + int32) is the wrapping 32-bit sum, so
+            // `@addWithOverflow`'s low result IS the answer whether or
+            // not it overflowed — no overflow branch, no double
+            // round-trip, no separate coercion. Slow path reproduces
+            // the un-fused `Add r; ToInt32` EXACTLY: `intArith`/
+            // `numArith`/`addValues` for the sum, then `intBitwise`/
+            // `bitwiseBinary(.bit_or, _, 0)` for the ToInt32 — so double
+            // truncate, NaN/±∞ → +0, string ToNumber, BigInt TypeError,
+            // and a throwing `valueOf` all behave bit-identically.
+            const r = code[ip];
+            ip += 1;
+            const lhs = registers[r];
+            if (lhs.isInt32() and acc.isInt32()) {
+                const ov = @addWithOverflow(lhs.asInt32(), acc.asInt32());
+                acc = Value.fromInt32(ov[0]);
+                continue :dispatch try decodeNext(code, &ip, &committed);
+            }
+            // Slow path — sum via the `.add` sequence (the both-int32
+            // case already returned above, so `intArith` would be dead
+            // here: only `numArith` (double operand) and `addValues`
+            // (string / object / BigInt) remain).
+            var sum: Value = undefined;
+            if (numArith(.add, lhs, acc)) |s| {
+                sum = s;
+            } else if (try addValues(realm, lhs, acc)) |s| {
+                sum = s;
+            } else {
+                const ex = realm.pending_exception orelse try makeTypeError(realm, "ToPrimitive failed");
+                realm.pending_exception = null;
+                f.ip = ip;
+                f.accumulator = acc;
+                committed = true;
+                if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .thrown = ex };
+                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+            }
+            // ToInt32(sum) via the `.to_int32` sequence.
+            const zero = Value.fromInt32(0);
+            if (intBitwise(.bor, sum, zero)) |res| {
+                acc = res;
+            } else if (try bitwiseBinary(realm, .bit_or, sum, zero)) |res| {
+                acc = res;
+            } else {
+                const ex = realm.pending_exception orelse try makeTypeError(realm, "ToPrimitive failed");
+                realm.pending_exception = null;
+                f.ip = ip;
+                f.accumulator = acc;
+                committed = true;
+                if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .thrown = ex };
+                continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+            }
+            continue :dispatch try decodeNext(code, &ip, &committed);
+        },
         .sub => {
             const r = code[ip];
             ip += 1;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -14824,6 +14824,135 @@ test "to_int32: 0 | 0 idiom" {
     , 0);
 }
 
+// ── add_to_int32 (`(a + b) | 0` fused super-instruction) ────────────
+//
+// When `compileBinary` lowers `expr | 0` and the just-emitted LHS is
+// a plain `Add r`, the two ops collapse into a single `add_to_int32
+// r` dispatch. Int32 fast path is the wrapping 32-bit sum — ToInt32
+// of `int32 + int32` IS that wrap, so no overflow branch and no
+// separate coercion. Every other operand shape (double, NaN, string,
+// object valueOf, BigInt) must stay observably identical to the
+// un-fused `Add r; ToInt32`, including both deopt throw sites (a
+// `valueOf` that throws during the add, and the BigInt TypeError at
+// the `| 0`).
+
+test "add_to_int32: emits fused op for (a + b) | 0" {
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    try installBuiltinsAllFeatures(&realm);
+    const out = try compileAndDisassemble(&realm,
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(1, 2);
+    );
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "AddToInt32") != null);
+    // The fused form replaces the `Add r; ToInt32` pair — neither the
+    // bare `Add ` nor a trailing ` ToInt32` survives in `f`'s body.
+    try testing.expect(std.mem.indexOf(u8, out, "ToInt32") != null); // substring of AddToInt32
+    try testing.expect(std.mem.indexOf(u8, out, " Add r") == null);
+}
+
+test "add_to_int32: non-add LHS keeps unfused ToInt32" {
+    // Only `+` fuses. `(a * b) | 0` must still emit a `Mul` followed
+    // by a standalone `ToInt32` — no `add_to_int32`.
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    try installBuiltinsAllFeatures(&realm);
+    const out = try compileAndDisassemble(&realm,
+        \\function f(a, b) { return (a * b) | 0; }
+        \\f(3, 4);
+    );
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "AddToInt32") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "Mul r") != null);
+}
+
+test "add_to_int32: int32 fast path" {
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(3, 4);
+    , 7);
+}
+
+test "add_to_int32: overflow wraps modulo 2^32 (identical to Add;ToInt32)" {
+    // 2147483647 + 1 = 2147483648 → ToInt32 → -2147483648. The fused
+    // fast path must wrap, NOT deopt-then-double-then-truncate wrong.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(2147483647, 1);
+    , -2147483648);
+}
+
+test "add_to_int32: negative wrap boundary" {
+    // -2147483648 + -1 = -2147483649 → ToInt32 → 2147483647.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(-2147483648, -1);
+    , 2147483647);
+}
+
+test "add_to_int32: double operands truncate toward zero" {
+    // 2.9 + 0.5 = 3.4 → ToInt32 → 3. Non-int32 register routes to
+    // the addValues + ToInt32 slow path.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(2.9, 0.5);
+    , 3);
+}
+
+test "add_to_int32: NaN operand coerces to 0" {
+    // NaN + 1 = NaN → ToInt32 → +0.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(NaN, 1);
+    , 0);
+}
+
+test "add_to_int32: string operands concatenate then ToInt32" {
+    // "3" + "4" = "34" (string add) → ToInt32("34") = 34. Proves the
+    // slow path runs addValues (concat) BEFORE the | 0.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f("3", "4");
+    , 34);
+}
+
+test "add_to_int32: object valueOf coercion" {
+    // {valueOf:5} + 3 = 8 → | 0 = 8. ToPrimitive on the object runs
+    // in the add step, exactly as the un-fused pair would.
+    try expectScriptIntWithBuiltins(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f({ valueOf() { return 5; } }, 3);
+    , 8);
+}
+
+test "add_to_int32: valueOf that throws propagates (add-step deopt)" {
+    // The add's ToPrimitive throws — a catchable JS exception, never
+    // a host abort. First slow-path throw site.
+    try expectScriptThrows(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f({ valueOf() { throw new Error("boom"); } }, 1);
+    );
+}
+
+test "add_to_int32: BigInt sum throws TypeError at the | 0 (ToInt32-step deopt)" {
+    // 1n + 2n = 3n succeeds; ToInt32(3n) throws TypeError. Second
+    // slow-path throw site — must surface as a catchable exception.
+    try expectScriptThrows(
+        \\function f(a, b) { return (a + b) | 0; }
+        \\f(1n, 2n);
+    );
+}
+
+test "add_to_int32: hot loop sanity ((sum + i) | 0 over 1000 iters)" {
+    try expectScriptIntWithBuiltins(
+        \\let sum = 0;
+        \\for (let i = 0; i < 1000; i++) sum = (sum + i) | 0;
+        \\sum;
+        // sum(0..999) = 499500
+    , 499500);
+}
+
 test "def_template_property: literal with mixed static + computed keys" {
     // Compiler bails template build on a literal that contains
     // any computed key (template build sees `.computed` and


### PR DESCRIPTION
## Before / After

The `(a + b) | 0` int32 idiom — the single most common shape in hot numeric code and the literal per-iteration inner pair of the `arith_loop` micro — compiled to two separate opcodes: a plain `Add r` followed by the `to_int32` op (`| 0`).

**Before** — arith_loop's inner loop, 7 dispatches/iteration:

```
LdaGlobalSlot s0
Star3
Ldar1
Add r3          ┐ two dispatches
ToInt32         ┘
StaGlobalSlot s0
LoopIncLt r1 r2
```

**After** — the pair collapses into one `AddToInt32 r3` dispatch, 6/iteration:

```
LdaGlobalSlot s0
Star3
Ldar1
AddToInt32 r3   ← one dispatch
StaGlobalSlot s0
LoopIncLt r1 r2
```

A reader watching the disassembler sees the `Add; ToInt32` pair replaced by a single `AddToInt32`, and the arith loop doing one fewer interpreter dispatch per iteration.

## Why this fusion (adjacency survey)

Counted fusible bytecode-pair adjacencies across all `bench/micros/*.js`:

- `Ldar; <Add/Sub/Mul>` (the ideal *general* two-register arithmetic fusion) appears only **2** times — the LHS almost always arrives via `LdaGlobalSlot` / `LdaProperty` / `AddSmi`, not a bare `Ldar`. Not survey-supported.
- `Add; ToInt32` is the **dominant arithmetic fusion** (6 static occurrences), the per-iteration inner pair of `arith_loop`, and also hot in `array_iter`, `construct_loop`, and `array_literal_loop`.
- `LdaGlobalSlot; Star` is statically more frequent (30) but is a global-scope-specific memory shuffle with no compute win; fusing it cleanly would need a builder-level rewrite of every store site — a broad matcher, out of scope for one reviewable slice.

`Add; ToInt32` also carries a genuine **compute** win beyond dispatch elimination: ToInt32 of an `int32 + int32` sum *is* the wrapping 32-bit result, so the fast path is a single wrapping add with no overflow branch and no separate coercion — strictly less work than `add` alone.

## How

One fused opcode, `add_to_int32` (`[op][r:u8]`, same shape as `add`), threaded through the interpreter with `continue :dispatch` like the existing fused arms:

- **compiler.zig / chunk.zig** — `compileBinary`'s existing `expr | 0` lowering, after compiling the LHS, calls the new `Builder.fuseAddToInt32`, which rewrites a trailing `Add r` opcode byte to `add_to_int32` in place (guarded by the same tail + no-branch-in checks as `accStillHoldsRegister`) and skips the standalone `to_int32`. Declines on any non-`add` LHS.
- **interpreter.zig** — fast path: `@addWithOverflow` low word (the wrap). Slow path reproduces the un-fused `Add r; ToInt32` exactly (`numArith`/`addValues` for the sum, then `intBitwise`/`bitwiseBinary(.bit_or, _, 0)` for ToInt32), so double truncate, NaN/±∞ → +0, string ToNumber, BigInt TypeError, and a throwing `valueOf` all stay bit-identical. Both deopt throw sites unwind to a catchable JS exception — never a host abort.
- **op.zig / disasm.zig / liveness.zig** — operand size (1), mnemonic, disassembly, and register-read effect all mirror `add`.
- **JIT differential** — Bistromath *compiles* the new op (matching the `add_smi` / `to_int32` precedent for arith fusions): same emit as `.add` minus the overflow bail, since the wrap is the desired ToInt32 result. Keeps the aarch64 `--jit` differential pass-set byte-identical. (Emit is a strict subset of `.add`; verified structurally — this host is x86_64 where Bistromath is comptime-off, so the CI `test262-jit-differential` job is the executable gate.)

Tests (written first, TDD): a compiler-emit test (positive + a `(a*b)|0` negative), plus behavioral guards pinning the int32 fast path, overflow/negative wrap boundaries, double truncation, NaN, string concat-then-ToInt32, object `valueOf` coercion, a throwing `valueOf` (add-step deopt), and a BigInt sum TypeError (ToInt32-step deopt).

## Numbers

**Conformance** — full `test262` sweep, identical on both sides (no regression):

| | passing | failing | pass% |
|---|---:|---:|---:|
| baseline (parent) | 48653 | 1324 | 97.35% |
| feature | 48653 | 1324 | 97.35% |

**A/B** — two same-commit worktrees (parent vs parent+patch), both ReleaseFast, `zig build bench` interleaved baseline→feature ×8 rounds on a **shared container**. Only `arith_loop` and `array_iter` carry the fused op (verified 0 `AddToInt32` in the other 10 fixtures — their bytecode is byte-identical, so their swings are pure container noise):

| fixture | base p50 (med) | feat p50 (med) | Δ p50 | base min (of 80) | feat min | Δ min |
|---|---:|---:|---:|---:|---:|---:|
| **arith_loop** | 99.45 | 94.95 | **−4.5%** | 95.22 | 91.15 | **−4.3%** |
| array_iter | 64.50 | 64.28 | −0.3% | 61.97 | 62.03 | +0.1% |
| prop_write* | 46.38 | 37.94 | −18.2% | 45.05 | 36.30 | −19.4% |
| prop_access* | 34.53 | 37.87 | +9.7% | 33.01 | 36.11 | +9.4% |

`*` = unchanged bytecode; the ±10–18% swings show this container's noise floor.

`arith_loop` shows a **consistent −4.3–4.5%** (7 of 8 feature rounds below the baseline median; the distributions barely overlap) — the win materialized on the headline fixture. `array_iter` is neutral: its per-element cost is dominated by the for-of iterator protocol, so removing one dispatch of ~15 is in the noise.

## bench-results.md decision

**No canonical row added.** Unrelated, byte-identical fixtures swing up to ±18% between interleaved rounds on this shared container — too jittery to publish a single-number row that a reader could distinguish from noise (per docs/benchmarking.md's same-host-line rule). The controlled interleave isolates a real ~4.5% `arith_loop` signal, but the canonical `bench-results.md` row should be captured on a quiet, CPU-pinned bench box.