### PR TITLE
runtime: overlay object overflow and element storage

### DIFF
--- a/docs/gc-immix-rearchitecture.md
+++ b/docs/gc-immix-rearchitecture.md
@@ -142,7 +142,8 @@ Stage A moved the *cold* clusters (fields null on a plain object). The rest
 of the header is the *storage* fields — empty on a shape-mode object but
 still resident: `properties`/`property_flags` (40 B each), `own_key_order`
 (24 B), `elements` (24 B), `sparse_elements`+`is_sparse`+`sparse_length`
-(~28 B), `inline_slots[4]` (32 B), `overflow_slots` (24 B), `shape` (8 B).
+(~28 B), `inline_slots[4]` (32 B), the then-separate `overflow_slots`
+(24 B; now the overflow role of `secondary_values`), and `shape` (8 B).
 A survey of the property/element substrate splits these into two moves along
 one hard constraint: **Bistromath (the JIT) bakes header offsets into
 emitted machine code.**
@@ -153,7 +154,8 @@ representation. They are empty on every shape-mode object (splay's `Node`s,
 all plain literals — a shaped object stores values in `inline_slots`, never
 the bag), and the JIT deopts to the interpreter for dict-mode objects and
 **never reads these fields**. So they moved into a lazily-allocated
-`DictStore` reached by one pointer (`dict_store`), allocated only on
+`DictStore` reached by one pointer (originally `dict_store`, now the tagged
+`aux_store`), allocated only on
 `demoteFromShape` / first bag write, read through `propsConst`/`propsMut`
 (and the flags/order pair). Shape-mode objects never allocate it, so the
 `is_pristine` fast-death and the shape/IC hot path are undisturbed — the
