### PR TITLE
Fast-path int32 remainder in Lantern

### DIFF
--- a/bench/micros/mod_loop.js
+++ b/bench/micros/mod_loop.js
@@ -1,0 +1,15 @@
+// Tight numeric remainder loop. Both operands stay Int32, the dividend
+// changes to prevent constant folding, and the checksum keeps every result
+// observable while exercising Lantern's direct Number::remainder path.
+'use strict';
+function run() {
+    let checksum = 0;
+    let dividend = 1;
+    const divisor = 97;
+    for (let i = 0; i < 3_000_000; i++) {
+        checksum = (checksum + (dividend % divisor)) | 0;
+        dividend = (dividend + 1) | 0;
+    }
+    return checksum;
+}
+print(run());

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1620,13 +1620,23 @@ not measurements.
    it caches the key bytes inline ([inline-caches.md](inline-caches.md)
    "Computed-property read + write IC").
 
-10. **SMI fast paths in arithmetic / comparison opcodes.**
+10. **SMI fast paths in arithmetic / comparison opcodes — modulo
+    slice shipped (2026-07-29).**
     Cynic uses NaN-boxing so an int32 value is identifiable
     by tag. The `add` / `sub` / `mul` / `lt` / `eq` opcodes
     can check `(lhs.isInt32() and rhs.isInt32())` early and
     take a non-overflow integer path before falling back to
     the full numeric-tower coercion. Some opcodes already
-    have this; auditing for completeness is the work.
+    have this; auditing for completeness remains the work.
+    Int32/Int32 `%` now calls one total Number-remainder helper
+    directly from Lantern and the generic numeric path, preserving
+    NaN and signed zero while guarding the host-trapping
+    `minInt(i32) % -1` pair. On the remote 20-pair interpreter
+    A/B, `mod_loop` moved to **0.824×**; a 60-pair Crypto
+    confirmation measured **0.968×**. The six-macro interpreter
+    geometric mean stayed **1.000×** (worst **1.034×**), and the
+    only initially noisy >5% micro control resolved to **1.007×**
+    over 60 pairs.
 
 11. **Direct-threaded dispatch.** Pre-decode each chunk's
     bytecode into a list of `(handler_fn_ptr, operand_bytes)`

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -98,6 +98,7 @@ Run one fixture with `zig build bench -- --filter=<name>`; combine it with
 | `arith_loop` | 5,000,000 | Bytecode dispatch density on `Op.add` / `Op.lt` / `Op.jmp` — int32 fast-path + the threaded-dispatch loop with no property access. Smi-overflow paths are NOT exercised (every step stays int32-clean via `\| 0`). |
 | `mul_loop` | 3,000,000 | Numeric `Op.mul` dispatch with an Int32/Double raw-operand pair and a Double result. Pins Lantern's one-byte per-site operand profile plus the fused Number multiplication path; the changing multiplicand prevents constant folding. |
 | `div_loop` | 3,000,000 | Numeric `Op.div` dispatch with Int32 raw operands and a Double result. Pins Lantern's one-byte per-site operand profile plus the fused Number division path; the changing numerator prevents constant folding. |
+| `mod_loop` | 3,000,000 | Numeric `Op.mod` dispatch with two Int32 operands. Pins Lantern's direct truncating Number-remainder path; the changing dividend prevents constant folding, while an accumulated checksum keeps every result observable. |
 | `prop_access` | 500,000 | Hot named-property reads on a same-shape object — `lda_property` IC hit-rate. Pre-IC: ~3× behind QuickJS-NG. Post-IC (e03f5cd): −66 % on Cynic. The headline cache-effectiveness bench. |
 | `prop_write` | 500,000 | Hot named-property writes on a same-shape object — `sta_property` IC + shape-shadow update + property-bag put. The mirror of `prop_access`. Post-IC (7bad504): −63 % on Cynic. |
 | `array_iter` | 10,000×100 passes | `for-of` over a packed Array — iterator protocol + indexed reads on §10.4.2 Array exotic. The env-hoist (`f719ae3`) was measured here at −69.6 %. |
@@ -135,10 +136,10 @@ out of the timed samples. Increase confidence with:
 
     zig build bench -- --ohaimark-rollout --runs=30
 
