### PR TITLE
Skip disabled interpreter tier probes

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,50 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-29 — disabled-tier probe gate, host `Darwin 25.6.0 arm64`
+
+Interleaved A/B: runtime head `85616796` against exact merged main
+`0d4da627`, 60 pairs in both Lantern-only (`--no-jit`) and the default
+production-tier posture. A disabled-JIT realm previously entered the
+Ohaimark and Bistromath policy paths after every fresh frame and loop
+backedge merely to rediscover the shared master switch. Head checks that
+switch once, after preserving the existing `+16` entry and `+1` backedge
+warmth updates, and skips both tier-specific probes.
+
+Merged-main ReleaseFast profiles attributed the fresh-entry probes to 7.36%
+of Richards samples and 7.50% of DeltaBlue; Navier-Stokes attributed another
+1.49% to the backedge Ohaimark policy probe. The interpreter-only geometric
+mean improved to **0.969x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 258.12 | 244.84 | 0.949x | 16.6 |
+| deltablue | 199.67 | 188.04 | 0.942x | 6.4 |
+| crypto | 136.45 | 132.88 | 0.974x | 19.2 |
+| raytrace | 79.94 | 77.53 | 0.972x | 4.7 |
+| navier_stokes | 102.99 | 102.38 | 0.994x | 5.1 |
+| splay | 164.27 | 161.15 | 0.982x | 18.1 |
+
+The loop-only `arith_loop` control improved to **0.911x** over 50 pairs.
+The matching 60-pair default-tier control stayed flat at a **1.003x**
+geometric mean:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 234.44 | 237.46 | 1.013x | 5.9 |
+| deltablue | 178.58 | 177.58 | 0.996x | 10.3 |
+| crypto | 137.00 | 137.48 | 1.004x | 6.3 |
+| raytrace | 80.45 | 80.47 | 1.000x | 5.5 |
+| navier_stokes | 103.04 | 103.45 | 1.002x | 7.9 |
+| splay | 168.90 | 169.23 | 1.002x | 14.5 |
+
+The shared remote box's 20-pair cross-check had 15–29% ratio spread, too
+noisy to resolve this small change; it reported no regression past the
+harness threshold. ReleaseFast disassembly confirms every disabled path
+branches before the Ohaimark/Bistromath calls. Full ReleaseSafe units pass,
+and the non-`--only-failing` test262 sweep retains the exact merged-main pass
+set: **48,653 pass / 1,324 fail (97.35%)**.
+
 ### 2026-07-29 — schema-derived operand-size lookup, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Interleaved A/B: runtime head `0760c74a` against exact pre-change

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1004,6 +1004,14 @@ sampling by `/profile`.
   **0.720x** interpreter macro geometric mean and **0.706x** in the default
   production-tier posture, with all six workloads improving and no gated
   micro regression. See `bench-results.md`.
+- **Disabled-tier probe gate (2026-07-29).** Lantern-only realms still
+  accumulate the tiering contract's `+16` fresh-entry and `+1` loop-backedge
+  warmth, but now check `Realm.jit_enabled` once before entering the separate
+  Ohaimark and Bistromath policy probes. Merged-main profiles put the redundant
+  fresh-entry path at 7.36% of Richards and 7.50% of DeltaBlue samples. A
+  60-pair local A/B measured a **0.969x** interpreter macro geometric mean and
+  **0.911x** on the loop-only `arith_loop` control; the default production-tier
+  macro control stayed flat at **1.003x**. See `bench-results.md`.
 - **Bistromath continuation + hardened-load closure (2026-07-16).**
   Catch/finally PCs now receive compiled reentry stubs in the shared
   bytecode-continuation table; the driver invokes Lantern's real unwinder

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -484,6 +484,20 @@ pub fn tryEnterFreshJitFrame(
     realm: *Realm,
     frames: *std.ArrayListUnmanaged(CallFrame),
 ) RunError!bistromath.EnterOutcome {
+    // Lantern-only realms still heat chunks so an embedder can enable the
+    // tiers later, but they need not enter both tier drivers merely to
+    // rediscover the master switch is off. Keep this increment identical to
+    // Ohaimark's entry observation; when JIT is enabled that driver
+    // remains the single owner so compiled T1 callers continue heating T2.
+    if (!realm.jit_enabled) {
+        const frame = &frames.items[frames.items.len - 1];
+        if (frame.ip == 0) {
+            if (frame.chunk.jit_state) |state| {
+                state.warmth +|= Chunk.JitState.entry_weight;
+            }
+        }
+        return .not_entered;
+    }
     switch (try tryEnterOhaimarkTop(allocator, realm, frames)) {
         .not_entered => return bistromath.tryEnterTop(allocator, realm, frames),
         .resumed => return .not_entered,
@@ -1257,6 +1271,10 @@ inline fn tryBackedgeOsr(
     frames: *std.ArrayListUnmanaged(CallFrame),
     chunk: *const Chunk,
 ) RunError!BackedgeOsr {
+    // `loopSafePoint` already recorded the back-edge warmth above. When the
+    // master tier switch is off, avoid entering both tier-specific policy
+    // probes merely to rediscover it.
+    if (!realm.jit_enabled) return .none;
     if (ohaimark_driver.osrWorth(realm, chunk)) {
         switch (try ohaimark_driver.tryOsrEnterTop(allocator, realm, frames)) {
             .not_entered => {},


### PR DESCRIPTION
## Summary

- short-circuit fresh-frame tier selection when `Realm.jit_enabled` is false
- short-circuit loop-backedge OSR policy probes under the same master switch
- preserve the existing `+16` entry and `+1` backedge warmth accounting so later host re-enablement behaves identically
- record the profile and paired benchmark results

## Why

Merged-main ReleaseFast profiles attributed the redundant fresh-entry path to 7.36% of Richards and 7.50% of DeltaBlue samples. Lantern-only realms entered both Ohaimark and Bistromath policy paths after each fresh call or backedge only to rediscover that the shared tier switch was disabled.

## Performance

A 60-pair interleaved local A/B against exact main `0d4da627` measured a 0.969x interpreter macro geometric mean: Richards 0.949x, DeltaBlue 0.942x, Crypto 0.974x, RayTrace 0.972x, Navier-Stokes 0.994x, and Splay 0.982x. The loop-only `arith_loop` control measured 0.911x over 50 pairs. The matching default-tier macro control stayed flat at 1.003x.

The shared remote box was too noisy (15–29% ratio spread) to resolve the small change, but reported no thresholded regression.

## Validation

- `zig fmt --check src/runtime/lantern/interpreter.zig`
- `zig build test-fast -Dtest-filter='jit warmth'`
- `zig build test-fast` (9/9 steps)
- full non-`--only-failing` `zig build test262 -- --quiet`: 48,653 pass / 1,324 fail (97.35%), exact main pass set
- independent correctness, codegen, test-scope, and benchmark-documentation reviews: no findings
- ReleaseFast disassembly confirms disabled paths branch before all Ohaimark/Bistromath probe calls
