### PR TITLE
runtime: right-size pooled array literal buffers

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,45 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-29 — compact/fused dense-element pools, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Interpreter-only interleaved A/B against `fe0cf39d` (the compact-storage
+baseline), five pairs per fixture. Runtime head `c8aadcd5` splits fused
+array-literal buffers into capacity-10 and capacity-16 slab classes instead of
+giving every 1–16 element literal a 16-slot buffer.
+
+The headline is Splay's retained-memory result. Its 256,000 live ten-element
+leaf arrays predict a `256000 × (16 − 10) × 8 = 12,000 KiB` payload reduction;
+observed peak RSS fell **183,540 → 171,616 KiB** (**−11,924 KiB / −11.64 MiB /
+−6.50%**), within 76 KiB of that exact prediction. Standalone timing stayed
+flat inside run spread:
+
+| revision | p50_ms | min_ms | max_ms | spread% | rss_kb |
+|---|---:|---:|---:|---:|---:|
+| base `fe0cf39d` | 676.54 | 659.15 | 710.94 | 7.7 | 183540 |
+| head `c8aadcd5` | 679.69 | 643.53 | 713.01 | 10.2 | 171616 |
+
+The back-to-back ratios are the timing signal. No macro crossed the runner's
+regression gate (a move must exceed both 5% and one-third of ratio spread):
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 1040.81 | 1066.90 | 1.024x | 6.6 |
+| deltablue | 660.17 | 663.45 | 1.018x | 16.1 |
+| crypto | 638.01 | 643.69 | 1.009x | 6.1 |
+| raytrace | 295.36 | 291.59 | 0.997x | 17.9 |
+| navier_stokes | 412.20 | 404.01 | 0.958x | 7.4 |
+| splay | 688.29 | 691.64 | 1.011x | 3.7 |
+
+The allocation-only `array_literal_loop` micro initially read 1.063x at five
+pairs, then **1.042x with 9.9% spread at 12 confirmation pairs**, below the
+gate. Its pool helpers are already inlined in the ReleaseFast binary, leaving
+only the required capacity-class branch. Controls were also unflagged:
+`ctor_array_build` 1.012x (5.5% spread) and `array_iter` 1.092x (38.5% spread).
+This run also registers the already-present `array_literal_loop.js` fixture in
+the standard benchmark table so the allocation path remains directly
+measurable.
+
 ### 2026-07-17 — multiplication operand profile + tagged Number T2 path, host `Darwin 25.6.0 arm64`
 
 Focused interleaved A/B against `0ca910a9` (pre-profile), Lantern-only

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -337,9 +337,16 @@ pub const Heap = struct {
     /// the integers actually stringified allocate a backing string.
     pub const small_int_cache_max = 256;
 
-    /// Capacity (in Values) of one pooled dense-element buffer —
-    /// matches the compiler's fused-literal cap so every
-    /// `make_array_n` array fits one pool item exactly.
+    /// Capacities (in Values) of the two pooled dense-element buffer
+    /// classes. The compact class matches Splay's retained leaf arrays
+    /// and the fused class matches the compiler's `make_array_n` cap.
+    /// Array length and backing capacity are distinct and the latter is
+    /// unobservable (§13.2.4.1 / §10.4.2), so the exact capacity also
+    /// serves as the internal pool-class discriminator without spending
+    /// another JSObject brand bit. Keep this measured two-class policy
+    /// narrow; add another arena only when a retained-length histogram
+    /// demonstrates that its saved live bytes outweigh idle slabs.
+    pub const compact_element_buf_cap = 10;
     pub const element_buf_cap = 16;
 
     allocator: std.mem.Allocator,
@@ -874,13 +881,13 @@ pub const Heap = struct {
     /// via `destroy`, teardown frees the slabs wholesale.
     promise_store_pool: std.heap.MemoryPool(@import("object.zig").PromiseReactionStore) = .empty,
 
-    /// Slab pool of small dense-element buffers — one fixed class of
-    /// `element_buf_cap` Values (128 bytes). The fused array-literal
-    /// arm draws from it instead of a libc malloc per array, and the
-    /// sweep returns it on death; an array that outgrows the class
-    /// migrates to a general-purpose buffer once (see
-    /// `JSObject.brand.elements_pooled`). Most literal arrays live and die
-    /// entirely inside the pool.
+    /// Slab pools of small dense-element buffers. Literals through ten
+    /// Values use the exact 80-byte compact class; the remaining fused
+    /// literals use the 128-byte class. The sweep returns each buffer
+    /// by its exact capacity; a compact buffer can promote once to the
+    /// fused class, then growth past that migrates to general-purpose
+    /// storage (see `JSObject.brand.elements_pooled`).
+    compact_element_buf_pool: std.heap.MemoryPool([compact_element_buf_cap]Value) = .empty,
     element_buf_pool: std.heap.MemoryPool([element_buf_cap]Value) = .empty,
 
     /// Cache of pinned `JSString`s for the decimal forms of small
@@ -1033,6 +1040,7 @@ pub const Heap = struct {
         self.pending_realm_teardown.deinit(self.allocator);
         self.object_pool.deinit(self.allocator);
         self.promise_store_pool.deinit(self.allocator);
+        self.compact_element_buf_pool.deinit(self.allocator);
         self.element_buf_pool.deinit(self.allocator);
         // Free each environment's slot vector first (the only
         // sub-field the env owns separately). The Environment
@@ -1184,18 +1192,64 @@ pub const Heap = struct {
         return o;
     }
 
+    /// Allocate the smallest pooled dense-element class that can hold
+    /// `min_capacity`. The returned list is empty but owns its buffer.
+    /// Exact capacity is the pool provenance tag used by
+    /// `releasePooledElements`.
+    pub fn allocatePooledElements(
+        self: *Heap,
+        min_capacity: usize,
+    ) error{OutOfMemory}!std.ArrayListUnmanaged(Value) {
+        if (min_capacity > element_buf_cap) return error.OutOfMemory;
+        if (min_capacity <= compact_element_buf_cap) {
+            const buf = self.compact_element_buf_pool.create(self.allocator) catch
+                return error.OutOfMemory;
+            return .{ .items = buf[0..0], .capacity = compact_element_buf_cap };
+        }
+        const buf = self.element_buf_pool.create(self.allocator) catch
+            return error.OutOfMemory;
+        return .{ .items = buf[0..0], .capacity = element_buf_cap };
+    }
+
+    /// Return a pooled dense-element list to the matching size class.
+    /// Pooled capacity is immutable until an allocate-copy-release
+    /// transition publishes a different list, so it is safe to dispatch
+    /// independently of logical length (which may shrink).
+    pub fn releasePooledElements(
+        self: *Heap,
+        elements: *std.ArrayListUnmanaged(Value),
+    ) void {
+        switch (elements.capacity) {
+            compact_element_buf_cap => {
+                const buf: *[compact_element_buf_cap]Value = @ptrCast(elements.items.ptr);
+                self.compact_element_buf_pool.destroy(buf);
+            },
+            element_buf_cap => {
+                const buf: *[element_buf_cap]Value = @ptrCast(elements.items.ptr);
+                self.element_buf_pool.destroy(buf);
+            },
+            else => {
+                // Fail closed if internal provenance is ever corrupted:
+                // orphaning a pooled pointer until Heap teardown is safe;
+                // letting a caller clear `elements_pooled` while retaining
+                // this header could later send it to the GPA allocator.
+                elements.* = .empty;
+                return;
+            },
+        }
+        elements.* = .empty;
+    }
+
     /// §13.2.4.1 — build a dense Array exotic holding exactly `elems`,
-    /// drawing its element buffer from the fixed-class slab pool
-    /// (`element_buf_pool`). The single source of truth for the fused
-    /// dense-literal construction: Lantern's `make_array_n` arm and
-    /// Bistromath's codegen both call this, so the object they build is
-    /// byte-identical — same array-exotic shape, same pooled buffer
-    /// with `elements_pooled` set, same virtual length. `elems.len`
-    /// must be `<= element_buf_cap` (the compiler caps fused literals
-    /// there). The array is young and holds only `elems`' values, so
-    /// no write barrier is needed. The CALLER keeps `elems`' backing
-    /// store GC-rooted across this call — it allocates (the JIT's
-    /// frame-identity register file; the interpreter's frame
+    /// drawing its element buffer from the smallest fitting slab class.
+    /// This is the single source of truth for fused dense literals:
+    /// Lantern's `make_array_n` arm and Bistromath's codegen both call
+    /// it, so they share the same array-exotic shape, pooled provenance,
+    /// and virtual length. `elems.len` must be `<= element_buf_cap` (the
+    /// compiler caps fused literals there). The array is young and holds
+    /// only `elems`' values, so no write barrier is needed. The CALLER
+    /// keeps `elems`' backing store GC-rooted across this allocating call
+    /// (the JIT's frame-identity register file; the interpreter's frame
     /// registers).
     pub fn makeDenseArray(
         self: *Heap,
@@ -1206,8 +1260,7 @@ pub const Heap = struct {
         self.setObjectPrototype(obj, array_prototype);
         obj.markAsArrayExotic(self.allocator) catch return error.OutOfMemory;
         const elements = obj.elementsMut(self.allocator) catch return error.OutOfMemory;
-        const buf = self.element_buf_pool.create(self.allocator) catch return error.OutOfMemory;
-        elements.* = .{ .items = buf[0..0], .capacity = element_buf_cap };
+        elements.* = try self.allocatePooledElements(elems.len);
         obj.brand.elements_pooled = true;
         elements.appendSliceAssumeCapacity(elems);
         obj.markNonPristine();
@@ -5115,6 +5168,34 @@ test "Heap: collectFull keeps a rooted mature object" {
     heap.collectFull(&.{Value.fromString(s)});
     try testing.expectEqual(@as(usize, 1), heap.stringCount());
     try testing.expectEqual(@as(usize, 1), heap.strings_mature.items.len);
+}
+
+test "Heap: dense array literals select compact and fused element pools" {
+    var heap = Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    var compact_values: [10]Value = undefined;
+    for (&compact_values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(i));
+    }
+    const compact = try heap.makeDenseArray(null, &compact_values);
+    try testing.expect(compact.brand.elements_pooled);
+    try testing.expectEqual(@as(usize, 10), compact.elementsConst().capacity);
+    try testing.expectEqualSlices(Value, &compact_values, compact.elementItems());
+
+    var fused_values: [11]Value = undefined;
+    for (&fused_values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(100 + i));
+    }
+    const fused = try heap.makeDenseArray(null, &fused_values);
+    try testing.expect(fused.brand.elements_pooled);
+    try testing.expectEqual(Heap.element_buf_cap, fused.elementsConst().capacity);
+    try testing.expectEqualSlices(Value, &fused_values, fused.elementItems());
+
+    try testing.expectError(
+        error.OutOfMemory,
+        heap.allocatePooledElements(Heap.element_buf_cap + 1),
+    );
 }
 
 test "Heap: denseElementFastSet overwrites only clean existing packed elements" {

--- a/src/runtime/object.zig
+++ b/src/runtime/object.zig
@@ -1055,11 +1055,13 @@ pub const BrandFlags = packed struct(u32) {
     /// `sparse_elements` map (in the extension); `sparse_length` is
     /// the logical length. Once sparse, stays sparse.
     is_sparse: bool = false,
-    /// `elements.items.ptr` came from the heap's `element_buf_pool`
-    /// (capacity exactly `Heap.element_buf_cap`) rather than the GPA.
-    /// Growth past the class migrates to a GPA buffer
-    /// (`elementsUnpool`); frees/teardown return the buffer to the
-    /// pool — a pooled pointer must NEVER reach `allocator.free`.
+    /// `elements.items.ptr` came from one of the heap's fixed-capacity
+    /// dense-element pools rather than the GPA. Exact capacity identifies
+    /// the class: `Heap.compact_element_buf_cap` or
+    /// `Heap.element_buf_cap`. Growth can promote compact → fused →
+    /// GPA (`elementsGrowPooled`); frees/teardown return the buffer to
+    /// its matching pool — a pooled pointer must NEVER reach
+    /// `allocator.free`.
     elements_pooled: bool = false,
     /// The base object's single `secondary_values` vector is normally
     /// dense indexed storage. Once named-property slots overflow the
@@ -2731,9 +2733,8 @@ pub const JSObject = struct {
         const elements = self.elementsExistingMut();
         if (self.brand.elements_pooled) {
             // Pool-owned buffer — must not reach `allocator.free`.
-            const heap_ty = @import("heap.zig");
-            const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.?.items.ptr);
-            if (self.heap) |h| h.element_buf_pool.destroy(buf);
+            std.debug.assert(self.heap != null);
+            if (self.heap) |h| h.releasePooledElements(elements.?);
         } else if (elements) |dense| {
             dense.deinit(allocator);
         }
@@ -4100,6 +4101,51 @@ pub const JSObject = struct {
         }
     }
 
+    /// Grow pooled elements without exposing a half-published ownership
+    /// transition. A compact buffer first promotes to the fused class;
+    /// growth past that migrates to GPA storage. In both cases the
+    /// destination allocation and copy complete before the old buffer
+    /// returns to its pool, so OOM leaves pointer, capacity, contents,
+    /// and provenance unchanged.
+    fn elementsGrowPooled(self: *JSObject, allocator: std.mem.Allocator, min_cap: usize) !void {
+        if (!self.brand.elements_pooled) return;
+        const heap_ty = @import("heap.zig");
+        const elements = self.elementsExistingMut().?;
+        if (min_cap <= elements.capacity) return;
+        std.debug.assert(self.heap != null);
+
+        if (elements.capacity == heap_ty.Heap.compact_element_buf_cap and
+            min_cap <= heap_ty.Heap.element_buf_cap)
+        {
+            const h = self.heap.?;
+            var fresh = try h.allocatePooledElements(min_cap);
+            fresh.appendSliceAssumeCapacity(elements.items);
+            h.releasePooledElements(elements);
+            elements.* = fresh;
+            return;
+        }
+
+        std.debug.assert(
+            elements.capacity == heap_ty.Heap.compact_element_buf_cap or
+                elements.capacity == heap_ty.Heap.element_buf_cap,
+        );
+        var fresh: std.ArrayListUnmanaged(Value) = .empty;
+        try fresh.ensureTotalCapacity(allocator, @max(min_cap, elements.items.len));
+        fresh.appendSliceAssumeCapacity(elements.items);
+        self.heap.?.releasePooledElements(elements);
+        elements.* = fresh;
+        self.brand.elements_pooled = false;
+    }
+
+    /// Release pooled elements back to the pool and reset to empty.
+    /// Mirrors `clearAndFree` for the pooled representation.
+    fn elementsFreePooled(self: *JSObject) void {
+        const elements = self.elementsExistingMut().?;
+        std.debug.assert(self.heap != null);
+        if (self.heap) |h| h.releasePooledElements(elements);
+        self.brand.elements_pooled = false;
+    }
+
     /// Append `v` at the next dense index on a dense Array exotic — the
     /// sequential array-literal init case `[a, b, c]`, whose elements
     /// land at 0, 1, 2 in order. Pushes straight onto `elements` and
@@ -4109,34 +4155,6 @@ pub const JSObject = struct {
     /// back to the general indexed path when the array is sparse or
     /// `idx` is not the next slot (a hole-creating or overwriting
     /// write). Does NOT touch `length`; the caller syncs it. §10.4.2.1.
-    /// Migrate pooled elements to a general-purpose buffer sized for
-    /// at least `min_cap`, returning the pooled buffer. No-op when the
-    /// buffer is already GPA-owned. Must run before ANY operation that
-    /// could grow the buffer past `Heap.element_buf_cap`.
-    fn elementsUnpool(self: *JSObject, allocator: std.mem.Allocator, min_cap: usize) !void {
-        if (!self.brand.elements_pooled) return;
-        const heap_ty = @import("heap.zig");
-        const elements = self.elementsExistingMut().?;
-        var fresh: std.ArrayListUnmanaged(Value) = .empty;
-        try fresh.ensureTotalCapacity(allocator, @max(min_cap, elements.items.len));
-        fresh.appendSliceAssumeCapacity(elements.items);
-        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.items.ptr);
-        if (self.heap) |h| h.element_buf_pool.destroy(buf);
-        elements.* = fresh;
-        self.brand.elements_pooled = false;
-    }
-
-    /// Release pooled elements back to the pool and reset to empty.
-    /// Mirrors `clearAndFree` for the pooled representation.
-    fn elementsFreePooled(self: *JSObject) void {
-        const heap_ty = @import("heap.zig");
-        const elements = self.elementsExistingMut().?;
-        const buf: *[heap_ty.Heap.element_buf_cap]Value = @ptrCast(elements.items.ptr);
-        if (self.heap) |h| h.element_buf_pool.destroy(buf);
-        elements.* = .empty;
-        self.brand.elements_pooled = false;
-    }
-
     pub fn appendDenseSequential(
         self: *JSObject,
         allocator: std.mem.Allocator,
@@ -4147,7 +4165,7 @@ pub const JSObject = struct {
         if (idx != self.elementCount()) return false;
         var elements = try self.elementsMut(allocator);
         if (self.brand.elements_pooled and elements.items.len == elements.capacity) {
-            try self.elementsUnpool(allocator, elements.items.len + 1);
+            try self.elementsGrowPooled(allocator, elements.items.len + 1);
             elements = self.elementsExistingMut().?;
         }
         try elements.append(allocator, v);
@@ -4178,7 +4196,7 @@ pub const JSObject = struct {
         }
         var elements = try self.elementsMut(allocator);
         if (self.brand.elements_pooled and new_len > elements.capacity) {
-            try self.elementsUnpool(allocator, new_len);
+            try self.elementsGrowPooled(allocator, new_len);
             elements = self.elementsExistingMut().?;
         }
         try elements.resize(allocator, new_len);
@@ -4595,8 +4613,13 @@ test "JSObject: named overflow and dense elements coexist through the cold spill
     // ownership transition. Its buffer must remain pool-owned after the
     // list header spills, and teardown must return it to the pool rather
     // than passing it to the general allocator.
-    const pooled = try heap.makeDenseArray(null, &.{ Value.fromInt32(404), Value.fromInt32(505) });
+    var pooled_values: [10]Value = undefined;
+    for (&pooled_values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(404 + i));
+    }
+    const pooled = try heap.makeDenseArray(null, &pooled_values);
     try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(usize, 10), pooled.elementsConst().capacity);
     try pooled.resizeSlots(testing.allocator, n);
     for (0..n) |i| {
         pooled.setSlot(i, Value.fromInt32(@intCast(40 + i)));
@@ -4605,11 +4628,176 @@ test "JSObject: named overflow and dense elements coexist through the cold spill
     try testing.expectEqual(ObjectAuxKind.elements, pooled.brand.aux_kind);
     try testing.expect(pooled.brand.elements_pooled);
     try testing.expectEqual(@as(i32, 404), pooled.getIndexed(0).asInt32());
-    try testing.expectEqual(@as(i32, 505), pooled.getIndexed(1).asInt32());
+    try testing.expectEqual(@as(i32, 405), pooled.getIndexed(1).asInt32());
+
+    const compact_ptr = pooled.elementsConst().items.ptr;
+    try pooled.ensureElementsLen(testing.allocator, 11);
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(heap_mod.Heap.element_buf_cap, pooled.elementsConst().capacity);
+    try testing.expect(compact_ptr != pooled.elementsConst().items.ptr);
+    try testing.expectEqual(@as(i32, 404), pooled.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 405), pooled.getIndexed(1).asInt32());
+
     try pooled.ensureElementsLen(testing.allocator, heap_mod.Heap.element_buf_cap + 1);
     try testing.expect(!pooled.brand.elements_pooled);
     try testing.expectEqual(@as(i32, 404), pooled.getIndexed(0).asInt32());
-    try testing.expectEqual(@as(i32, 505), pooled.getIndexed(1).asInt32());
+    try testing.expectEqual(@as(i32, 405), pooled.getIndexed(1).asInt32());
+}
+
+test "JSObject: compact pooled-element growth is OOM-atomic" {
+    const heap_mod = @import("heap.zig");
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{});
+    var heap = heap_mod.Heap.init(failing.allocator());
+    defer heap.deinit();
+
+    var values: [10]Value = undefined;
+    for (&values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(700 + i));
+    }
+    const pooled = try heap.makeDenseArray(null, &values);
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(usize, 10), pooled.elementsConst().capacity);
+
+    const old_ptr = pooled.elementsConst().items.ptr;
+    failing.fail_index = failing.alloc_index;
+    try testing.expectError(
+        error.OutOfMemory,
+        pooled.appendDenseSequential(
+            failing.allocator(),
+            @intCast(values.len),
+            Value.fromInt32(999),
+        ),
+    );
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(usize, 10), pooled.elementsConst().capacity);
+    try testing.expectEqual(old_ptr, pooled.elementsConst().items.ptr);
+    try testing.expectEqualSlices(Value, &values, pooled.elementItems());
+
+    failing.fail_index = std.math.maxInt(usize);
+    var compact_probe = try heap.allocatePooledElements(values.len);
+    try testing.expect(compact_probe.items.ptr != old_ptr);
+    heap.releasePooledElements(&compact_probe);
+
+    try testing.expect(try pooled.appendDenseSequential(
+        failing.allocator(),
+        @intCast(values.len),
+        Value.fromInt32(999),
+    ));
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(heap_mod.Heap.element_buf_cap, pooled.elementsConst().capacity);
+    try testing.expect(old_ptr != pooled.elementsConst().items.ptr);
+    try testing.expectEqualSlices(Value, &values, pooled.elementItems()[0..values.len]);
+    try testing.expectEqual(@as(i32, 999), pooled.getIndexed(10).asInt32());
+
+    const fused_ptr = pooled.elementsConst().items.ptr;
+    failing.fail_index = failing.alloc_index;
+    try testing.expectError(
+        error.OutOfMemory,
+        pooled.ensureElementsLen(failing.allocator(), heap_mod.Heap.element_buf_cap + 1),
+    );
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(heap_mod.Heap.element_buf_cap, pooled.elementsConst().capacity);
+    try testing.expectEqual(fused_ptr, pooled.elementsConst().items.ptr);
+    try testing.expectEqual(@as(i32, 999), pooled.getIndexed(10).asInt32());
+
+    failing.fail_index = std.math.maxInt(usize);
+    var fused_probe = try heap.allocatePooledElements(heap_mod.Heap.element_buf_cap);
+    try testing.expect(fused_probe.items.ptr != fused_ptr);
+    heap.releasePooledElements(&fused_probe);
+
+    try pooled.ensureElementsLen(failing.allocator(), heap_mod.Heap.element_buf_cap + 1);
+    try testing.expect(!pooled.brand.elements_pooled);
+    try testing.expectEqualSlices(Value, &values, pooled.elementItems()[0..values.len]);
+    try testing.expectEqual(@as(i32, 999), pooled.getIndexed(10).asInt32());
+}
+
+test "JSObject: compact pooled elements can grow directly past fused capacity" {
+    const heap_mod = @import("heap.zig");
+    var heap = heap_mod.Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    var values: [10]Value = undefined;
+    for (&values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(800 + i));
+    }
+    const pooled = try heap.makeDenseArray(null, &values);
+    try pooled.ensureElementsLen(testing.allocator, heap_mod.Heap.element_buf_cap + 1);
+    try testing.expect(!pooled.brand.elements_pooled);
+    try testing.expectEqualSlices(Value, &values, pooled.elementItems()[0..values.len]);
+    for (pooled.elementItems()[values.len..]) |value| {
+        try testing.expect(JSObject.isElementHole(value));
+    }
+}
+
+test "JSObject: sparse promotion returns each pooled element class" {
+    const heap_mod = @import("heap.zig");
+    var heap = heap_mod.Heap.init(testing.allocator);
+    defer heap.deinit();
+
+    var compact_values: [10]Value = @splat(Value.undefined_);
+    const compact = try heap.makeDenseArray(null, &compact_values);
+    const compact_ptr = compact.elementsConst().items.ptr;
+    try compact.setIndexed(testing.allocator, 100_000, Value.fromInt32(1));
+    try testing.expect(compact.brand.is_sparse);
+    try testing.expect(!compact.brand.elements_pooled);
+
+    var fused_values: [11]Value = @splat(Value.undefined_);
+    var fused_probe = try heap.allocatePooledElements(fused_values.len);
+    try testing.expect(fused_probe.items.ptr != compact_ptr);
+    heap.releasePooledElements(&fused_probe);
+
+    const fused = try heap.makeDenseArray(null, &fused_values);
+    const fused_ptr = fused.elementsConst().items.ptr;
+    try fused.setIndexed(testing.allocator, 100_000, Value.fromInt32(2));
+    try testing.expect(fused.brand.is_sparse);
+    try testing.expect(!fused.brand.elements_pooled);
+
+    var compact_reused = try heap.allocatePooledElements(compact_values.len);
+    try testing.expectEqual(compact_ptr, compact_reused.items.ptr);
+    heap.releasePooledElements(&compact_reused);
+    var fused_reused = try heap.allocatePooledElements(fused_values.len);
+    try testing.expectEqual(fused_ptr, fused_reused.items.ptr);
+    heap.releasePooledElements(&fused_reused);
+}
+
+test "JSObject: sparse-promotion OOM retains exclusive pooled ownership" {
+    const heap_mod = @import("heap.zig");
+    var failing = std.testing.FailingAllocator.init(testing.allocator, .{});
+    var heap = heap_mod.Heap.init(failing.allocator());
+    defer heap.deinit();
+
+    var values: [10]Value = undefined;
+    for (&values, 0..) |*value, i| {
+        value.* = Value.fromInt32(@intCast(900 + i));
+    }
+    const pooled = try heap.makeDenseArray(null, &values);
+    const old_ptr = pooled.elementsConst().items.ptr;
+
+    failing.fail_index = failing.alloc_index;
+    try testing.expectError(
+        error.OutOfMemory,
+        pooled.setIndexed(failing.allocator(), 100_000, Value.fromInt32(1234)),
+    );
+    try testing.expect(!pooled.brand.is_sparse);
+    try testing.expect(pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(usize, 10), pooled.elementsConst().capacity);
+    try testing.expectEqual(old_ptr, pooled.elementsConst().items.ptr);
+    try testing.expectEqualSlices(Value, &values, pooled.elementItems());
+
+    failing.fail_index = std.math.maxInt(usize);
+    var compact_probe = try heap.allocatePooledElements(values.len);
+    try testing.expect(compact_probe.items.ptr != old_ptr);
+    heap.releasePooledElements(&compact_probe);
+
+    try pooled.setIndexed(failing.allocator(), 100_000, Value.fromInt32(1234));
+    try testing.expect(pooled.brand.is_sparse);
+    try testing.expect(!pooled.brand.elements_pooled);
+    try testing.expectEqual(@as(i32, 900), pooled.getIndexed(0).asInt32());
+    try testing.expectEqual(@as(i32, 1234), pooled.getIndexed(100_000).asInt32());
+
+    var compact_reused = try heap.allocatePooledElements(values.len);
+    try testing.expectEqual(old_ptr, compact_reused.items.ptr);
+    heap.releasePooledElements(&compact_reused);
 }
 
 test "JSObject: aux upgrades preserve dictionary and element header addresses" {

--- a/tools/bench.zig
+++ b/tools/bench.zig
@@ -93,6 +93,7 @@ const BENCHES = [_]Bench{
     .{ .name = "prop_access", .path = "bench/micros/prop_access.js" },
     .{ .name = "prop_write", .path = "bench/micros/prop_write.js" },
     .{ .name = "array_iter", .path = "bench/micros/array_iter.js" },
+    .{ .name = "array_literal_loop", .path = "bench/micros/array_literal_loop.js" },
     .{ .name = "string_concat", .path = "bench/micros/string_concat.js" },
     .{ .name = "promise_chain", .path = "bench/micros/promise_chain.js" },
     .{ .name = "object_alloc", .path = "bench/micros/object_alloc.js" },


### PR DESCRIPTION
## What

- split fused dense-array literal storage into 10-Value and 16-Value slab classes
- keep pool provenance internal via the existing pooled bit plus exact capacity
- make compact → fused → GPA growth allocation-atomic, with centralized class-aware release
- add boundary, aux-spill, sparse-promotion, cross-pool reuse, direct-growth, and induced-OOM coverage
- register the existing `array_literal_loop` fixture and record the remote A/B in `bench-results.md`

## Why

The compact-storage change leaves Splay's retained ten-element leaf arrays in 16-slot buffers. Splay holds about 256,000 of them, wasting 48 bytes apiece. A measured 10/16 policy recovers that memory without adding another JSObject brand bit or changing observable Array semantics.

PR #77 is merged; this PR is now rebased directly onto `main` with only its four-file delta.

## Remote benchmark

Interpreter-only, remote Linux box, base `fe0cf39d`, runtime patch `c8aadcd5` (rebased patch-identically as `f58a9db9`):

- Splay RSS: **183,540 → 171,616 KiB** (**−11,924 KiB / −11.64 MiB / −6.50%**)
- theoretical payload saving: 12,000 KiB; observed result is within 76 KiB
- Splay interleaved timing: 1.011x (3.7% spread)
- no macro crossed the ±5% + spread/3 regression gate
- allocation-only micro confirmation: 1.042x with 9.9% spread over 12 pairs, below the gate

## Validation

- `zig build test-fast`
- `zig build test-ses` — 36/36
- focused pooled selection/growth/release/OOM/JIT tests
- exact pre/post test262 pass-list parity:
  - `built-ins/Array`: 3,273 passes, 27 existing failures
  - `language/expressions/array`: 52/52
- ReleaseSafe `--gc-threshold=1`:
  - array expressions: 52/52
  - full Array bucket completed without ownership/GC failures; the 60s sort outlier passed 1/1 with `--timeout=180` (69.2s)
- all 34 pre-rebase CI checks passed
- `zig fmt --check`
- `git diff --check`