@@ -183,13 +185,50 @@ byte-identical, `--gc-threshold=1` verifiers green. **The dense `elements`
 vector is deliberately NOT moved** — it is the array hot path (every dense
 index read/write) and belongs to a perf-sensitive "packed JSArray"
 redesign, not a cold move. So header now stands at 176 B (408 → 176 overall,
-−57 %); the remaining big fields — `inline_slots[4]`, `overflow_slots`,
-`shape` — are all JIT-baked and only move under B2.
+−57 %); the remaining big fields — `inline_slots[4]`, the then-separate
+`overflow_slots` (now `secondary_values`), and `shape` — are all JIT-baked
+and only move under B2.
+
+**B1c — overlay the two secondary value-vector headers (IN PROGRESS).**
+Shape-mode named properties need an overflow vector only after the four
+inline slots fill; dense indexed objects need an elements vector. The
+common objects measured in `splay` use one role or the other, yet every
+object currently pays for both 24-byte `ArrayListUnmanaged(Value)` headers.
+`secondary_values` overlays those headers without moving either vector's
+payload. It starts as the dense-elements header. On the first named-slot
+spill, the elements header moves to an exact-sized cold auxiliary record
+only if that same object actually has indexed storage, and
+`secondary_values` becomes the overflow-slot header. The
+`secondary_is_overflow` transition is monotonic, so
+`layout.object.overflow_items_ptr` remains one direct JIT load even after a
+later shape demotion. A tagged auxiliary store composes the rare mixed
+elements-plus-dictionary case from stable child pointers; ordinary shaped
+objects and ordinary dense arrays allocate no new sidecar.
+
+This is a deliberately smaller step than JavaScriptCore's
+[Butterfly](https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/runtime/Butterfly.h),
+which lays property and indexed storage around one out-of-line allocation.
+SpiderMonkey's
+[NativeObject](https://searchfox.org/mozilla-central/source/js/src/vm/NativeObject.h)
+and Hermes'
+[JSObject](https://github.com/facebook/hermes/blob/main/include/hermes/VM/JSObject.h)
+instead keep direct slots plus separate out-of-line storage. The overlay
+keeps Cynic's existing element and compiled-slot access shapes, trading a
+cold allocation only for the uncommon object that uses both roles.
+
+The representation is not ECMAScript-observable: §10.1 ordinary-object
+property operations and §10.4.2 array-exotic indexed semantics must remain
+identical. The implementation gate therefore includes both construction
+orders for mixed named/indexed objects, deletion and shape demotion,
+snapshot round trips, GC marking/deinit under allocation pressure, and the
+JIT layout proof. test262's property/array buckets and the SES hardened-
+primordial suite must remain unchanged. Header-size and peak-RSS results
+will be recorded after those gates and the remote macro run complete.
 
 **B2 — the hot-field / uniform-header move (JIT lane, the actual ~75 MB
-target).** `shape` + `inline_slots` + `overflow_slots` (and `elements`) are
-the shape-mode value storage — the hot path. Moving them out-of-line to
-reach ~90 B is where the 4× RSS outlier actually closes, but it is
+target).** `shape` + `inline_slots` + the overlaid `secondary_values`
+header are still resident hot-path storage. Moving them fully out-of-line
+to reach ~90 B is where the 4× RSS outlier actually closes, but it is
 **machine-code-coupled**: `src/runtime/jit/layout.zig` is the single source
 of truth for `object.shape` / `object.inline_slots` /
 `object.overflow_items_ptr` / `inline_slot_cap`, and `emitLoadSlot` /

--- a/docs/gc-immix-rearchitecture.md
+++ b/docs/gc-immix-rearchitecture.md
@@ -189,7 +189,7 @@ redesign, not a cold move. So header now stands at 176 B (408 → 176 overall,
 `overflow_slots` (now `secondary_values`), and `shape` — are all JIT-baked
 and only move under B2.
 
-**B1c — overlay the two secondary value-vector headers (IN PROGRESS).**
+**B1c — overlay the two secondary value-vector headers (SHIPPED).**
 Shape-mode named properties need an overflow vector only after the four
 inline slots fill; dense indexed objects need an elements vector. The
 common objects measured in `splay` use one role or the other, yet every
@@ -222,8 +222,20 @@ identical. The implementation gate therefore includes both construction
 orders for mixed named/indexed objects, deletion and shape demotion,
 snapshot round trips, GC marking/deinit under allocation pressure, and the
 JIT layout proof. test262's property/array buckets and the SES hardened-
-primordial suite must remain unchanged. Header-size and peak-RSS results
-will be recorded after those gates and the remote macro run complete.
+primordial suite remain unchanged.
+
+**Result: the later packed-brand baseline falls from 168 → 144 B per
+`JSObject` (−24 B, −14.3%).** On the pinned remote box, interpreter Splay
+falls from **201,856 → 183,664 KiB peak RSS** (−18,192 KiB / −17.77 MiB,
+−9.01%), matching the 768,000-live-object prediction (18,000 KiB) within
+allocator/page noise. It also gets slightly faster: absolute p50
+**688.05 → 660.14 ms** (−4.1%), while the interleaved five-pair comparison
+reports **0.968×** with 4.9% ratio spread. The adjacent interpreter micro
+smokes (`array_iter`, property read/write, object allocation, constructor
+array build) show no stable regression; their small ±3–8% movements carry
+11.7–26.0% spread except Splay's low-noise result. ReleaseSafe unit tests,
+the SES suite, allocation-pressure Array/Object/object-expression buckets,
+and the JIT layout/Bistromath/Ohaimark proofs stay green.
 
 **B2 — the hot-field / uniform-header move (JIT lane, the actual ~75 MB
 target).** `shape` + `inline_slots` + the overlaid `secondary_values`

--- a/docs/lazy-property-bag.md
+++ b/docs/lazy-property-bag.md
@@ -209,7 +209,8 @@ These need to route to the shape when the object is shape-mode:
 objects it must walk the shape slots `obj.slotAt(i)` for `i` in
 `0..obj.slotCount()` instead — the values live inline in the JSObject
 header plus an overflow buffer, reached through the slot accessors
-(`JSObject.inline_slots` / `overflow_slots`). (The shape itself is
+(`JSObject.inline_slots` / the overflow view of `secondary_values`).
+(The shape itself is
 realm-lifetime, not GC-managed, so no extra trace.)
 
 `deinitFields` likewise has to skip the bag teardown when the bag

--- a/docs/realm-snapshots.md
+++ b/docs/realm-snapshots.md
@@ -320,10 +320,12 @@ hooks above.
   back-pointer disappears. `pinned`, `length_cu`, `byte_len` copied.
 - `JSObject` (`object.zig:821`): `properties` /
   `property_flags` (StringArrayHashMaps — key slices + Values),
-  `shape: ?*Shape`, `inline_slots[4]` + `overflow_slots` +
+  `shape: ?*Shape`, `inline_slots[4]` + the overflow view of
+  `secondary_values` +
   `slot_count` (`object.zig:819` `inline_slot_cap = 4`;
   `object.zig:862-864`), `heap` back-pointer (restamp), `prototype` /
-  `prototype_fn`, `elements` / `sparse_elements` (+
+  `prototype_fn`, dense elements (the alternate `secondary_values`
+  role, with an aux header on mixed objects) / `sparse_elements` (+
   `elements_pooled`, `object.zig:1230` — pooled buffers must be
   re-drawn from the pool or unpooled at restore), `key_anchors`
   (`object.zig:1241`), `own_key_order` (`object.zig:1262` — borrowed
@@ -591,7 +593,8 @@ needs a `snapshot_arena` field or ownership hook on `Realm`
   post-restore transitions dedupe against the snapshot's tree
   exactly as against the original.
 - Shape-mode objects: `slot_count` + the first 4 values from
-  `inline_slots` + `overflow_slots` serialize as one logical slot
+  `inline_slots` + the overflow view of `secondary_values` serialize
+  as one logical slot
   vector (encoder reads through `slotAt`, decoder writes through
   `setSlot`/`resizeSlots` equivalents, keeping the inline/overflow
   split an implementation detail per `object.zig:857-859`).

--- a/src/runtime/bistromath/bistromath.zig
+++ b/src/runtime/bistromath/bistromath.zig
@@ -3342,10 +3342,10 @@ test "jit bistromath: dense array literals compile via make_array_n" {
     };
     const arr = heap_mod.valueAsPlainObject(v) orelse return error.NotAnArray;
     try testing.expect(arr.brand.is_array_exotic);
-    try testing.expectEqual(@as(usize, 3), arr.elements.items.len);
-    try testing.expectEqual(@as(i32, 10), arr.elements.items[0].asInt32());
-    try testing.expectEqual(@as(i32, 20), arr.elements.items[1].asInt32());
-    try testing.expectEqual(@as(i32, 30), arr.elements.items[2].asInt32());
+    try testing.expectEqual(@as(usize, 3), arr.elementCount());
+    try testing.expectEqual(@as(i32, 10), arr.elementItems()[0].asInt32());
+    try testing.expectEqual(@as(i32, 20), arr.elementItems()[1].asInt32());
+    try testing.expectEqual(@as(i32, 30), arr.elementItems()[2].asInt32());
     try testing.expectEqual(
         Chunk.JitState.Tier.compiled,
         templateNamed(&chunk, "build").jit_state.?.bistromath.code.tier,

--- a/src/runtime/builtins/collections.zig
+++ b/src/runtime/builtins/collections.zig
@@ -544,8 +544,8 @@ fn arrayLikeIterStep(realm: *Realm, this_value: Value) StepOutcome {
         } else if (obj.brand.is_array_exotic and !obj.brand.is_sparse) {
             // §23.1.5.2.1 step 6 — fast path for a dense Array
             // exotic. `length` is a data property kept synced with
-            // `elements.items.len`, and in-range data slots live
-            // directly in `elements`, so `Get(O, "length")` and
+            // `elementCount()`, and in-range data slots live in dense
+            // element storage, so `Get(O, "length")` and
             // `Get(O, Pk)` are observably equivalent to a direct
             // vector read. Holes and descriptor-flag-promoted slots
             // read back as the hole sentinel — fall through to the

--- a/src/runtime/builtins/harden.zig
+++ b/src/runtime/builtins/harden.zig
@@ -24,8 +24,8 @@
 //!     Proxy.harden would route through the trap; defer.
 //!   - Recursion uses the Zig stack; pathological depth would
 //!     overflow. Real-world capability graphs are shallow.
-//!   - Array-exotic indexed slots (§10.4.2) live in
-//!     `obj.elements`, not `obj.propsConst()`, so the bag-only
+//!   - Array-exotic indexed slots (§10.4.2) live in dense
+//!     element storage, not `obj.propsConst()`, so the bag-only
 //!     walk below misses them. The root array becomes non-
 //!     extensible and the *values* at each slot freeze
 //!     transitively (good), but `a[0] = …` doesn't throw on
@@ -188,7 +188,7 @@ pub fn hardenWalk(realm: *Realm, v: Value, visited: *std.AutoHashMap(usize, void
         var rit = obj.iterOwnNamedKeys();
         while (rit.next()) |e| try hardenWalk(realm, e.value_ptr.*, visited);
         // Recurse into array indexed slots. `iterOwnNamedKeys`
-        // skips these — they live in `obj.elements` /
+        // skips these — they live in dense element storage /
         // `obj.sparseConst()` per the array-exotic layout, not
         // in the named-property bag. The harden contract is
         // "deep-freeze every reachable value," and an array of
@@ -199,7 +199,7 @@ pub fn hardenWalk(realm: *Realm, v: Value, visited: *std.AutoHashMap(usize, void
         // this only recurses into the VALUES so transitive
         // freezing actually reaches them.
         if (obj.brand.is_array_exotic) {
-            for (obj.elements.items) |elem| try hardenWalk(realm, elem, visited);
+            for (obj.elementItems()) |elem| try hardenWalk(realm, elem, visited);
             var sit = obj.sparseConst().iterator();
             while (sit.next()) |e| try hardenWalk(realm, e.value_ptr.*, visited);
         }

--- a/src/runtime/builtins/object.zig
+++ b/src/runtime/builtins/object.zig
@@ -261,9 +261,10 @@ pub fn ownPropertyKeysOrdered(
                 integer_keys.append(realm.allocator, .{ .idx = idx, .key = owned.flatBytes() }) catch return error.OutOfMemory;
             }
         } else {
+            const elements = obj.elementItems();
             var ei: u32 = 0;
-            while (ei < obj.elements.items.len) : (ei += 1) {
-                if (JSObject.isElementHole(obj.elements.items[ei])) continue;
+            while (ei < elements.len) : (ei += 1) {
+                if (JSObject.isElementHole(elements[ei])) continue;
                 var ibuf: [16]u8 = undefined;
                 const ks = std.fmt.bufPrint(&ibuf, "{d}", .{ei}) catch continue;
                 const owned = realm.heap.allocateString(ks) catch return error.OutOfMemory;
@@ -3161,7 +3162,7 @@ fn objectFreeze(realm: *Realm, this_value: Value, args: []const Value) NativeErr
     }
     obj.brand.extensible = false;
     // §10.4.2 — for Array exotic objects, indexed elements live
-    // in `obj.elements` (or `sparse_elements`) and default to
+    // in dense (or sparse) element storage and default to
     // `{w:true, e:true, c:true}`. SetIntegrityLevel(O, frozen)
     // must lower them to `{w:false, e:true, c:false}`; promote
     // each present indexed slot into `property_flags` keyed by
@@ -3238,9 +3239,10 @@ fn lowerArrayIndexedFlags(realm: *Realm, obj: *JSObject, sealed_only: bool) Nati
             try indices.append(realm.allocator, entry.key_ptr.*);
         }
     } else {
+        const elements = obj.elementItems();
         var i: u32 = 0;
-        while (i < obj.elements.items.len) : (i += 1) {
-            if (JSObject.isElementHole(obj.elements.items[i])) continue;
+        while (i < elements.len) : (i += 1) {
+            if (JSObject.isElementHole(elements[i])) continue;
             try indices.append(realm.allocator, i);
         }
     }
@@ -3433,7 +3435,7 @@ fn objectIsSealed(realm: *Realm, this_value: Value, args: []const Value) NativeE
 
 /// `true` iff `obj` is an Array exotic with at least one
 /// present indexed slot whose descriptor hasn't been lowered
-/// into the property bag. Indexed slots in `obj.elements` /
+/// into the property bag. Indexed slots in dense element storage /
 /// `obj.sparseConst()` default to `{w,e,c} = true` (per
 /// §10.4.2) — `isSealed` / `isFrozen` must observe that as
 /// "not sealed" until SetIntegrityLevel promotes the slots.
@@ -3450,9 +3452,10 @@ fn hasUnlockedIndexedElements(obj: *JSObject) bool {
         }
         return false;
     }
+    const elements = obj.elementItems();
     var i: u32 = 0;
-    while (i < obj.elements.items.len) : (i += 1) {
-        if (JSObject.isElementHole(obj.elements.items[i])) continue;
+    while (i < elements.len) : (i += 1) {
+        if (JSObject.isElementHole(elements[i])) continue;
         var ibuf: [16]u8 = undefined;
         const ks = std.fmt.bufPrint(&ibuf, "{d}", .{i}) catch return true;
         if (!obj.ownDataContains(ks)) return true;

--- a/src/runtime/builtins/string.zig
+++ b/src/runtime/builtins/string.zig
@@ -2209,7 +2209,7 @@ pub fn regexReplace(
         const match_arr = heap_mod.valueAsPlainObject(exec_result) orelse break;
         // The match array and the whole-match string survive the
         // functional-replacer GC only if rooted: the captures live
-        // in `match_arr.elements`, so rooting `match_arr` keeps the
+        // in `match_arr`'s dense elements, so rooting it keeps the
         // whole capture set reachable through `appendRegexReplacement`.
         const iter_scope = realm.heap.openScope() catch return error.OutOfMemory;
         defer iter_scope.close();

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -1205,10 +1205,11 @@ pub const Heap = struct {
         const obj = self.allocateObject() catch return error.OutOfMemory;
         self.setObjectPrototype(obj, array_prototype);
         obj.markAsArrayExotic(self.allocator) catch return error.OutOfMemory;
+        const elements = obj.elementsMut(self.allocator) catch return error.OutOfMemory;
         const buf = self.element_buf_pool.create(self.allocator) catch return error.OutOfMemory;
-        obj.elements = .{ .items = buf[0..0], .capacity = element_buf_cap };
+        elements.* = .{ .items = buf[0..0], .capacity = element_buf_cap };
         obj.brand.elements_pooled = true;
-        obj.elements.appendSliceAssumeCapacity(elems);
+        elements.appendSliceAssumeCapacity(elems);
         obj.markNonPristine();
         return obj;
     }
@@ -1234,7 +1235,7 @@ pub const Heap = struct {
         if (!aobj.brand.is_array_exotic or aobj.brand.is_sparse or
             aobj.getProxyTarget() != null or aobj.brand.proxy_revoked) return null;
         const idx: usize = @intCast(ik);
-        const els = aobj.elements.items;
+        const els = aobj.elementItems();
         if (idx >= els.len or JSObject.isElementHole(els[idx])) return null;
         return els[idx];
     }
@@ -1260,18 +1261,18 @@ pub const Heap = struct {
         if (!aobj.brand.is_array_exotic or aobj.brand.is_sparse or aobj.brand.is_proxy) return false;
 
         const idx: usize = @intCast(ik);
-        const els = aobj.elements.items;
+        const els = aobj.elementItems();
         if (idx >= els.len or JSObject.isElementHole(els[idx])) return false;
 
         // Array exotics normally keep indexed values exclusively in
-        // `elements`. Be conservative around any named representation:
+        // dense element storage. Be conservative around any named representation:
         // `markAsArrayExotic` can brand a pre-shaped object, and an
         // indexed descriptor demotion can leave bag/flag metadata that
         // must win over a blind packed-vector store. Accessors live in
         // the extension independently of the dictionary pointer.
         if (aobj.shape != null or aobj.dictStore() != null or aobj.accessorCount() != 0) return false;
 
-        aobj.elements.items[idx] = v;
+        aobj.elementItemsMut()[idx] = v;
         // The direct store bypasses `JSObject.setIndexed`, so preserve
         // both its mature→young remembered-set edge and its Dijkstra
         // incremental-marking shade explicitly.
@@ -1969,7 +1970,7 @@ pub const Heap = struct {
                         var sit = o.sparseConst().iterator();
                         while (sit.next()) |entry| self.enqueue(entry.value_ptr.*);
                     } else {
-                        for (o.elements.items) |elem| self.enqueue(elem);
+                        for (o.elementItems()) |elem| self.enqueue(elem);
                     }
                 }
                 // §26.1 WeakRef — the `[[WeakRefTarget]]` is a weak
@@ -4260,7 +4261,7 @@ pub const Heap = struct {
                         }
                     }
                 } else {
-                    for (o.elements.items, 0..) |elem, idx| {
+                    for (o.elementItems(), 0..) |elem, idx| {
                         if (isYoungHeapValue(elem) and !o.dirty) {
                             std.debug.print(
                                 "verifyRememberedSet: un-barriered mature\u{2192}young edge: " ++
@@ -5123,8 +5124,8 @@ test "Heap: denseElementFastSet overwrites only clean existing packed elements" 
     const arr = try heap.makeDenseArray(null, &.{ Value.fromInt32(10), Value.fromInt32(20) });
     const arr_v = taggedObject(arr);
     try testing.expect(heap.denseElementFastSet(arr_v, Value.fromInt32(1), Value.fromInt32(99)));
-    try testing.expectEqual(@as(i32, 10), arr.elements.items[0].asInt32());
-    try testing.expectEqual(@as(i32, 99), arr.elements.items[1].asInt32());
+    try testing.expectEqual(@as(i32, 10), arr.elementItems()[0].asInt32());
+    try testing.expectEqual(@as(i32, 99), arr.elementItems()[1].asInt32());
     try testing.expectEqual(@as(u32, 2), arr.arrayLength());
 
     // P0 deliberately accepts only non-negative int32 keys. Numeric
@@ -5134,17 +5135,17 @@ test "Heap: denseElementFastSet overwrites only clean existing packed elements" 
     try testing.expect(!heap.denseElementFastSet(arr_v, Value.fromDouble(-0.0), Value.fromInt32(1)));
     try testing.expect(!heap.denseElementFastSet(arr_v, Value.fromDouble(1.0), Value.fromInt32(1)));
     try testing.expect(!heap.denseElementFastSet(arr_v, Value.fromInt32(2), Value.fromInt32(1)));
-    try testing.expectEqual(@as(i32, 10), arr.elements.items[0].asInt32());
-    try testing.expectEqual(@as(i32, 99), arr.elements.items[1].asInt32());
+    try testing.expectEqual(@as(i32, 10), arr.elementItems()[0].asInt32());
+    try testing.expectEqual(@as(i32, 99), arr.elementItems()[1].asInt32());
 
     const holed = try heap.makeDenseArray(null, &.{Value.hole_});
     try testing.expect(!heap.denseElementFastSet(taggedObject(holed), Value.fromInt32(0), Value.fromInt32(1)));
-    try testing.expect(JSObject.isElementHole(holed.elements.items[0]));
+    try testing.expect(JSObject.isElementHole(holed.elementItems()[0]));
 
     const ordinary = try heap.allocateObject();
     try ordinary.setIndexed(heap.allocator, 0, Value.fromInt32(3));
     try testing.expect(!heap.denseElementFastSet(taggedObject(ordinary), Value.fromInt32(0), Value.fromInt32(4)));
-    try testing.expectEqual(@as(i32, 3), ordinary.elements.items[0].asInt32());
+    try testing.expectEqual(@as(i32, 3), ordinary.elementItems()[0].asInt32());
 
     const sparse = try heap.allocateObject();
     try sparse.markAsArrayExotic(heap.allocator);
@@ -5156,7 +5157,7 @@ test "Heap: denseElementFastSet overwrites only clean existing packed elements" 
     const proxy_branded = try heap.makeDenseArray(null, &.{Value.fromInt32(7)});
     proxy_branded.brand.is_proxy = true;
     try testing.expect(!heap.denseElementFastSet(taggedObject(proxy_branded), Value.fromInt32(0), Value.fromInt32(8)));
-    try testing.expectEqual(@as(i32, 7), proxy_branded.elements.items[0].asInt32());
+    try testing.expectEqual(@as(i32, 7), proxy_branded.elementItems()[0].asInt32());
 
     // Array exotics can be branded after acquiring a shape. A numeric
     // shape descriptor could then coexist with indexed storage, so the
@@ -5167,7 +5168,7 @@ test "Heap: denseElementFastSet overwrites only clean existing packed elements" 
     try shaped.markAsArrayExotic(heap.allocator);
     try shaped.setIndexed(heap.allocator, 0, Value.fromInt32(9));
     try testing.expect(!heap.denseElementFastSet(taggedObject(shaped), Value.fromInt32(0), Value.fromInt32(10)));
-    try testing.expectEqual(@as(i32, 9), shaped.elements.items[0].asInt32());
+    try testing.expectEqual(@as(i32, 9), shaped.elementItems()[0].asInt32());
 
     // Descriptor-demoted indexed entries and accessors live outside
     // the packed vector. Conservatively reject any dictionary or
@@ -5177,14 +5178,14 @@ test "Heap: denseElementFastSet overwrites only clean existing packed elements" 
     try dictionary.set(heap.allocator, "meta", Value.fromInt32(1));
     try testing.expect(dictionary.dictStore() != null);
     try testing.expect(!heap.denseElementFastSet(taggedObject(dictionary), Value.fromInt32(0), Value.fromInt32(12)));
-    try testing.expectEqual(@as(i32, 11), dictionary.elements.items[0].asInt32());
+    try testing.expectEqual(@as(i32, 11), dictionary.elementItems()[0].asInt32());
 
     const accessor_bearing = try heap.makeDenseArray(null, &.{Value.fromInt32(13)});
     const accessor = try accessor_bearing.getOrPutAccessor(heap.allocator, "meta");
     if (!accessor.found_existing) accessor.value_ptr.* = .{};
     try testing.expectEqual(@as(usize, 1), accessor_bearing.accessorCount());
     try testing.expect(!heap.denseElementFastSet(taggedObject(accessor_bearing), Value.fromInt32(0), Value.fromInt32(14)));
-    try testing.expectEqual(@as(i32, 13), accessor_bearing.elements.items[0].asInt32());
+    try testing.expectEqual(@as(i32, 13), accessor_bearing.elementItems()[0].asInt32());
 }
 
 test "Heap: denseElementFastSet remembers a young child stored into a mature array" {
@@ -5205,7 +5206,7 @@ test "Heap: denseElementFastSet remembers a young child stored into a mature arr
     // store's write barrier can make the mature array a minor-GC root.
     heap.collectYoung(&.{});
     try testing.expectEqual(Generation.mature, child.generation);
-    try testing.expectEqual(taggedObject(child).bits, arr.elements.items[0].bits);
+    try testing.expectEqual(taggedObject(child).bits, arr.elementItems()[0].bits);
     try testing.expectEqual(@as(i32, 42), child.get("tag").asInt32());
     try testing.expect(!arr.dirty);
     try testing.expectEqual(@as(usize, 0), heap.dirty_list.items.len);
@@ -5894,6 +5895,45 @@ test "Heap: major mark scans each shape-mode named value once" {
     while (i < n) : (i += 1) {
         try testing.expectEqual(@as(i32, @intCast(i)), children[i].get("tag").asInt32());
     }
+}
+
+test "Heap: major mark scans named overflow and spilled dense elements" {
+    var heap = Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    const object_mod = @import("object.zig");
+    const owner = try heap.allocateObject();
+    const named_count: usize = object_mod.inline_slot_cap + 2;
+    var named_children: [object_mod.inline_slot_cap + 2]*object_mod.JSObject = undefined;
+    var keys: [object_mod.inline_slot_cap + 2][1]u8 = undefined;
+
+    for (0..named_count) |i| {
+        const child = try heap.allocateObject();
+        try child.set(heap.allocator, "tag", Value.fromInt32(@intCast(i)));
+        named_children[i] = child;
+        keys[i] = .{@as(u8, 'a') + @as(u8, @intCast(i))};
+        try heap.storeProperty(owner, heap.allocator, &keys[i], taggedObject(child));
+    }
+    try owner.markAsArrayExotic(heap.allocator);
+
+    const element_a = try heap.allocateObject();
+    const element_b = try heap.allocateObject();
+    try element_a.set(heap.allocator, "tag", Value.fromInt32(101));
+    try element_b.set(heap.allocator, "tag", Value.fromInt32(202));
+    try owner.setIndexed(heap.allocator, 0, taggedObject(element_a));
+    try owner.setIndexed(heap.allocator, 1, taggedObject(element_b));
+
+    try testing.expect(owner.brand.secondary_is_overflow);
+    try testing.expectEqual(named_count, owner.slotCount());
+    try testing.expectEqual(@as(usize, 2), owner.elementCount());
+
+    heap.collectFull(&.{taggedObject(owner)});
+
+    for (0..named_count) |i| {
+        try testing.expectEqual(@as(i32, @intCast(i)), named_children[i].get("tag").asInt32());
+    }
+    try testing.expectEqual(@as(i32, 101), element_a.get("tag").asInt32());
+    try testing.expectEqual(@as(i32, 202), element_b.get("tag").asInt32());
 }
 
 test "Heap: major mark preserves dictionary named values and Symbol keys" {

--- a/src/runtime/intrinsics.zig
+++ b/src/runtime/intrinsics.zig
@@ -1522,14 +1522,15 @@ pub fn tryCreateListFromArrayLikeFast(
         // Any own accessor could shadow an index (or `length` cannot
         // — it is virtual on an array exotic — but index accessors
         // installed via defineProperty live in the accessor map and
-        // fire before `elements`).
+        // fire before dense element storage).
         if (o.accessorCount() != 0) return false;
-        const len = o.elements.items.len; // dense: mirrors the §23.1.4 virtual length
+        const elements = o.elementItems();
+        const len = elements.len; // dense: mirrors the §23.1.4 virtual length
         // Over the harness iteration cap the generic path raises the
         // error; let it.
         if (len > @as(usize, @intCast(max_iter_length))) return false;
         try out.ensureUnusedCapacity(realm.allocator, len);
-        for (o.elements.items) |v| {
+        for (elements) |v| {
             if (v.isHole()) {
                 // §10.4.2.1 step 2 — a hole delegates the read up the
                 // prototype chain; that walk is observable.

--- a/src/runtime/jit/layout.zig
+++ b/src/runtime/jit/layout.zig
@@ -90,7 +90,7 @@ pub const realm = struct {
         @offsetOf(Realm, "globals") + @offsetOf(GlobalBindings, "decl_revision");
     /// The §9.1.1.4 declarative-record slot caches (slice pointers
     /// at offset 0 — the same layout assumption the proof test
-    /// witnesses for `overflow_slots`).
+    /// witnesses for `secondary_values`).
     pub const globals_decl_slots_ptr: usize =
         @offsetOf(Realm, "globals") + @offsetOf(GlobalBindings, "decl_slots");
     pub const globals_decl_slots_len: usize =
@@ -123,11 +123,14 @@ pub const object = struct {
     pub const shape: u15 = @offsetOf(JSObject, "shape");
     pub const prototype: u15 = @offsetOf(JSObject, "prototype");
     pub const inline_slots: u15 = @offsetOf(JSObject, "inline_slots");
-    /// Byte offset of `overflow_slots.items.ptr` — the
-    /// slice-pointer-at-offset-0 assumption the proof test
-    /// witnesses.
+    /// Byte offset of `secondary_values.items.ptr`. Once an object
+    /// needs a named slot past `inline_slot_cap`,
+    /// `secondary_is_overflow` is monotonic: this header remains the
+    /// JIT-visible overflow-slot vector even if the object later
+    /// demotes from shape mode. The slice-pointer-at-offset-0
+    /// assumption is witnessed by the proof test below.
     pub const overflow_items_ptr: u15 =
-        @offsetOf(JSObject, "overflow_slots") +
+        @offsetOf(JSObject, "secondary_values") +
         @offsetOf(std.ArrayListUnmanaged(Value), "items");
     pub const inline_slot_cap: u32 = object_mod.inline_slot_cap;
 };

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -7731,7 +7731,7 @@ pub fn runFrames(
                     // re-check liveness here. Plain shape-mode objects
                     // never carry these, so this is ~free in the common
                     // case.
-                    if (recv.elements.items.len != 0 or recv.brand.is_sparse or recv.sparseConst().count() != 0) break :forin_hit;
+                    if (recv.elementCount() != 0 or recv.brand.is_sparse or recv.sparseConst().count() != 0) break :forin_hit;
                     acc = wrapForInSnapshot(realm, snap, acc) catch return error.OutOfMemory;
                     continue :dispatch try decodeNext(code, &ip, &committed);
                 }
@@ -7787,7 +7787,7 @@ pub fn runFrames(
                     if (recv.shape == null) break :fill;
                     if (recv.brand.is_proxy) break :fill;
                     if (recv.brand.is_array_exotic or recv.brand.is_module_namespace or recv.getTypedView() != null) break :fill;
-                    if (recv.elements.items.len != 0 or recv.brand.is_sparse or recv.sparseConst().count() != 0) break :fill;
+                    if (recv.elementCount() != 0 or recv.brand.is_sparse or recv.sparseConst().count() != 0) break :fill;
                     const proto = recv.prototype orelse break :fill;
                     if (proto.brand.extensible) break :fill; // not frozen / sealed
                     if (proto.prototype != null) break :fill; // not a one-level chain
@@ -7800,7 +7800,7 @@ pub fn runFrames(
                     // require the proto have no own integer elements
                     // it could re-enumerate, and no live proxy.
                     if (proto.getProxyTarget() != null or proto.brand.proxy_revoked) break :fill;
-                    if (proto.elements.items.len != 0 or proto.brand.is_sparse or proto.sparseConst().count() != 0) break :fill;
+                    if (proto.elementCount() != 0 or proto.brand.is_sparse or proto.sparseConst().count() != 0) break :fill;
                     const cell = &local_chunk.inline_forin_caches[forin_ic_idx];
                     cell.recv_shape = recv.shape;
                     cell.proto = proto;

--- a/src/runtime/lantern/iterator.zig
+++ b/src/runtime/lantern/iterator.zig
@@ -461,9 +461,10 @@ pub fn buildForInSnapshot(
                         int_keys.append(realm.allocator, .{ .idx = idx, .key = key_owned_str.flatBytes() }) catch return error.OutOfMemory;
                     }
                 } else {
+                    const elements = cur.elementItems();
                     var ei: u32 = 0;
-                    while (ei < cur.elements.items.len) : (ei += 1) {
-                        if (@import("../object.zig").JSObject.isElementHole(cur.elements.items[ei])) continue;
+                    while (ei < elements.len) : (ei += 1) {
+                        if (@import("../object.zig").JSObject.isElementHole(elements[ei])) continue;
                         var ibuf: [16]u8 = undefined;
                         const ks = std.fmt.bufPrint(&ibuf, "{d}", .{ei}) catch continue;
                         const key_owned_str = realm.heap.allocateString(ks) catch return error.OutOfMemory;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1924,7 +1924,7 @@ test "later: harden on Array reaches nested values but not indexed slots (known 
     //                   object). ✓
     //   `a.push(3)`     throws (root is non-extensible). ✓
     //   `a[0] = 9`      **does NOT throw** — the indexed slot
-    //                   itself lives in `obj.elements`, not
+    //                   itself lives in dense element storage, not
     //                   `obj.propsConst()`, so harden's bag-only
     //                   walk doesn't reach it. Object.freeze
     //                   handles this via `lowerArrayIndexedFlags`

--- a/src/runtime/object.zig
+++ b/src/runtime/object.zig
@@ -509,12 +509,12 @@ pub const FinalizationCell = struct {
 /// §10.1 dictionary-mode representation, moved out-of-line. A
 /// *shape-mode* object (`shape != null` — every plain `{a, b}`
 /// literal, `new Point(x, y)`, splay's `Node`) stores its values in
-/// `inline_slots` / `overflow_slots` and leaves all three of these
+/// `inline_slots` / `secondary_values` and leaves all three of these
 /// EMPTY, so they cost 104 B on the header for nothing. This side
 /// allocation carries them only for the objects that actually go
 /// dictionary mode (`demoteFromShape`, or a runtime that writes the
-/// bag directly). Reached by `JSObject.dict_store`; allocated lazily
-/// by `ensureDictStore`. The JIT never reads these fields (it deopts
+/// bag directly). Reached through `JSObject.aux_store`; allocated
+/// lazily by `ensureDictStore`. The JIT never reads these fields (it deopts
 /// to the interpreter for dict-mode receivers), so this move is
 /// invisible to emitted code — unlike `shape`/`inline_slots`, which
 /// must stay on the header (see the JIT layout SSoT).
@@ -536,6 +536,30 @@ pub const DictStore = struct {
     }
 };
 
+/// Discriminator for the lazily allocated `JSObject.aux_store`.
+///
+/// The common object carries no aux allocation. Dictionary-mode named
+/// properties and the rare dense-element metadata spill each allocate
+/// only their exact payload; an object that needs both upgrades to the
+/// combined payload. Keeping the discriminator in `BrandFlags` lets the
+/// header retain one pointer instead of paying for independent
+/// dictionary and element-spill pointers.
+const ObjectAuxKind = enum(u2) {
+    none,
+    dict,
+    elements,
+    combined,
+};
+
+const ObjectAuxCombined = struct {
+    /// Keep each exact-sized child at its original address when the
+    /// second aux kind appears. Callers may hold a map/list pointer for
+    /// the duration of an operation; upgrading the discriminator must
+    /// not invalidate it.
+    dict: *DictStore,
+    elements: *std.ArrayListUnmanaged(Value),
+};
+
 /// Shared, never-mutated empty maps returned by the `*Const` dict
 /// accessors when an object has no `DictStore` (the common shape-mode
 /// case). Reads (`get` / `contains` / `count` / `iterator` / `values`)
@@ -545,6 +569,7 @@ pub const DictStore = struct {
 const empty_props: std.StringArrayHashMapUnmanaged(Value) = .empty;
 const empty_flags: std.StringArrayHashMapUnmanaged(PropertyFlags) = .empty;
 const empty_order: std.ArrayListUnmanaged([]const u8) = .empty;
+const empty_elements: std.ArrayListUnmanaged(Value) = .empty;
 /// Shared empty sparse map for the `sparseConst` read path on a
 /// non-sparse object (no extension). Never mutated — writes go through
 /// `sparseMut`, which allocates the extension.
@@ -556,7 +581,7 @@ const empty_sparse: std.AutoHashMapUnmanaged(u32, Value) = .empty;
 /// or writes." Subsequent commits migrate the cold fields here
 /// one at a time. Anything the JIT will speculate on stays in the
 /// hot JSObject prefix and MUST NOT move here — keep `shape`,
-/// `slots`, `elements`, `prototype` out of this struct forever.
+/// property/index storage, and `prototype` out of this struct forever.
 /// (`properties` / `property_flags` / `own_key_order` are the
 /// dictionary representation — they live in `DictStore`, reached by
 /// a separate pointer, not here.)
@@ -1036,6 +1061,16 @@ pub const BrandFlags = packed struct(u32) {
     /// (`elementsUnpool`); frees/teardown return the buffer to the
     /// pool — a pooled pointer must NEVER reach `allocator.free`.
     elements_pooled: bool = false,
+    /// The base object's single `secondary_values` vector is normally
+    /// dense indexed storage. Once named-property slots overflow the
+    /// four inline values, their JIT-visible vector permanently takes
+    /// over that header and dense-element metadata (if any) moves to
+    /// `aux_store`. Monotonic so emitted slot loads never need a mode
+    /// guard.
+    secondary_is_overflow: bool = false,
+    /// Type of allocation reached by `JSObject.aux_store`: dictionary
+    /// state, spilled dense-element metadata, or their combined form.
+    aux_kind: ObjectAuxKind = .none,
     /// `[[ArrayBufferData]]` brand presence (§25.1.5.x
     /// RequireInternalSlot) — true iff produced by the ArrayBuffer
     /// constructor (or `.transfer` / `.slice`).
@@ -1059,7 +1094,7 @@ pub const BrandFlags = packed struct(u32) {
     /// no footprint benefit to a narrower tag).
     promise_state: PromiseState = .none,
     /// Reserved padding to fill the 32-bit word.
-    _padding: u7 = 0,
+    _padding: u4 = 0,
 };
 
 pub const JSObject = struct {
@@ -1071,17 +1106,24 @@ pub const JSObject = struct {
     /// §10.1 dictionary-mode representation — `properties` (name →
     /// value), `property_flags` (non-default §6.2.5 descriptor bits),
     /// and `own_key_order` (§10.1.11 insertion order) — moved into a
-    /// lazily-allocated `DictStore` reached by this single pointer.
-    /// `null` on every shape-mode object (the hot case: plain
-    /// literals, `new Point(x,y)`, splay's `Node`), which stores its
-    /// values in `inline_slots` and never touches the bag. Allocated
-    /// only on `demoteFromShape` / a direct bag write. Access through
+    /// lazily-allocated `DictStore` reached through this single aux
+    /// pointer.
+    /// `null` on the hot shape-only case (plain literals,
+    /// `new Point(x,y)`, splay's `Node`), which stores its values in
+    /// `inline_slots` and never touches the bag. Dictionary state is
+    /// allocated only on `demoteFromShape` / a direct bag write.
+    /// A still-shaped object may instead use this pointer for the rare
+    /// dense-element metadata spill after named slots overflow. Access through
     /// `propsConst`/`propsMut` / `flagsConst`/`flagsMut` /
     /// `orderConst`/`orderMut` and the `dictStore`/`ensureDictStore`
-    /// helpers — never a raw field. The JIT never reads these (it
+    /// helpers — never a raw field. The same pointer may instead hold
+    /// the rare dense-element metadata spill, discriminated by
+    /// `brand.aux_kind`; exact-sized variants avoid charging every
+    /// object for independent dictionary and spill pointers. The JIT
+    /// never reads these (it
     /// deopts for dict-mode receivers), so the move is invisible to
     /// emitted code (unlike `shape`/`inline_slots`).
-    dict_store: ?*DictStore = null,
+    aux_store: ?*anyopaque = null,
     /// §10.1 shape-based named-property storage — not yet the
     /// source of truth. `shape` describes this object's named-
     /// property layout (see `shape.zig`); `slots[shape.lookup(key)
@@ -1098,17 +1140,20 @@ pub const JSObject = struct {
     /// RGBA) stores every value here and pays NO separate
     /// allocation, since the header itself comes from the slab
     /// pool. Only objects that grow past the inline capacity spill
-    /// the remainder into `overflow_slots` (a heap buffer holding
-    /// logical slots `[inline_slot_cap ..]`). `slot_count` is the
-    /// total live count across both. Access ONLY through
+    /// the remainder into `secondary_values` (a heap buffer holding
+    /// logical slots `[inline_slot_cap ..]`). Before that first spill,
+    /// the same 24-byte vector header carries dense indexed elements;
+    /// if an object needs both, the element header moves into the
+    /// exact-sized aux variant. `slot_count` is the total live named-
+    /// property count. Access ONLY through
     /// `slotAt` / `slotPtr` / `setSlot` / `slotCount` /
-    /// `resizeSlots` / `clearSlots` — never the raw fields — so the
-    /// inline/overflow split stays an implementation detail.
+    /// `resizeSlots` / `clearSlots` and the element helpers — never the
+    /// raw field — so the overlay stays an implementation detail.
     /// Non-moving: inline slots live in the (pinned-address) header,
     /// so the engine's pointer-stability invariant is preserved.
     inline_slots: [inline_slot_cap]Value = undefined,
     slot_count: u32 = 0,
-    overflow_slots: std.ArrayListUnmanaged(Value) = .empty,
+    secondary_values: std.ArrayListUnmanaged(Value) = .empty,
     /// Back-pointer to the owning heap, stamped at allocation by
     /// `Heap.allocateObject`. Lets the realm-agnostic `get` / `set`
     /// API reach the agent-wide property-shape tree (`heap.shapes`)
@@ -1187,8 +1232,8 @@ pub const JSObject = struct {
     needs_internal_scan: bool = false,
     /// True while this object has not accumulated any heap-attached
     /// state — every potentially-allocated field (`properties`,
-    /// `property_flags`, `own_key_order`, `key_anchors`, `elements`,
-    /// `sparse_elements`, `overflow_slots`, `extension`, plus the
+    /// `property_flags`, `own_key_order`, `key_anchors`, dense elements,
+    /// `sparse_elements`, named overflow slots, `extension`, plus the
     /// optional state pointers `array_like_iter` / `map_set_iter` /
     /// `regexp_string_iter` / `iter_record` / `iter_helper` /
     /// `regex_perlex` / `promise_store`, and the capability /
@@ -1299,7 +1344,6 @@ pub const JSObject = struct {
     // `JSObjectExtension` — only Module Namespace exotics populate
     // them. Access via the `namespaceRedirect*` /
     // `ambiguousNamespaceKey*` helpers below.)
-    elements: std.ArrayListUnmanaged(Value) = .empty,
     // §10.4.2 sparse indexed store (`sparse_elements`) moved to
     // `JSObjectExtension` — populated only on the rare sparse array
     // exotic. The `is_sparse` brand + `sparse_length` stay inline (the
@@ -1510,33 +1554,149 @@ pub const JSObject = struct {
     // `shadowSet`), not the typed-slot scan — so, unlike the extension,
     // `ensureDictStore` sets `markNonPristine` but NOT
     // `needs_internal_scan`.
+    fn auxAs(self: *const JSObject, comptime T: type) *T {
+        return @ptrCast(@alignCast(self.aux_store.?));
+    }
+
     pub fn dictStore(self: *const JSObject) ?*DictStore {
-        return self.dict_store;
+        return switch (self.brand.aux_kind) {
+            .none, .elements => null,
+            .dict => self.auxAs(DictStore),
+            .combined => self.auxAs(ObjectAuxCombined).dict,
+        };
     }
+
     pub fn ensureDictStore(self: *JSObject, allocator: std.mem.Allocator) !*DictStore {
-        if (self.dict_store) |d| return d;
-        const d = try allocator.create(DictStore);
-        d.* = .{};
-        self.dict_store = d;
-        self.markNonPristine();
-        return d;
+        switch (self.brand.aux_kind) {
+            .dict => return self.auxAs(DictStore),
+            .combined => return self.auxAs(ObjectAuxCombined).dict,
+            .none => {
+                std.debug.assert(self.aux_store == null);
+                const d = try allocator.create(DictStore);
+                d.* = .{};
+                self.aux_store = d;
+                self.brand.aux_kind = .dict;
+                self.markNonPristine();
+                return d;
+            },
+            .elements => {
+                // Upgrade atomically: allocation happens before the old
+                // exact-sized element header is detached.
+                const elems = self.auxAs(std.ArrayListUnmanaged(Value));
+                const dict = try allocator.create(DictStore);
+                errdefer allocator.destroy(dict);
+                dict.* = .{};
+                const both = try allocator.create(ObjectAuxCombined);
+                both.* = .{ .dict = dict, .elements = elems };
+                self.aux_store = both;
+                self.brand.aux_kind = .combined;
+                self.markNonPristine();
+                return dict;
+            },
+        }
     }
+
+    /// Dense-element vector metadata when named slots already occupy
+    /// `secondary_values`. This is the rare coexistence path; allocate
+    /// exactly one ArrayList header, upgrading to `ObjectAuxCombined`
+    /// only if dictionary state also exists.
+    fn ensureSpilledElements(
+        self: *JSObject,
+        allocator: std.mem.Allocator,
+    ) !*std.ArrayListUnmanaged(Value) {
+        switch (self.brand.aux_kind) {
+            .elements => return self.auxAs(std.ArrayListUnmanaged(Value)),
+            .combined => return self.auxAs(ObjectAuxCombined).elements,
+            .none => {
+                std.debug.assert(self.aux_store == null);
+                const elems = try allocator.create(std.ArrayListUnmanaged(Value));
+                elems.* = .empty;
+                self.aux_store = elems;
+                self.brand.aux_kind = .elements;
+                self.markNonPristine();
+                return elems;
+            },
+            .dict => {
+                const dict = self.auxAs(DictStore);
+                const elems = try allocator.create(std.ArrayListUnmanaged(Value));
+                errdefer allocator.destroy(elems);
+                elems.* = .empty;
+                const both = try allocator.create(ObjectAuxCombined);
+                both.* = .{ .dict = dict, .elements = elems };
+                self.aux_store = both;
+                self.brand.aux_kind = .combined;
+                self.markNonPristine();
+                return elems;
+            },
+        }
+    }
+
+    /// Read view of dense indexed storage. The shared empty header
+    /// avoids allocating an aux payload for an overflow-slot object
+    /// that has no indexed properties.
+    pub inline fn elementsConst(self: *const JSObject) *const std.ArrayListUnmanaged(Value) {
+        if (!self.brand.secondary_is_overflow) return &self.secondary_values;
+        return switch (self.brand.aux_kind) {
+            .elements => self.auxAs(std.ArrayListUnmanaged(Value)),
+            .combined => self.auxAs(ObjectAuxCombined).elements,
+            .none, .dict => &empty_elements,
+        };
+    }
+
+    /// Mutable dense indexed storage, allocating the exact-sized aux
+    /// header only when named overflow already owns `secondary_values`.
+    pub inline fn elementsMut(
+        self: *JSObject,
+        allocator: std.mem.Allocator,
+    ) !*std.ArrayListUnmanaged(Value) {
+        if (!self.brand.secondary_is_overflow) return &self.secondary_values;
+        return self.ensureSpilledElements(allocator);
+    }
+
+    pub inline fn elementItems(self: *const JSObject) []const Value {
+        return self.elementsConst().items;
+    }
+
+    /// Mutable element-list header when one already exists. Unlike
+    /// `elementsMut`, this never allocates: overflow-slot objects with
+    /// no indexed storage return null.
+    inline fn elementsExistingMut(self: *JSObject) ?*std.ArrayListUnmanaged(Value) {
+        if (!self.brand.secondary_is_overflow) return &self.secondary_values;
+        return switch (self.brand.aux_kind) {
+            .elements => self.auxAs(std.ArrayListUnmanaged(Value)),
+            .combined => self.auxAs(ObjectAuxCombined).elements,
+            .none, .dict => null,
+        };
+    }
+
+    /// Existing mutable element slice. The empty fallback is borrowed
+    /// from this object itself and is never written: callers validate an
+    /// index against `elementItems().len` before taking this path.
+    pub inline fn elementItemsMut(self: *JSObject) []Value {
+        if (self.elementsExistingMut()) |elements| return elements.items;
+        return self.inline_slots[0..0];
+    }
+
+    pub inline fn elementCount(self: *const JSObject) usize {
+        return self.elementsConst().items.len;
+    }
+
     /// Read view of the dict property bag (shared empty when no store).
     pub fn propsConst(self: *const JSObject) *const std.StringArrayHashMapUnmanaged(Value) {
-        return if (self.dict_store) |d| &d.properties else &empty_props;
+        return if (self.dictStore()) |d| &d.properties else &empty_props;
     }
     /// Mutable view; allocates the store on first use.
     pub fn propsMut(self: *JSObject, allocator: std.mem.Allocator) !*std.StringArrayHashMapUnmanaged(Value) {
         return &(try self.ensureDictStore(allocator)).properties;
     }
     pub fn flagsConst(self: *const JSObject) *const std.StringArrayHashMapUnmanaged(PropertyFlags) {
-        return if (self.dict_store) |d| &d.property_flags else &empty_flags;
+        return if (self.dictStore()) |d| &d.property_flags else &empty_flags;
     }
     pub fn flagsMut(self: *JSObject, allocator: std.mem.Allocator) !*std.StringArrayHashMapUnmanaged(PropertyFlags) {
         return &(try self.ensureDictStore(allocator)).property_flags;
     }
     pub fn orderConst(self: *const JSObject) *const std.ArrayListUnmanaged([]const u8) {
-        return if (self.dict_store) |d| &d.own_key_order else &empty_order;
+        return if (self.dictStore()) |d| &d.own_key_order else &empty_order;
     }
     pub fn orderMut(self: *JSObject, allocator: std.mem.Allocator) !*std.ArrayListUnmanaged([]const u8) {
         return &(try self.ensureDictStore(allocator)).own_key_order;
@@ -2369,7 +2529,7 @@ pub const JSObject = struct {
     // ── Shape-mode slot storage (inline + overflow) ─────────────────
     //
     // The first `inline_slot_cap` logical slots live in `inline_slots`
-    // (in the header); the rest in `overflow_slots`. These accessors
+    // (in the header); the rest in `secondary_values`. These accessors
     // hide the split — callers index a single logical [0 .. slot_count)
     // space. Bounds are the caller's responsibility (same contract the
     // old `slots.items[i]` had).
@@ -2381,18 +2541,16 @@ pub const JSObject = struct {
 
     /// Read logical slot `i`.
     pub inline fn slotAt(self: *const JSObject, i: usize) Value {
-        return if (i < inline_slot_cap)
-            self.inline_slots[i]
-        else
-            self.overflow_slots.items[i - inline_slot_cap];
+        if (i < inline_slot_cap) return self.inline_slots[i];
+        std.debug.assert(self.brand.secondary_is_overflow);
+        return self.secondary_values.items[i - inline_slot_cap];
     }
 
     /// Pointer to logical slot `i` (for in-place update).
     pub inline fn slotPtr(self: *JSObject, i: usize) *Value {
-        return if (i < inline_slot_cap)
-            &self.inline_slots[i]
-        else
-            &self.overflow_slots.items[i - inline_slot_cap];
+        if (i < inline_slot_cap) return &self.inline_slots[i];
+        std.debug.assert(self.brand.secondary_is_overflow);
+        return &self.secondary_values.items[i - inline_slot_cap];
     }
 
     /// Write logical slot `i`.
@@ -2400,7 +2558,8 @@ pub const JSObject = struct {
         if (i < inline_slot_cap) {
             self.inline_slots[i] = v;
         } else {
-            self.overflow_slots.items[i - inline_slot_cap] = v;
+            std.debug.assert(self.brand.secondary_is_overflow);
+            self.secondary_values.items[i - inline_slot_cap] = v;
         }
     }
 
@@ -2410,12 +2569,32 @@ pub const JSObject = struct {
     /// (the caller writes them); shrinking just lowers the count.
     pub fn resizeSlots(self: *JSObject, allocator: std.mem.Allocator, n: usize) !void {
         if (n > inline_slot_cap) {
-            try self.overflow_slots.resize(allocator, n - inline_slot_cap);
+            if (!self.brand.secondary_is_overflow) {
+                // Named overflow permanently claims the inline vector
+                // header. Preserve any dense-element header in the
+                // exact-sized aux store before reusing the field. All
+                // allocation happens before the representation flip, so
+                // OOM leaves the original element vector intact.
+                const old_elements = self.secondary_values;
+                if (old_elements.capacity != 0 or
+                    old_elements.items.len != 0 or
+                    self.brand.elements_pooled)
+                {
+                    const spilled = try self.ensureSpilledElements(allocator);
+                    std.debug.assert(spilled.capacity == 0);
+                    spilled.* = old_elements;
+                }
+                self.secondary_values = .empty;
+                self.brand.secondary_is_overflow = true;
+            }
+            try self.secondary_values.resize(allocator, n - inline_slot_cap);
             self.markNonPristine();
-        } else if (self.overflow_slots.items.len != 0) {
+        } else if (self.brand.secondary_is_overflow and
+            self.secondary_values.items.len != 0)
+        {
             // Shrinking back into the inline range — drop the
             // overflow buffer's live entries (keep capacity).
-            self.overflow_slots.clearRetainingCapacity();
+            self.secondary_values.clearRetainingCapacity();
         }
         self.slot_count = @intCast(n);
     }
@@ -2424,7 +2603,9 @@ pub const JSObject = struct {
     /// demote path's `slots.clearRetainingCapacity()` analogue).
     pub fn clearSlots(self: *JSObject) void {
         self.slot_count = 0;
-        self.overflow_slots.clearRetainingCapacity();
+        if (self.brand.secondary_is_overflow) {
+            self.secondary_values.clearRetainingCapacity();
+        }
     }
 
     /// Drop every sub-allocation owned by this object — does NOT
@@ -2466,17 +2647,49 @@ pub const JSObject = struct {
     ///
     /// Compiled out of ReleaseFast — only the runtime-safety builds
     /// (Debug, ReleaseSafe, test) run it.
+    fn assertAuxInvariant(self: *const JSObject) void {
+        switch (self.brand.aux_kind) {
+            .none => std.debug.assert(self.aux_store == null),
+            .dict => std.debug.assert(self.aux_store != null),
+            .elements => {
+                std.debug.assert(self.aux_store != null);
+                std.debug.assert(self.brand.secondary_is_overflow);
+            },
+            .combined => {
+                std.debug.assert(self.aux_store != null);
+                std.debug.assert(self.brand.secondary_is_overflow);
+            },
+        }
+        if (self.slot_count > inline_slot_cap) {
+            std.debug.assert(self.brand.secondary_is_overflow);
+        }
+        if (self.brand.secondary_is_overflow) {
+            const expected_overflow_len: usize = if (self.slot_count > inline_slot_cap)
+                @intCast(self.slot_count - inline_slot_cap)
+            else
+                0;
+            std.debug.assert(self.secondary_values.items.len == expected_overflow_len);
+        }
+        if (!self.brand.secondary_is_overflow) {
+            std.debug.assert(self.brand.aux_kind != .elements);
+            std.debug.assert(self.brand.aux_kind != .combined);
+        }
+    }
+
     fn assertPristineFieldsClean(self: *const JSObject) void {
+        self.assertAuxInvariant();
         // The dictionary representation (`properties` / `property_flags`
-        // / `own_key_order`) lives in `dict_store`; a pristine object
+        // / `own_key_order`) lives in `aux_store`; a pristine object
         // never allocated one.
-        if (self.dict_store != null) std.debug.panic("pristine violated: dict_store is non-null", .{});
+        if (self.aux_store != null) std.debug.panic("pristine violated: aux_store is non-null", .{});
         // `key_anchors` lives in the extension; the `extension != null`
         // check below covers it.
-        if (self.elements.items.len != 0) std.debug.panic("pristine violated: elements.len={d}", .{self.elements.items.len});
+        if (self.elementCount() != 0) std.debug.panic("pristine violated: elements.len={d}", .{self.elementCount()});
         // `sparse_elements` lives in the extension; the `extension != null`
         // check below covers it.
-        if (self.overflow_slots.items.len != 0) std.debug.panic("pristine violated: overflow_slots.len={d}", .{self.overflow_slots.items.len});
+        if (self.brand.secondary_is_overflow and self.secondary_values.items.len != 0) {
+            std.debug.panic("pristine violated: overflow slots len={d}", .{self.secondary_values.items.len});
+        }
         // A pristine object has no `extension`, which transitively
         // guarantees its iterator-state slots (`array_like_iter` /
         // `map_set_iter` / `regexp_string_iter` / `iter_record` /
@@ -2496,12 +2709,7 @@ pub const JSObject = struct {
             return;
         }
         if (self.heap) |h| h.deinit_slowpath_count +%= 1;
-        // §10.1 dictionary representation (`properties` / `property_flags`
-        // / `own_key_order`) lives in `dict_store` — free it as a unit.
-        if (self.dict_store) |d| {
-            d.deinit(allocator);
-            allocator.destroy(d);
-        }
+        if (std.debug.runtime_safety) self.assertAuxInvariant();
         // `private_properties`, `private_methods`, `private_accessors`,
         // `accessors`, `namespace_redirects`, `ambiguous_namespace_keys`,
         // `map_data`, `set_data`, and the iterator-state structs
@@ -2519,20 +2727,39 @@ pub const JSObject = struct {
             if (self.heap) |h| h.promise_store_pool.destroy(s) else allocator.destroy(s);
         }
         // `key_anchors` lives in the extension — freed when it is.
-        // `own_key_order` lives in `dict_store` (freed above).
+        // `own_key_order` lives in the aux DictStore (freed below).
+        const elements = self.elementsExistingMut();
         if (self.brand.elements_pooled) {
             // Pool-owned buffer — must not reach `allocator.free`.
             const heap_ty = @import("heap.zig");
-            const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(self.elements.items.ptr);
+            const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.?.items.ptr);
             if (self.heap) |h| h.element_buf_pool.destroy(buf);
-        } else {
-            self.elements.deinit(allocator);
+        } else if (elements) |dense| {
+            dense.deinit(allocator);
         }
         // `sparse_elements` lives in the extension — freed when it is.
         // `shape` itself is realm-lifetime arena memory (ShapeTree),
         // not freed per-object; only the overflow slot vector is
         // owned here (inline slots live in the header).
-        self.overflow_slots.deinit(allocator);
+        if (self.brand.secondary_is_overflow) {
+            self.secondary_values.deinit(allocator);
+        }
+        switch (self.brand.aux_kind) {
+            .none => {},
+            .dict => {
+                const d = self.auxAs(DictStore);
+                d.deinit(allocator);
+                allocator.destroy(d);
+            },
+            .elements => allocator.destroy(self.auxAs(std.ArrayListUnmanaged(Value))),
+            .combined => {
+                const both = self.auxAs(ObjectAuxCombined);
+                both.dict.deinit(allocator);
+                allocator.destroy(both.dict);
+                allocator.destroy(both.elements);
+                allocator.destroy(both);
+            },
+        }
         if (self.extension) |ext| {
             ext.deinit(allocator);
             allocator.destroy(ext);
@@ -2678,7 +2905,7 @@ pub const JSObject = struct {
     pub fn forgetKey(self: *JSObject, key: []const u8) void {
         // No store ⇒ no ordering list ⇒ nothing to forget. `orderedRemove`
         // does not allocate, so mutate the store's list in place.
-        const d = self.dict_store orelse return;
+        const d = self.dictStore() orelse return;
         var i: usize = 0;
         while (i < d.own_key_order.items.len) : (i += 1) {
             if (std.mem.eql(u8, d.own_key_order.items[i], key)) {
@@ -2980,13 +3207,13 @@ pub const JSObject = struct {
             // Shape encodes the attrs on the transition node —
             // no `property_flags` entry needed. Clear any stale
             // entry left behind by a prior dict-mode redefine.
-            if (self.dict_store) |d| _ = d.property_flags.swapRemove(key);
+            if (self.dictStore()) |d| _ = d.property_flags.swapRemove(key);
             return;
         }
         // Dictionary-mode: bag is the source of truth.
         try self.bagPut(allocator, key, v);
         if (is_default) {
-            if (self.dict_store) |d| _ = d.property_flags.swapRemove(key);
+            if (self.dictStore()) |d| _ = d.property_flags.swapRemove(key);
         } else {
             try (try self.flagsMut(allocator)).put(allocator, key, flags);
             self.markNonPristine();
@@ -3295,7 +3522,7 @@ pub const JSObject = struct {
         // stays — the shape chain is the ordering authority now, but
         // keeping the list matches the pre-shape behaviour). The store
         // exists (promote runs on a dict-mode object).
-        if (self.dict_store) |d| {
+        if (self.dictStore()) |d| {
             d.properties.clearRetainingCapacity();
             d.property_flags.clearRetainingCapacity();
         }
@@ -3772,12 +3999,12 @@ pub const JSObject = struct {
         if (self.heap) |h| h.writeBarrier(.{ .object = self }, value);
     }
 
-    /// Logical array length. Dense → `elements.items.len`;
+    /// Logical array length. Dense → `elementCount()`;
     /// sparse → `sparse_length`. Callers should prefer this
     /// helper over poking the underlying storage directly.
     pub fn arrayLength(self: *const JSObject) u32 {
         if (self.brand.is_sparse) return self.sparse_length;
-        return @intCast(self.elements.items.len);
+        return @intCast(self.elementCount());
     }
 
     /// Own indexed slot read that distinguishes hole from
@@ -3794,8 +4021,9 @@ pub const JSObject = struct {
             }
             return null;
         }
-        if (idx >= self.elements.items.len) return null;
-        const v = self.elements.items[idx];
+        const elements = self.elementItems();
+        if (idx >= elements.len) return null;
+        const v = elements[idx];
         if (isElementHole(v)) return null;
         return v;
     }
@@ -3843,7 +4071,7 @@ pub const JSObject = struct {
         if (self.brand.is_sparse) {
             try (try self.sparseMut(allocator)).put(allocator, idx, v);
         } else {
-            self.elements.items[idx] = v;
+            self.elementItemsMut()[idx] = v;
         }
         self.markNonPristine();
         // Generational write barrier — a mature array gaining a young
@@ -3867,8 +4095,8 @@ pub const JSObject = struct {
     pub fn holeIndexed(self: *JSObject, idx: u32) void {
         if (self.brand.is_sparse) {
             if (self.extension) |ext| _ = ext.sparse_elements.remove(idx);
-        } else if (idx < self.elements.items.len) {
-            self.elements.items[idx] = Value.hole_;
+        } else if (idx < self.elementCount()) {
+            self.elementItemsMut()[idx] = Value.hole_;
         }
     }
 
@@ -3888,12 +4116,13 @@ pub const JSObject = struct {
     fn elementsUnpool(self: *JSObject, allocator: std.mem.Allocator, min_cap: usize) !void {
         if (!self.brand.elements_pooled) return;
         const heap_ty = @import("heap.zig");
+        const elements = self.elementsExistingMut().?;
         var fresh: std.ArrayListUnmanaged(Value) = .empty;
-        try fresh.ensureTotalCapacity(allocator, @max(min_cap, self.elements.items.len));
-        fresh.appendSliceAssumeCapacity(self.elements.items);
-        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(self.elements.items.ptr);
+        try fresh.ensureTotalCapacity(allocator, @max(min_cap, elements.items.len));
+        fresh.appendSliceAssumeCapacity(elements.items);
+        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.items.ptr);
         if (self.heap) |h| h.element_buf_pool.destroy(buf);
-        self.elements = fresh;
+        elements.* = fresh;
         self.brand.elements_pooled = false;
     }
 
@@ -3901,9 +4130,10 @@ pub const JSObject = struct {
     /// Mirrors `clearAndFree` for the pooled representation.
     fn elementsFreePooled(self: *JSObject) void {
         const heap_ty = @import("heap.zig");
-        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(self.elements.items.ptr);
+        const elements = self.elementsExistingMut().?;
+        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.items.ptr);
         if (self.heap) |h| h.element_buf_pool.destroy(buf);
-        self.elements = .empty;
+        elements.* = .empty;
         self.brand.elements_pooled = false;
     }
 
@@ -3914,11 +4144,13 @@ pub const JSObject = struct {
         v: Value,
     ) !bool {
         if (self.brand.is_sparse) return false;
-        if (idx != self.elements.items.len) return false;
-        if (self.brand.elements_pooled and self.elements.items.len == self.elements.capacity) {
-            try self.elementsUnpool(allocator, self.elements.items.len + 1);
+        if (idx != self.elementCount()) return false;
+        var elements = try self.elementsMut(allocator);
+        if (self.brand.elements_pooled and elements.items.len == elements.capacity) {
+            try self.elementsUnpool(allocator, elements.items.len + 1);
+            elements = self.elementsExistingMut().?;
         }
-        try self.elements.append(allocator, v);
+        try elements.append(allocator, v);
         self.markNonPristine();
         if (self.heap) |h| h.writeBarrier(.{ .object = self }, v);
         return true;
@@ -3938,19 +4170,21 @@ pub const JSObject = struct {
             }
             return;
         }
-        const old_len = self.elements.items.len;
+        const old_len = self.elementCount();
         if (new_len <= old_len) return;
         if (new_len - old_len > sparse_gap_threshold) {
             try self.promoteToSparse(allocator, new_len);
             return;
         }
-        if (self.brand.elements_pooled and new_len > self.elements.capacity) {
+        var elements = try self.elementsMut(allocator);
+        if (self.brand.elements_pooled and new_len > elements.capacity) {
             try self.elementsUnpool(allocator, new_len);
+            elements = self.elementsExistingMut().?;
         }
-        try self.elements.resize(allocator, new_len);
+        try elements.resize(allocator, new_len);
         var i = old_len;
         while (i < new_len) : (i += 1) {
-            self.elements.items[i] = Value.hole_;
+            elements.items[i] = Value.hole_;
         }
         self.markNonPristine();
     }
@@ -3962,16 +4196,17 @@ pub const JSObject = struct {
     fn promoteToSparse(self: *JSObject, allocator: std.mem.Allocator, new_len: usize) !void {
         std.debug.assert(!self.brand.is_sparse);
         std.debug.assert(new_len <= std.math.maxInt(u32));
+        const elements = self.elementItems();
         var i: u32 = 0;
-        while (i < self.elements.items.len) : (i += 1) {
-            const v = self.elements.items[i];
+        while (i < elements.len) : (i += 1) {
+            const v = elements[i];
             if (isElementHole(v)) continue;
             try (try self.sparseMut(allocator)).put(allocator, i, v);
         }
         if (self.brand.elements_pooled) {
             self.elementsFreePooled();
-        } else {
-            self.elements.clearAndFree(allocator);
+        } else if (self.elementsExistingMut()) |dense| {
+            dense.clearAndFree(allocator);
         }
         self.sparse_length = @intCast(new_len);
         self.brand.is_sparse = true;
@@ -4009,10 +4244,10 @@ pub const JSObject = struct {
             if (new_len < self.sparse_length) self.sparse_length = new_len;
             return true;
         }
-        const cur: usize = self.elements.items.len;
+        const cur: usize = self.elementCount();
         const want: usize = new_len;
         if (want >= cur) return true;
-        try self.elements.resize(allocator, want);
+        try (try self.elementsMut(allocator)).resize(allocator, want);
         return true;
     }
 
@@ -4075,8 +4310,8 @@ pub const JSObject = struct {
             if (self.extension) |ext| _ = ext.sparse_elements.remove(idx);
             return true;
         }
-        if (idx >= self.elements.items.len) return true; // already absent
-        self.elements.items[idx] = Value.hole_;
+        if (idx >= self.elementCount()) return true; // already absent
+        self.elementItemsMut()[idx] = Value.hole_;
         return true;
     }
 
@@ -4113,8 +4348,8 @@ pub const JSObject = struct {
                     // reverse / copyWithin / unshift) reach here
                     // for array-like generic-object receivers.
                     try self.demoteFromShape(allocator);
-                    if (self.dict_store) |d| _ = d.properties.swapRemove(key);
-                    if (self.dict_store) |d| _ = d.property_flags.swapRemove(key);
+                    if (self.dictStore()) |d| _ = d.properties.swapRemove(key);
+                    if (self.dictStore()) |d| _ = d.property_flags.swapRemove(key);
                 }
                 return true;
             }
@@ -4122,14 +4357,14 @@ pub const JSObject = struct {
         if (self.hasAccessor(key)) {
             try self.demoteFromShape(allocator);
             _ = self.removeAccessor(key);
-            if (self.dict_store) |d| _ = d.property_flags.swapRemove(key);
+            if (self.dictStore()) |d| _ = d.property_flags.swapRemove(key);
             if (!self.propsConst().contains(key)) self.forgetKey(key);
             return true;
         }
         if (!self.ownDataContains(key)) return true;
         try self.demoteFromShape(allocator);
-        if (self.dict_store) |d| _ = d.properties.swapRemove(key);
-        if (self.dict_store) |d| _ = d.property_flags.swapRemove(key);
+        if (self.dictStore()) |d| _ = d.properties.swapRemove(key);
+        if (self.dictStore()) |d| _ = d.property_flags.swapRemove(key);
         if (!self.hasAccessor(key)) self.forgetKey(key);
         return true;
     }
@@ -4264,7 +4499,7 @@ test "JSObject: set/get round-trip" {
 test "JSObject: inline/overflow slot boundary round-trips" {
     // The first `inline_slot_cap` property values live in the
     // header's `inline_slots`; the rest spill to the heap-backed
-    // `overflow_slots`. Set enough properties to straddle the
+    // overflow view of `secondary_values`. Set enough properties to straddle the
     // boundary and confirm every value reads back through both
     // `slotAt` and the spec-facing `get`, including the slots on
     // either side of the inline/overflow seam.
@@ -4299,6 +4534,151 @@ test "JSObject: inline/overflow slot boundary round-trips" {
     // inline array.
     o.setSlot(inline_slot_cap + 1, Value.fromInt32(777));
     try testing.expectEqual(@as(i32, 777), o.slotAt(inline_slot_cap + 1).asInt32());
+}
+
+test "JSObject: named overflow and dense elements coexist through the cold spill" {
+    // Compact storage overlays the common mutually-exclusive cases:
+    // the secondary vector is either named-property overflow OR dense
+    // indexed elements. An object that genuinely needs both spills the
+    // element-vector metadata into its exact-sized aux store. Exercise both
+    // transition orders, then demote one receiver from shape mode; no
+    // named or indexed value may be lost at either representation seam.
+    const heap_mod = @import("heap.zig");
+    var heap = heap_mod.Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    const elements_first = try heap.allocateObject();
+    try elements_first.setIndexed(testing.allocator, 0, Value.fromInt32(101));
+    try elements_first.setIndexed(testing.allocator, 1, Value.fromInt32(202));
+
+    const n: usize = inline_slot_cap + 2;
+    var keys: [inline_slot_cap + 2][1]u8 = undefined;
+    for (0..n) |i| {
+        keys[i] = .{@as(u8, 'a') + @as(u8, @intCast(i))};
+        try elements_first.set(testing.allocator, &keys[i], Value.fromInt32(@intCast(i + 1)));
+    }
+    try testing.expect(elements_first.brand.secondary_is_overflow);
+    try testing.expectEqual(ObjectAuxKind.elements, elements_first.brand.aux_kind);
+    try testing.expect(elements_first.extension == null);
+    try testing.expectEqual(@as(i32, 101), elements_first.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 202), elements_first.getIndexed(1).asInt32());
+    for (0..n) |i| {
+        try testing.expectEqual(@as(i32, @intCast(i + 1)), elements_first.get(&keys[i]).asInt32());
+    }
+    try elements_first.setIndexed(testing.allocator, 4_294_967_294, Value.fromInt32(606));
+    try testing.expect(elements_first.brand.is_sparse);
+    try testing.expectEqual(@as(usize, 0), elements_first.elementCount());
+    try testing.expectEqual(@as(i32, 606), elements_first.getIndexed(4_294_967_294).asInt32());
+    for (0..n) |i| {
+        try testing.expectEqual(@as(i32, @intCast(i + 1)), elements_first.get(&keys[i]).asInt32());
+    }
+
+    const overflow_first = try heap.allocateObject();
+    for (0..n) |i| {
+        try overflow_first.set(testing.allocator, &keys[i], Value.fromInt32(@intCast(20 + i)));
+    }
+    try overflow_first.setIndexed(testing.allocator, 0, Value.fromInt32(303));
+    try testing.expect(overflow_first.brand.secondary_is_overflow);
+    try testing.expectEqual(ObjectAuxKind.elements, overflow_first.brand.aux_kind);
+    try testing.expect(overflow_first.extension == null);
+    try testing.expectEqual(@as(i32, 303), overflow_first.getIndexed(0).asInt32());
+    for (0..n) |i| {
+        try testing.expectEqual(@as(i32, @intCast(20 + i)), overflow_first.get(&keys[i]).asInt32());
+    }
+
+    try testing.expect(try overflow_first.deleteOwn(testing.allocator, &keys[0]));
+    try testing.expectEqual(ObjectAuxKind.combined, overflow_first.brand.aux_kind);
+    try testing.expect(overflow_first.extension == null);
+    try testing.expectEqual(@as(i32, 303), overflow_first.getIndexed(0).asInt32());
+
+    // The heap's fixed-capacity dense-element pool follows the same
+    // ownership transition. Its buffer must remain pool-owned after the
+    // list header spills, and teardown must return it to the pool rather
+    // than passing it to the general allocator.
+    const pooled = try heap.makeDenseArray(null, &.{ Value.fromInt32(404), Value.fromInt32(505) });
+    try testing.expect(pooled.brand.elements_pooled);
+    try pooled.resizeSlots(testing.allocator, n);
+    for (0..n) |i| {
+        pooled.setSlot(i, Value.fromInt32(@intCast(40 + i)));
+    }
+    try testing.expect(pooled.brand.secondary_is_overflow);
+    try testing.expectEqual(ObjectAuxKind.elements, pooled.brand.aux_kind);
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(i32, 404), pooled.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 505), pooled.getIndexed(1).asInt32());
+    try pooled.ensureElementsLen(testing.allocator, heap_mod.Heap.element_buf_cap + 1);
+    try testing.expect(!pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(i32, 404), pooled.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 505), pooled.getIndexed(1).asInt32());
+}
+
+test "JSObject: aux upgrades preserve dictionary and element header addresses" {
+    const heap_mod = @import("heap.zig");
+    var heap = heap_mod.Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    // Dictionary first, then overflow-mode indexed storage.
+    const dict_first = try heap.allocateObject();
+    const original_dict = try dict_first.ensureDictStore(testing.allocator);
+    try dict_first.resizeSlots(testing.allocator, inline_slot_cap + 1);
+    dict_first.setSlot(inline_slot_cap, Value.undefined_);
+    const added_elements = try dict_first.elementsMut(testing.allocator);
+    try added_elements.append(testing.allocator, Value.fromInt32(1));
+    try testing.expectEqual(ObjectAuxKind.combined, dict_first.brand.aux_kind);
+    try testing.expect(original_dict == dict_first.dictStore().?);
+
+    // Element header first, then dictionary state. The Combined node
+    // owns stable child pointers rather than moving either payload.
+    const elements_first = try heap.allocateObject();
+    try elements_first.resizeSlots(testing.allocator, inline_slot_cap + 1);
+    elements_first.setSlot(inline_slot_cap, Value.undefined_);
+    const original_elements = try elements_first.elementsMut(testing.allocator);
+    try original_elements.append(testing.allocator, Value.fromInt32(2));
+    _ = try elements_first.ensureDictStore(testing.allocator);
+    try testing.expectEqual(ObjectAuxKind.combined, elements_first.brand.aux_kind);
+    try testing.expect(original_elements == elements_first.elementsConst());
+}
+
+test "JSObject: aux publication remains valid at each allocation failure" {
+    const o = try JSObject.init(testing.allocator);
+    defer o.deinit(testing.allocator);
+    try o.setIndexed(testing.allocator, 0, Value.fromInt32(77));
+
+    // The first transition allocation is the exact-sized element
+    // header. If it fails, the original inline element header remains
+    // authoritative and no discriminator is published.
+    var fail_header = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 0 });
+    try testing.expectError(
+        error.OutOfMemory,
+        o.resizeSlots(fail_header.allocator(), inline_slot_cap + 1),
+    );
+    try testing.expect(!o.brand.secondary_is_overflow);
+    try testing.expectEqual(ObjectAuxKind.none, o.brand.aux_kind);
+    try testing.expectEqual(@as(i32, 77), o.getIndexed(0).asInt32());
+
+    // If the overflow-buffer allocation fails after the header moved,
+    // the monotonic overflow representation is still self-consistent:
+    // slot_count remains old, the overflow slice is empty, and indexed
+    // data remains reachable through the aux header.
+    var fail_overflow = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    try testing.expectError(
+        error.OutOfMemory,
+        o.resizeSlots(fail_overflow.allocator(), inline_slot_cap + 1),
+    );
+    try testing.expect(o.brand.secondary_is_overflow);
+    try testing.expectEqual(ObjectAuxKind.elements, o.brand.aux_kind);
+    try testing.expectEqual(@as(usize, 0), o.slotCount());
+    try testing.expectEqual(@as(usize, 0), o.secondary_values.items.len);
+    try testing.expectEqual(@as(i32, 77), o.getIndexed(0).asInt32());
+
+    // Upgrading elements → combined allocates a DictStore and then the
+    // two-pointer node. Failure of the second allocation must destroy
+    // the unpublished DictStore and leave the element payload in place.
+    var fail_combined = std.testing.FailingAllocator.init(testing.allocator, .{ .fail_index = 1 });
+    try testing.expectError(error.OutOfMemory, o.ensureDictStore(fail_combined.allocator()));
+    try testing.expectEqual(ObjectAuxKind.elements, o.brand.aux_kind);
+    try testing.expect(o.dictStore() == null);
+    try testing.expectEqual(@as(i32, 77), o.getIndexed(0).asInt32());
 }
 
 test "JSObject: get prefers the shape slot when present" {
@@ -4527,7 +4907,7 @@ test "JSObject: setIndexed past threshold promotes to sparse" {
 
     try o.setIndexed(testing.allocator, 4_294_967_294, Value.fromInt32(100));
     try testing.expect(o.brand.is_sparse);
-    try testing.expectEqual(@as(usize, 0), o.elements.items.len);
+    try testing.expectEqual(@as(usize, 0), o.elementCount());
     try testing.expectEqual(@as(u32, 4_294_967_295), o.arrayLength());
     try testing.expectEqual(@as(i32, 100), o.getIndexed(4_294_967_294).asInt32());
     try testing.expect(o.hasOwnIndexedSlot(4_294_967_294));
@@ -4600,7 +4980,7 @@ test "JSObject: defineProperty-style flagged write past threshold goes sparse" {
         .configurable = true,
     });
     try testing.expect(o.brand.is_sparse);
-    try testing.expectEqual(@as(usize, 0), o.elements.items.len);
+    try testing.expectEqual(@as(usize, 0), o.elementCount());
     try testing.expectEqual(@as(u32, 4_294_967_295), o.arrayLength());
     try testing.expectEqual(@as(i32, 100), o.get("4294967294").asInt32());
 }
@@ -4641,15 +5021,24 @@ test "JSObjectExtension: footprint probe (size measurement, not an invariant)" {
     // from 408 B down: the cold per-kind clusters (iterator / RegExp /
     // key anchors / Proxy) went behind `extension` (296 B), the
     // dictionary representation (`properties` / `property_flags` /
-    // `own_key_order`) went into `dict_store` (200 B), the sparse
+    // `own_key_order`) went into the aux DictStore (200 B), the sparse
     // indexed store (`sparse_elements`) went into `extension` (176 B),
     // and the 18 scattered brand bool/enum fields folded into the
     // single packed `BrandFlags` word (168 B — the V8 `Map`-flags /
-    // JSC `Structure`-flags model). See docs/gc-immix-rearchitecture.md
-    // "The memory axis". This catches an accidental re-inlining — the
-    // smallest moved field is 24 B, which would push the header past
-    // this bound.
-    try testing.expect(@sizeOf(JSObject) <= 172);
+    // JSC `Structure`-flags model). The next compact-storage step
+    // overlays the mutually-exclusive common cases for the two
+    // 24-byte value vectors: named-property overflow slots and indexed
+    // elements. That removes one vector header without adding an
+    // allocation to ordinary <=4-property objects or dense arrays,
+    // taking JSObject to 144 B. See
+    // docs/gc-immix-rearchitecture.md "The memory axis".
+    try testing.expect(@sizeOf(JSObject) <= 148);
+    if (@sizeOf(usize) == 8) {
+        try testing.expectEqual(@as(usize, 144), @sizeOf(JSObject));
+        try testing.expectEqual(@as(usize, 104), @sizeOf(DictStore));
+        try testing.expectEqual(@as(usize, 24), @sizeOf(std.ArrayListUnmanaged(Value)));
+        try testing.expectEqual(@as(usize, 16), @sizeOf(ObjectAuxCombined));
+    }
 }
 
 test "JSObjectExtension: extension is null on a fresh object" {

--- a/src/runtime/realm.zig
+++ b/src/runtime/realm.zig
@@ -347,8 +347,8 @@ pub const GlobalBindings = struct {
     decl_revision: u64 = 0,
 
     fn map(self: *GlobalBindings) *std.StringArrayHashMapUnmanaged(Value) {
-        // `bindToObject` guarantees the target has a `dict_store`.
-        if (self.target) |t| return &t.dict_store.?.properties;
+        // `bindToObject` guarantees the target has a DictStore.
+        if (self.target) |t| return &t.dictStore().?.properties;
         return &self.fallback;
     }
     fn mapConst(self: *const GlobalBindings) *const std.StringArrayHashMapUnmanaged(Value) {
@@ -693,7 +693,7 @@ pub const GlobalBindings = struct {
         self.fallback = .empty;
         // The object env-record writes/reads the global's property bag
         // through `map()` (a raw `*Map`, no allocator). The bag lives in
-        // the JSObject's lazily-allocated `dict_store` now, so ensure it
+        // the JSObject's lazily-allocated dictionary aux store now, so ensure it
         // exists here — the global is definitionally dict-backed.
         _ = try gt.ensureDictStore(allocator);
         self.target = gt;

--- a/src/runtime/snapshot.zig
+++ b/src/runtime/snapshot.zig
@@ -269,13 +269,14 @@ fn featureSetFromBits(bits: u64) features.FeatureSet {
 /// the remaining bits (the proxy / promise / weakref / sparse / buffer
 /// brands) are at their default — a non-default one is outside the
 /// phase-1 envelope (`error.SnapshotUnsupported`), same as before the
-/// fields were folded into one word.
+/// fields were folded into one word. The compact-storage representation
+/// bits (`secondary_is_overflow` / `aux_kind`) are reconstructed from
+/// the logical property/slot/element tags rather than persisted.
 const object_serialized_fields = [_][]const u8{
-    "kind",         "dict_store",   "shape",
-    "inline_slots", "slot_count",   "overflow_slots",
-    "prototype",    "prototype_fn", "brand",
-    "elements",     "extension",    "needs_internal_scan",
-    "is_pristine",
+    "kind",         "aux_store",           "shape",
+    "inline_slots", "slot_count",          "secondary_values",
+    "prototype",    "prototype_fn",        "brand",
+    "extension",    "needs_internal_scan", "is_pristine",
 };
 /// Fields recomputed / re-defaulted at restore (GC header, heap
 /// back-pointer). Borrowed-key anchors are dropped-by-design too, but
@@ -860,10 +861,11 @@ const Capture = struct {
             try w.w8(obj_tag_prototype_fn);
             try w.w32(@intCast(try self.functionRef(p)));
         }
-        if (o.elements.items.len != 0) {
+        const elements = o.elementItems();
+        if (elements.len != 0) {
             try w.w8(obj_tag_elements);
-            try w.w32(@intCast(o.elements.items.len));
-            for (o.elements.items) |v| try w.w64(try self.encodeValue(v));
+            try w.w32(@intCast(elements.len));
+            for (elements) |v| try w.w64(try self.encodeValue(v));
         }
         if (o.orderConst().items.len != 0) {
             try w.w8(obj_tag_own_key_order);
@@ -1596,8 +1598,9 @@ const Restore = struct {
                 obj_tag_elements => {
                     const n = try r.r32();
                     if (n > r.data.len) return error.SnapshotCorrupt;
-                    try o.elements.ensureTotalCapacity(allocator, n);
-                    for (0..n) |_| o.elements.appendAssumeCapacity(try self.readValue(r));
+                    const elements = try o.elementsMut(allocator);
+                    try elements.ensureTotalCapacity(allocator, n);
+                    for (0..n) |_| elements.appendAssumeCapacity(try self.readValue(r));
                 },
                 obj_tag_own_key_order => try self.readKeyList(r, try o.orderMut(allocator)),
                 obj_tag_accessors => {
@@ -1858,6 +1861,64 @@ test "snapshot: hardened realm round-trip preserves per-kind heap counts" {
     try testing.expectEqual(want_symbols, restored.heap.symbolCount());
     try testing.expectEqual(want_cells, restored.synth_accessor_cells.items.len);
     try testing.expect(restored.hardened);
+}
+
+test "snapshot: mixed named-overflow and dense elements round-trip logically" {
+    const source = try makeInstalledRealm(testing.allocator, false);
+    const owner = try source.heap.allocateObject();
+    const names = [_][]const u8{ "a", "b", "c", "d", "e", "f" };
+    for (names, 0..) |name, i| {
+        try source.heap.storeProperty(owner, source.allocator, name, Value.fromInt32(@intCast(i + 1)));
+    }
+    try owner.markAsArrayExotic(source.allocator);
+    try owner.setIndexed(source.allocator, 0, Value.fromInt32(101));
+    try owner.setIndexed(source.allocator, 1, Value.fromInt32(202));
+    try testing.expect(owner.brand.secondary_is_overflow);
+    try source.globals.put(source.allocator, "snapshotMixed", heap_mod.taggedObject(owner));
+
+    // Exercise the other aux composition as well: deleting a named key
+    // demotes the shaped mixed object to a DictStore while its dense
+    // element header remains spilled. The snapshot format must encode
+    // the logical dict + elements, not the `.combined` representation.
+    const combined = try source.heap.allocateObject();
+    for (names, 0..) |name, i| {
+        try source.heap.storeProperty(combined, source.allocator, name, Value.fromInt32(@intCast(10 + i)));
+    }
+    try combined.markAsArrayExotic(source.allocator);
+    try combined.setIndexed(source.allocator, 0, Value.fromInt32(303));
+    try testing.expect(try combined.deleteOwn(source.allocator, "a"));
+    try testing.expect(combined.shape == null);
+    try testing.expect(combined.dictStore() != null);
+    try testing.expect(combined.brand.secondary_is_overflow);
+    try source.globals.put(source.allocator, "snapshotCombined", heap_mod.taggedObject(combined));
+
+    const image = try Snapshot.capture(source, testing.allocator);
+    defer testing.allocator.free(image);
+    destroyRealm(testing.allocator, source);
+
+    const restored = try Snapshot.restore(testing.allocator, image);
+    defer destroyRealm(testing.allocator, restored);
+    const restored_value = restored.globals.get("snapshotMixed") orelse return error.TestUnexpectedResult;
+    const mixed = heap_mod.valueAsPlainObject(restored_value) orelse return error.TestUnexpectedResult;
+
+    try testing.expect(mixed.brand.secondary_is_overflow);
+    try testing.expectEqual(@as(usize, names.len), mixed.slotCount());
+    try testing.expectEqual(@as(usize, 2), mixed.elementCount());
+    for (names, 0..) |name, i| {
+        try testing.expectEqual(@as(i32, @intCast(i + 1)), mixed.get(name).asInt32());
+    }
+    try testing.expectEqual(@as(i32, 101), mixed.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 202), mixed.getIndexed(1).asInt32());
+
+    const combined_value = restored.globals.get("snapshotCombined") orelse return error.TestUnexpectedResult;
+    const restored_combined = heap_mod.valueAsPlainObject(combined_value) orelse return error.TestUnexpectedResult;
+    try testing.expect(restored_combined.shape == null);
+    try testing.expect(restored_combined.dictStore() != null);
+    try testing.expect(restored_combined.get("a").isUndefined());
+    for (names[1..], 1..) |name, i| {
+        try testing.expectEqual(@as(i32, @intCast(10 + i)), restored_combined.get(name).asInt32());
+    }
+    try testing.expectEqual(@as(i32, 303), restored_combined.getIndexed(0).asInt32());
 }
 
 test "snapshot: restored hardened realm behaves like a fresh one" {

--- a/src/wasm_format.zig
+++ b/src/wasm_format.zig
@@ -80,7 +80,7 @@ fn appendValueAt(
     } else if (v.isHole()) {
         // Array exotics store dense holes as a distinct `Value.hole_`
         // sentinel — never reachable from user JS, but the array
-        // printer below feeds them in when iterating `obj.elements`.
+        // printer below feeds them in when iterating dense element storage.
         try buf.appendSlice(allocator, "<empty>");
     } else if (v.isString()) {
         const s: *JSString = @ptrCast(@alignCast(v.asString()));
@@ -123,7 +123,7 @@ fn appendValueAt(
 /// `max_array_show` and `max_depth`. Sparse holes (the
 /// `is_sparse = true` storage where indices are absent from the
 /// `sparse_elements` map) render as `<empty>`. Dense holes (the
-/// `Value.hole_` sentinel in `elements`) route through
+/// `Value.hole_` sentinel in dense element storage) route through
 /// `appendValueAt`'s `isHole` branch, which prints the same string.
 fn appendArray(
     allocator: std.mem.Allocator,
@@ -134,7 +134,7 @@ fn appendArray(
     const len: usize = if (obj.brand.is_sparse)
         @intCast(obj.sparse_length)
     else
-        obj.elements.items.len;
+        obj.elementCount();
 
     if (depth >= max_depth) {
         var scratch: [32]u8 = undefined;
@@ -156,7 +156,7 @@ fn appendArray(
             }
         }
     } else {
-        for (obj.elements.items[0..show_n], 0..) |elem, idx| {
+        for (obj.elementItems()[0..show_n], 0..) |elem, idx| {
             if (idx > 0) try buf.appendSlice(allocator, ", ");
             try appendValueAt(allocator, buf, elem, depth + 1);
         }


### PR DESCRIPTION
## Summary

- shrink `JSObject` from 168 bytes to 144 bytes by overlaying the mutually exclusive named-overflow and dense-element vector headers
- add a tagged, exact-sized aux store for the rare objects that need dictionary state, spilled element metadata, or both
- preserve stable dictionary/element pointers, pooled-buffer ownership, logical GC/snapshot traversal, and the direct JIT overflow-slot load
- route runtime consumers through logical element accessors and add mixed-state, OOM-atomicity, GC, snapshot, and layout regressions

## Why

Splay retains roughly 768,000 `JSObject` headers. It uses either small shaped objects or dense arrays, so paying for two independent 24-byte vector headers on every object was pure live-set overhead. The 24-byte reduction has about 17.6 MiB of theoretical peak-RSS headroom without adding an allocation on Splay's paths.

## Validation

- `zig build test-fast --summary all` — 3,296 pass, 260 intentional skips
- `zig build test-ses` — 36/36 pass
- focused JSObject mixed-state, aux pointer-stability, and OOM-publication tests
- focused mixed GC marking and shaped/demoted snapshot round trips
- JIT layout proof plus Bistromath and Ohaimark overflow-property tests
- ReleaseSafe test262 allocation-pressure buckets: Array, Object, and object expressions completed without host-safety failures

## Measured impact

- `JSObject`: 168 → 144 bytes (−24 bytes, −14.3%)
- interpreter Splay peak RSS: 201,856 → 183,664 KiB (−18,192 KiB / −17.77 MiB, −9.01%)
- interpreter Splay p50: 688.05 → 660.14 ms (−4.1%)
- interleaved Splay timing ratio: 0.968× with 4.9% spread
- adjacent interpreter micro smokes show no stable regression

The full `origin/main` vs branch test262 comparison is exact: both revisions pass 48,653 tests, and the sorted pass-set diff is empty.