-The ordinary `bench/micros/mul_loop.js` and `div_loop.js` intentionally invoke
-their hot function once. Backedges heat those chunks, but an entry-only T2 has
-no later entry at which to compile them; they remain valid T1 benchmarks and
-are the shape the **OSR rollout** suite targets.
+The ordinary `bench/micros/mul_loop.js`, `div_loop.js`, and `mod_loop.js`
+intentionally invoke their hot function once. Backedges heat those chunks, but
+an entry-only T2 has no later entry at which to compile them; they remain valid
+T1 benchmarks and are the shape the **OSR rollout** suite targets.
 
 ### Ohaimark OSR natural-threshold gate
 

--- a/src/runtime/lantern/arith.zig
+++ b/src/runtime/lantern/arith.zig
@@ -303,23 +303,7 @@ pub fn numericBinary(realm: *Realm, comptime op: NumericOp, lhs: Value, rhs: Val
                 if (numberMultiplyInt32(a, b)) |result| return result;
             },
             .mod => {
-                // §13.6.2 / §6.1.6.1.5 Number::remainder — JS
-                // modulus is truncated, not Euclidean: the
-                // result's sign follows the dividend (a). `@mod`
-                // is Euclidean (always non-negative when b > 0);
-                // `@rem` is the C-style truncated remainder that
-                // matches JS.
-                if (b != 0) {
-                    const rem = @rem(a, b);
-                    // §6.1.6.1.5 — when the result is zero, its
-                    // sign tracks the dividend: `(-1) % 1 === -0`,
-                    // `(-1) % (-1) === -0`. The int32 representation
-                    // collapses ±0 to +0, so a negative dividend
-                    // with zero remainder must escape to a Double
-                    // to preserve sign.
-                    if (rem == 0 and a < 0) return Value.fromDouble(-0.0);
-                    return Value.fromInt32(rem);
-                }
+                return numberRemainderInt32(a, b);
             },
             .div, .pow => unreachable,
         }
@@ -332,10 +316,9 @@ pub fn numericBinary(realm: *Realm, comptime op: NumericOp, lhs: Value, rhs: Val
         .sub => a - b,
         .mul => a * b,
         .div => a / b,
-        // §13.6.2 — truncated remainder (sign follows dividend),
-        // not Euclidean. `@rem` for f64 yields IEEE 754
-        // remainder by truncated division, matching `Math.fmod`
-        // / V8 / SM behaviour.
+        // §13.7.1 / §6.1.6.1.6 — truncating remainder (sign follows
+        // the dividend), not Euclidean or IEEE-754 remainder.
+        // `@rem` matches JavaScript `%` / fmod semantics.
         .mod => @rem(a, b),
         .pow => jsPow(a, b),
     });
@@ -352,6 +335,29 @@ pub inline fn numberMultiplyInt32(lhs: i32, rhs: i32) ?Value {
         return Value.fromDouble(-0.0);
     }
     return Value.fromInt32(product[0]);
+}
+
+/// §6.1.6.1.6 Number::remainder for two canonical int32 operands. This helper
+/// is total: exceptional integer-division cases escape to their Number result
+/// without evaluating a trapping host operation.
+pub inline fn numberRemainderInt32(dividend: i32, divisor: i32) Value {
+    if (divisor == 0) return Value.fromDouble(std.math.nan(f64));
+
+    // Zig's signed integer remainder shares division's minInt / -1 overflow
+    // trap. Mathematically every integer remainder by -1 is zero; JavaScript
+    // gives that zero the dividend's sign.
+    if (divisor == -1) {
+        return if (dividend < 0)
+            Value.fromDouble(-0.0)
+        else
+            Value.fromInt32(0);
+    }
+
+    // `@rem` is truncated rather than Euclidean, matching Number::remainder:
+    // a non-zero result has the dividend's sign.
+    const result = @rem(dividend, divisor);
+    if (result == 0 and dividend < 0) return Value.fromDouble(-0.0);
+    return Value.fromInt32(result);
 }
 
 /// §6.1.6.1.3 Number::exponentiate — adds the JS spec's special

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1349,19 +1349,21 @@ inline fn profiledNumberArithmetic(
     });
 }
 
