### PR TITLE
ci(deps): pin xyzzylabs/setup-zig to v1.0.2 with a correct label

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: ${{ matrix.os }}
           # The Linux `.zig-cache` grows to ~2.3 GB (Debug binary +
@@ -163,7 +163,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
 
       - name: zig build fmt-check
         run: zig build fmt-check
@@ -215,7 +215,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: wasm
 
@@ -256,7 +256,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y wabt
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: wasm-testsuite
 
@@ -313,7 +313,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: cross-${{ matrix.target }}
 
@@ -368,7 +368,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
 
       - name: Run test262 (runtime, parallel)
         # Drop `--quiet` so the per-bucket tally lands in the CI
@@ -477,7 +477,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: jit-differential
 
@@ -551,7 +551,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: gc-stress-jit
 
@@ -652,7 +652,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           # Every gc-stress job builds the same ReleaseSafe harness,
           # so share one cache namespace across the matrix.

--- a/.github/workflows/fuzz-nightly.yml
+++ b/.github/workflows/fuzz-nightly.yml
@@ -112,7 +112,7 @@ jobs:
           submodules: false
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
           cache-key: fuzz
 

--- a/.github/workflows/playground.yml
+++ b/.github/workflows/playground.yml
@@ -60,7 +60,7 @@ jobs:
         # the test262 corpus, which the deploy doesn't need.
 
       - name: Set up Zig
-        uses: xyzzylabs/setup-zig@9e74c9ad42fc7d1769f5ea0cd18216fa693a609d  # v1.0.0
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         # Version resolved from `build.zig.zon`'s
         # `minimum_zig_version` — single source of truth across
         # this workflow and `.github/workflows/ci.yml`.


### PR DESCRIPTION
Every `xyzzylabs/setup-zig` pin was on `9e74c9a` with a `# v1.0.0` comment. Both are wrong:

- `9e74c9a` is an **un-released `main` commit** (the "chrysippus app" change), not a tagged release.
- **v1.0.0** is actually `031c931`. The `# v1.0.0` label never matched the pinned SHA.

That defeats the point of the version comment — the whole reason to annotate a SHA-pin is so a reviewer can trust the label reflects the bytes. A drifted label is exactly how a bad pin hides in plain sight.

## This PR

Repins all 11 usages (`ci.yml` ×9, `fuzz-nightly.yml`, `playground.yml`) to:

```
xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
```

`09d85d9` is the real **v1.0.2** (also the current `v1` and `main` head).

## Supersedes #71

Dependabot's #71 advanced the SHA to `09d85d9` (correct) but left the `# v1.0.0` comment (wrong) — it couldn't rewrite a comment that never matched the original SHA. This PR sets both correctly in one commit. Close #71 in favor of this.

Going forward Dependabot will track `v1.0.x` releases and label bumps correctly, because `09d85d9` is a properly tagged release SHA.

## Note

SHA-pinning itself is correct and stays — this only fixes *which* SHA and the label. `actions/checkout` and `step-security/harden-runner` pins are already accurate and untouched.