### PR TITLE
Precompute bytecode operand sizes

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,46 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-29 — schema-derived operand-size lookup, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Interleaved A/B: runtime head `0760c74a` against exact pre-change
+`5023ad4a`, 12 pairs in both Lantern-only (`--no-jit`) and the default
+production-tier posture. Merged opcode-family handlers previously resolved
+each runtime opcode's width through `Op.spec()` and
+`OperandLayout.operandSize()`. Head instead indexes a 256-byte table generated
+from `Op.spec()` at comptime. The schema remains authoritative; bytecode
+encoding and dynamic dispatch counts are unchanged.
+
+Exact-main ReleaseFast profiles attributed the metadata path to 30.7% of
+Richards samples, 19.3% of DeltaBlue, and 21.9% of RayTrace. Removing it
+improved every macro. The interpreter-only geometric mean was **0.720x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 1031.86 | 598.67 | 0.582x | 12 |
+| deltablue | 640.75 | 469.46 | 0.725x | 11 |
+| crypto | 618.37 | 414.89 | 0.681x | 17 |
+| raytrace | 290.82 | 217.14 | 0.748x | 21 |
+| navier_stokes | 396.61 | 291.48 | 0.765x | 17 |
+| splay | 566.50 | 480.54 | 0.849x | 20 |
+
+The default-tier confirmation likewise improved all six macros, for a
+**0.706x** geometric mean:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 1020.94 | 599.34 | 0.587x | 16 |
+| deltablue | 638.60 | 462.47 | 0.725x | 19 |
+| crypto | 636.59 | 416.02 | 0.656x | 18 |
+| raytrace | 296.55 | 216.51 | 0.734x | 25 |
+| navier_stokes | 389.86 | 284.10 | 0.733x | 12 |
+| splay | 573.65 | 476.07 | 0.827x | 15 |
+
+The full micro suite reported no regression past the paired-run threshold.
+Interpreter highlights were `arith_loop` **0.648x**, `prop_access` **0.576x**,
+`prop_write` **0.426x**, and `method_call` **0.634x**; the low-dispatch
+`promise_chain` control stayed flat at **0.999x**.
+
 ### 2026-07-29 — bounded shallow-ConsString memo, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Lantern-only (`--no-jit`) interleaved A/B: runtime head `654fc093` against

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -996,6 +996,14 @@ sampling by `/profile`.
   instructions **1,509 → 1,456** (-3.5%), encoded bytes **3,122 →
   3,067** (-1.8%), and dynamic dispatches **107,516,101 →
   104,678,462** (-2.64%).
+- **Schema-derived operand-size lookup (2026-07-29).** Merged Lantern
+  opcode-family handlers now advance `ip` through a 256-byte table generated
+  at comptime from the authoritative `Op.spec()` metadata, replacing repeated
+  runtime instruction-metadata and operand-layout classification. The wire
+  format and dispatch count are unchanged. A remote 12-pair A/B measured a
+  **0.720x** interpreter macro geometric mean and **0.706x** in the default
+  production-tier posture, with all six workloads improving and no gated
+  micro regression. See `bench-results.md`.
 - **Bistromath continuation + hardened-load closure (2026-07-16).**
   Catch/finally PCs now receive compiled reentry stubs in the shared
   bytecode-continuation table; the driver invokes Lantern's real unwinder

--- a/docs/handbook/compiler-engineering.md
+++ b/docs/handbook/compiler-engineering.md
@@ -115,8 +115,10 @@ without making Bistromath reconstruct a virtual stack.
 declares its mnemonic, operand layout, control-flow class, and
 Bistromath strategy in `Op.spec()`. The disassembler, liveness pass,
 statistics collector, branch decoder, Lantern, and Bistromath derive
-their stream walk from that schema. Do not add a parallel operand-size
-or opcode-classification table.
+their stream walk from that schema. `Op.operandSize()` uses a 256-byte
+table generated at comptime from `Op.spec()`; this is a cache of the
+authoritative schema, not an independent definition. Do not add a
+hand-maintained parallel operand-size or opcode-classification table.
 
 The wire format is compact but scalable:
 

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -1702,8 +1702,8 @@ pub const Op = enum(u8) {
     }
 
     /// Total operand bytes, derived from the authoritative layout.
-    pub fn operandSize(op: Op) u8 {
-        return op.spec().layout.operandSize();
+    pub inline fn operandSize(op: Op) u8 {
+        return operand_size_by_opcode[@intFromEnum(op)];
     }
 
     /// Arithmetic bytecodes whose trailing u16 indexes the chunk-owned raw
@@ -1820,6 +1820,20 @@ pub const Op = enum(u8) {
             else => unreachable,
         };
     }
+};
+
+/// Runtime operand decoding is part of every merged-family interpreter
+/// handler. Derive its compact lookup table from `Op.spec()` at comptime so
+/// the schema stays authoritative without re-running the full instruction
+/// metadata switch and operand-layout walk for every executed bytecode.
+const operand_size_by_opcode: [256]u8 = blk: {
+    @setEvalBranchQuota(10_000);
+    var sizes: [256]u8 = @splat(0);
+    for (@typeInfo(Op).@"enum".field_names) |field_name| {
+        const op: Op = @field(Op, field_name);
+        sizes[@intFromEnum(op)] = op.spec().layout.operandSize();
+    }
+    break :blk sizes;
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What changed

- Generate a 256-byte operand-size table at comptime from the authoritative `Op.spec()` schema.
- Inline `Op.operandSize()` as one indexed load instead of re-running instruction metadata and operand-layout classification at runtime.
- Document that the table is derived cache data, not a second hand-maintained schema.

## Why

ReleaseFast profiles attributed roughly 31% of Richards, 19% of DeltaBlue, and 22% of RayTrace samples to runtime operand-size metadata. Merged opcode-family handlers call this path on every execution even though the bytecode schema is immutable.

## Impact

The serialized remote 12-pair A/B improved all six interpreter macros: Richards 0.582x, DeltaBlue 0.725x, Crypto 0.681x, RayTrace 0.748x, Navier-Stokes 0.765x, and Splay 0.849x, for a 0.720x geometric mean. The default production-tier geometric mean was 0.706x. Interpreter `prop_access` measured 0.576x, and the full micro suite reported no regression past the paired-run threshold. Dispatch counts and bytecode encoding are unchanged.

## Validation

- `zig build test-fast`
- exhaustive `Op:` schema/table equality tests
- full non-cached test262: 48,653 pass / 1,324 fail, 97.35% (exact main pass set)
- independent code review: no findings
- serialized remote 12-pair A/B, both tiers: no regressions