-/// §6.1.6.1 / §13.15 — `+` `-` `*` `/` `%` on two numeric operands where
-/// at least one is a Double (int32+int32 stays on the int path so an
-/// in-range integer result keeps its int32 tag). Returns
-/// `Value.fromDouble(x OP y)`, byte-identical to the general
-/// `addValues` / `numericBinary` double branch — same `fromDouble`, same
-/// f64 op — so the fast path is transparent. `null` when either operand
-/// isn't a Number (object / string / bool / BigInt → general path) or
-/// both are int32.
+/// §6.1.6.1 / §13.15 — `+` `-` `*` `/` `%` on two numeric operands.
+/// Double and mixed pairs return `Value.fromDouble(x OP y)`, byte-identical
+/// to the general `addValues` / `numericBinary` double branch. The `%`
+/// specialization also handles int32 pairs through Number::remainder's total,
+/// host-safe helper; other int32 pairs keep their existing dedicated paths.
+/// Returns `null` for non-Numbers (object / string / bool / BigInt → general
+/// coercion path).
 inline fn numArith(comptime op: enum { add, sub, mul, div, mod }, a: Value, b: Value) ?Value {
     const a_num = a.isInt32() or a.isDouble();
     const b_num = b.isInt32() or b.isDouble();
     if (!a_num or !b_num) return null;
-    if (!a.isDouble() and !b.isDouble()) return null; // both int32 → int path
+    if (!a.isDouble() and !b.isDouble()) {
+        if (op == .mod) return arith.numberRemainderInt32(a.asInt32(), b.asInt32());
+        return null; // other int32 pairs keep their dedicated paths
+    }
     const x: f64 = if (a.isInt32()) @floatFromInt(a.asInt32()) else a.asDouble();
     const y: f64 = if (b.isInt32()) @floatFromInt(b.asInt32()) else b.asDouble();
     return Value.fromDouble(switch (op) {

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -8,6 +8,7 @@ const std = @import("std");
 const testing = std.testing;
 
 const lantern = @import("interpreter.zig");
+const lantern_arith = @import("arith.zig");
 const RunResult = lantern.RunResult;
 const run = lantern.run;
 const evaluateScript = lantern.evaluateScript;
@@ -305,7 +306,7 @@ test "const-fold: numeric tree folds to the exact spec value" {
     try expectInt("1 + 2*3;", 7);
     try expectInt("2 ** 10;", 1024);
     try expectInt("5 % 3;", 2);
-    try expectInt("-5 % 3;", -2); // §6.1.6.1.5 — sign follows the dividend
+    try expectInt("-5 % 3;", -2); // §6.1.6.1.6 — sign follows the dividend
     try expectInt("(7 & 3) | 8;", 11);
     try expectInt("1 << 31;", -2147483648); // wraps to i32 min
     try expectDouble("-1 >>> 0;", 4294967295.0); // §6.1.6.1.10 — uint32 result
@@ -332,6 +333,66 @@ test "multiplication: int32 fast path preserves negative zero" {
     // path independently from the compiler's constant folder.
     try expectDouble("(function () { let x = -1; let y = 0; return x * y; })();", -0.0);
     try expectDouble("(function () { let x = 0; let y = -1; return x * y; })();", -0.0);
+}
+
+test "remainder: dynamic int32 operands preserve Number semantics" {
+    // §6.1.6.1.6 Number::remainder. Keep both operands dynamic so these
+    // exercise Lantern's opcode path rather than the constant folder.
+    try expectInt("(function (x, y) { return x % y; })(5, 3);", 2);
+    try expectInt("(function (x, y) { return x % y; })(-5, 3);", -2);
+    try expectInt("(function (x, y) { return x % y; })(5, -3);", 2);
+    try expectInt("(function (x, y) { return x % y; })(-5, -3);", -2);
+
+    // A zero remainder takes the dividend's sign. The int32 Value encoding
+    // cannot represent -0, so negative dividends must escape to a Double.
+    try expectDouble("(function (x, y) { return x % y; })(-4, 2);", -0.0);
+    try expectDouble("(function (x, y) { return x % y; })(-4, -2);", -0.0);
+    try expectDouble("(function (x, y) { return x % y; })(4, -2);", 0.0);
+
+    // Division by zero produces NaN, never a host integer trap.
+    try expectBool(
+        "(function (x, y) { let r = x % y; return r !== r; })(5, 0);",
+        true,
+    );
+
+    // Zig's signed integer remainder traps for minInt / -1 even though the
+    // mathematical remainder is zero. Build minInt through a bitwise op so
+    // the `%` receives two canonical int32 Values at runtime.
+    try expectDouble(
+        "(function (x, y) { return x % y; })(1 << 31, -1);",
+        -0.0,
+    );
+
+    // The compiler's constant folder calls numericBinary directly; pin the
+    // same overflow edge there so the shared helper protects both paths.
+    try expectDouble("(1 << 31) % -1;", -0.0);
+}
+
+test "numberRemainderInt32: total helper covers signed zero and zero divisor" {
+    const ordinary = lantern_arith.numberRemainderInt32(5, 3);
+    try testing.expect(ordinary.isInt32());
+    try testing.expectEqual(@as(i32, 2), ordinary.asInt32());
+
+    const negative_zero = lantern_arith.numberRemainderInt32(-4, 2);
+    try testing.expect(negative_zero.isDouble());
+    try testing.expectEqual(
+        @as(u64, @bitCast(@as(f64, -0.0))),
+        @as(u64, @bitCast(negative_zero.asDouble())),
+    );
+
+    const zero_divisor = lantern_arith.numberRemainderInt32(5, 0);
+    try testing.expect(zero_divisor.isDouble());
+    try testing.expect(std.math.isNan(zero_divisor.asDouble()));
+
+    const overflow_edge = lantern_arith.numberRemainderInt32(
+        std.math.minInt(i32),
+        -1,
+    );
+    try testing.expect(overflow_edge.isDouble());
+    try testing.expectEqual(
+        @as(u64, @bitCast(@as(f64, -0.0))),
+        @as(u64, @bitCast(overflow_edge.asDouble())),
+    );
 }
 
 test "const-fold: string concat / comparisons / equality on literals" {

--- a/tools/bench.zig
+++ b/tools/bench.zig
@@ -90,6 +90,7 @@ const BENCHES = [_]Bench{
     .{ .name = "arith_loop", .path = "bench/micros/arith_loop.js" },
     .{ .name = "mul_loop", .path = "bench/micros/mul_loop.js" },
     .{ .name = "div_loop", .path = "bench/micros/div_loop.js" },
+    .{ .name = "mod_loop", .path = "bench/micros/mod_loop.js" },
     .{ .name = "prop_access", .path = "bench/micros/prop_access.js" },
     .{ .name = "prop_write", .path = "bench/micros/prop_write.js" },
     .{ .name = "array_iter", .path = "bench/micros/array_iter.js" },


### PR DESCRIPTION
## What changed

- route tagged Int32/Int32 `%` pairs directly through a shared `numberRemainderInt32` helper
- preserve Number semantics for NaN, signed zero, and `INT32_MIN % -1` without a trapping host remainder
- reuse the helper from the generic numeric path and constant folder
- add dynamic semantic regressions and a checksum-backed `mod_loop` microbenchmark

## Why

Lantern previously rejected two-int32 operands in its inline numeric fast path, then paid the full `ToNumeric`/BigInt routing machinery before reaching the existing integer remainder implementation. The old implementation also evaluated Zig `@rem` for the host-overflow pair `INT32_MIN / -1`.

## Validation

- ReleaseSafe focused unit tests: pass
- test262 `language/expressions/modulus`: 39 pass, 1 documented strict-only failure
- full non-cached test262: 48,653 / 49,977 passing, exactly matching main
- full ReleaseSafe unit suite: pass
- local 40-pair interpreter A/B: `mod_loop 0.815x`; controls `arith_loop 1.000x`, `mul_loop 1.003x`, `div_loop 0.999x`
- remote 20-pair interpreter A/B: `mod_loop 0.824x`; six-macro geometric mean `0.9996x`, worst macro `1.034x`
- remote 60-pair confirmations: Crypto `0.968x`; noisy string-concat control resolved to `1.007x`
- independent code review: no actionable findings
