### PR TITLE
Cache interpreter branch metadata

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,63 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — packed branch-metadata lookup, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Interleaved A/B on one pinned CPU: runtime head `83f2ac76` against exact
+merged main `92ed61ef`, 20 pairs in Lantern-only (`--no-jit`) and 12 pairs
+in the default production-tier posture. Merged width-family handlers
+previously called the out-of-line `Op.branchInfo()` classifier for every
+relative branch (twice in the fused equality and relational handlers), then
+loaded `operand_size_by_opcode` separately to advance `ip`.
+
+Head generates a 512-byte packed `u16` table from the authoritative
+branch-family definition at comptime. Large handler tails cross a scalar
+call barrier that returns the packed bits in a register; the compact
+`jmp_if_false` and `loop_inc_lt` tails probe it directly. Every handler
+decodes the metadata once and advances through
+`operand_offset + width.byteSize()`. An exhaustive opcode test pins the
+packed round trip, control-flow classification, signed operand kind and
+offset, canonical width variants, and the invariant that a relative
+displacement is the final operand.
+
+ReleaseFast profiles at `0d4da627` (with the same branch classifier)
+attributed `Op.branchInfo` self time to 2.72% of Richards samples, 1.86% of
+DeltaBlue, and 4.57% of Navier-Stokes. The `ratio` column is the median of
+the 20 per-pair `head / base` ratios, so it can differ from the quotient of
+the two aggregate p50 columns. The interpreter-only geometric mean improved
+to **0.979x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 599.20 | 578.22 | 0.966x | 10.9 |
+| deltablue | 471.13 | 464.31 | 0.977x | 19.7 |
+| crypto | 397.10 | 389.56 | 0.978x | 10.7 |
+| raytrace | 202.73 | 204.56 | 1.013x | 19.4 |
+| navier_stokes | 275.65 | 267.61 | 0.965x | 22.1 |
+| splay | 467.97 | 459.72 | 0.975x | 10.4 |
+
+RayTrace's +0.9% aggregate result sits inside 19.4% run spread; the paired
+median was +1.3%, so the remote box cannot resolve that workload's small
+effect. The noisier 12-pair default-tier confirmation improved to a
+**0.972x** geometric mean:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 607.84 | 561.91 | 0.928x | 12.6 |
+| deltablue | 485.76 | 470.32 | 0.959x | 16.5 |
+| crypto | 398.79 | 395.71 | 1.005x | 14.2 |
+| raytrace | 209.59 | 202.45 | 0.978x | 20.2 |
+| navier_stokes | 280.67 | 273.45 | 0.986x | 16.5 |
+| splay | 471.39 | 450.83 | 0.976x | 12.0 |
+
+A quieter `Darwin 25.6.0 arm64` cross-check measured a **0.981x**
+interpreter geometric mean over 60 pairs and **0.984x** with production
+tiers over 40 pairs; `arith_loop` improved to **0.894x** over 60 pairs.
+The selected inline/call-barrier frontier adds 2,956 bytes to total arm64
+text (0.071%) and 352 bytes to constants. Full ReleaseSafe units pass, and
+the non-`--only-failing` test262 sweep retains the exact merged-main pass
+set: **48,653 pass / 1,324 fail (97.35%)**.
+
 ### 2026-07-29 — disabled-tier probe gate, host `Darwin 25.6.0 arm64`
 
 Interleaved A/B: runtime head `85616796` against exact merged main

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1012,6 +1012,18 @@ sampling by `/profile`.
   60-pair local A/B measured a **0.969x** interpreter macro geometric mean and
   **0.911x** on the loop-only `arith_loop` control; the default production-tier
   macro control stayed flat at **1.003x**. See `bench-results.md`.
+- **Packed branch-metadata lookup (2026-07-30).** Relative-branch canonical
+  opcode, displacement width, and operand offset now live in a 512-byte
+  `u16` table generated at comptime from the existing branch-family
+  definition. Lantern decodes that record once per branch and derives the
+  post-instruction `ip` from the exhaustively tested final-displacement
+  invariant, removing both repeated `branchInfo()` classification and the
+  second operand-size-table load. Larger handler tails retain a scalar call
+  barrier to limit backend tail duplication; only compact `jmp_if_false` and
+  `loop_inc_lt` tails probe directly. A pinned-CPU Linux A/B measured a
+  **0.979x** interpreter macro geometric mean; 60-pair arm64 confirmation
+  measured **0.981x**, with `arith_loop` at **0.894x**. See
+  `bench-results.md`.
 - **Bistromath continuation + hardened-load closure (2026-07-16).**
   Catch/finally PCs now receive compiled reentry stubs in the shared
   bytecode-continuation table; the driver invokes Lantern's real unwinder

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -1720,7 +1720,30 @@ pub const Op = enum(u8) {
     /// Branch encoding metadata shared by relaxation, decoding, CFG analysis,
     /// disassembly, and Bistromath. `null` means ordinary fallthrough or a
     /// non-relative control transfer.
-    pub fn branchInfo(op: Op) ?BranchInfo {
+    pub noinline fn branchInfo(op: Op) ?BranchInfo {
+        return unpackBranchInfo(branch_info_bits_by_opcode[@intFromEnum(op)]);
+    }
+
+    /// Lantern's merged branch-family handlers call this for every executed
+    /// relative branch. Keep the table load out of line so the backend does
+    /// not duplicate the large dispatch tails, but return the packed metadata
+    /// in a scalar register instead of using the optional-struct ABI.
+    pub inline fn branchInfoForDispatch(op: Op) BranchInfo {
+        return unpackBranchInfo(branchInfoBits(op)).?;
+    }
+
+    /// The compact truthiness and fused counter-loop handlers are hot enough
+    /// to justify a direct table probe. Larger branch tails retain the scalar
+    /// call barrier to avoid backend tail duplication.
+    pub inline fn branchInfoInlineForDispatch(op: Op) BranchInfo {
+        return unpackBranchInfo(branch_info_bits_by_opcode[@intFromEnum(op)]).?;
+    }
+
+    noinline fn branchInfoBits(op: Op) u16 {
+        return branch_info_bits_by_opcode[@intFromEnum(op)];
+    }
+
+    fn branchInfoUncached(op: Op) ?BranchInfo {
         return switch (op) {
             .jmp8 => .{ .canonical = .jmp, .width = .i8, .operand_offset = 0 },
             .jmp => .{ .canonical = .jmp, .width = .i16, .operand_offset = 0 },
@@ -1836,6 +1859,38 @@ const operand_size_by_opcode: [256]u8 = blk: {
     break :blk sizes;
 };
 
+/// Branch decoding is hot in Lantern's merged width-family handlers. Keep the
+/// explicit family definition above as the one source for canonical opcode,
+/// width, and displacement position, then cache its result by wire opcode.
+const branch_info_bits_by_opcode: [256]u16 = blk: {
+    @setEvalBranchQuota(10_000);
+    var infos: [256]u16 = @splat(0);
+    for (@typeInfo(Op).@"enum".field_names) |field_name| {
+        const op: Op = @field(Op, field_name);
+        if (op.branchInfoUncached()) |info| {
+            infos[@intFromEnum(op)] = packBranchInfo(info);
+        }
+    }
+    break :blk infos;
+};
+
+fn packBranchInfo(info: BranchInfo) u16 {
+    const width: u3 = @intCast(@intFromEnum(info.width));
+    const operand_offset: u5 = @intCast(info.operand_offset);
+    return @as(u16, @intFromEnum(info.canonical)) |
+        (@as(u16, width) << 8) |
+        (@as(u16, operand_offset) << 11);
+}
+
+fn unpackBranchInfo(bits: u16) ?BranchInfo {
+    if (bits == 0) return null;
+    return .{
+        .canonical = @enumFromInt(@as(u8, @truncate(bits))),
+        .width = @enumFromInt(@as(u8, @truncate((bits >> 8) & 0b111))),
+        .operand_offset = @as(u8, @truncate(bits >> 11)),
+    };
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -1874,6 +1929,56 @@ test "Op: instruction specs classify representative execution contracts" {
     try testing.expectEqual(BaselineStrategy.inline_, Op.add.spec().baseline);
     try testing.expectEqual(BaselineStrategy.inline_, Op.inc_reg.spec().baseline);
     try testing.expectEqual(BaselineStrategy.unsupported, Op.await_.spec().baseline);
+}
+
+test "Op: branch metadata agrees with the instruction schema" {
+    @setEvalBranchQuota(10_000);
+    inline for (@typeInfo(Op).@"enum".field_names) |field_name| {
+        const op: Op = @field(Op, field_name);
+        const info = op.branchInfo();
+        try testing.expectEqual(op.branchInfoUncached(), info);
+        const is_relative_branch = switch (op.spec().control_flow) {
+            .jump, .conditional_jump => true,
+            else => false,
+        };
+        try testing.expectEqual(is_relative_branch, info != null);
+
+        if (info) |branch| {
+            try testing.expectEqual(branch, op.branchInfoForDispatch());
+            try testing.expectEqual(branch, op.branchInfoInlineForDispatch());
+            const expected_kind: OperandKind = switch (branch.width) {
+                .i8 => .i8,
+                .i16 => .i16,
+                .i32 => .i32,
+            };
+            var offset: u8 = 0;
+            var found_displacement = false;
+            for (op.spec().layout.operands()) |kind| {
+                if (offset == branch.operand_offset) {
+                    try testing.expectEqual(expected_kind, kind);
+                    found_displacement = true;
+                }
+                offset += kind.byteSize();
+            }
+            try testing.expect(found_displacement);
+            try testing.expectEqual(
+                op.operandSize(),
+                branch.operand_offset + branch.width.byteSize(),
+            );
+
+            const canonical_info = branch.canonical.branchInfo().?;
+            try testing.expectEqual(branch.canonical, canonical_info.canonical);
+            try testing.expectEqual(BranchWidth.i16, canonical_info.width);
+            try testing.expectEqual(op, branch.canonical.branchVariant(branch.width));
+
+            inline for ([_]BranchWidth{ .i8, .i16, .i32 }) |width| {
+                const variant = branch.canonical.branchVariant(width);
+                const variant_info = variant.branchInfo().?;
+                try testing.expectEqual(branch.canonical, variant_info.canonical);
+                try testing.expectEqual(width, variant_info.width);
+            }
+        }
+    }
 }
 
 test "Op: operandSize agrees with the documented encoding" {

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -2320,8 +2320,9 @@ pub fn runFrames(
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
         .jmp, .jmp8, .jmp32 => |op_tag| {
-            const off = op_tag.branchInfo().?.displacement(code, ip - 1);
-            ip += op_tag.operandSize();
+            const branch = op_tag.branchInfoForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             ip = applyOffset(ip, off);
             if (off < 0) {
                 if (try loopSafePoint(realm, f, ip, acc)) |r| return r;
@@ -2350,8 +2351,9 @@ pub fn runFrames(
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
         .jmp_if_false, .jmp_if_false8, .jmp_if_false32 => |op_tag| {
-            const off = op_tag.branchInfo().?.displacement(code, ip - 1);
-            ip += op_tag.operandSize();
+            const branch = op_tag.branchInfoInlineForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             // Inline ToBoolean fast path (§7.1.2): a comparison result
             // (bool) or an int condition skips the call; strings / objects
             // / doubles / BigInt fall through to `toBoolean`.
@@ -2386,8 +2388,9 @@ pub fn runFrames(
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
         .jmp_if_true, .jmp_if_true8, .jmp_if_true32 => |op_tag| {
-            const off = op_tag.branchInfo().?.displacement(code, ip - 1);
-            ip += op_tag.operandSize();
+            const branch = op_tag.branchInfoForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             const truthy = if (acc.isBool()) acc.asBool() else if (acc.isInt32()) (acc.asInt32() != 0) else toBoolean(acc);
             if (truthy) {
                 ip = applyOffset(ip, off);
@@ -2431,10 +2434,11 @@ pub fn runFrames(
             // OSR back-edge machinery is unneeded; a backward offset
             // (defensive) still takes a GC safepoint.
             const r = code[ip];
-            const off = t.branchInfo().?.displacement(code, ip - 1);
-            ip += t.operandSize();
+            const branch = t.branchInfoForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             const equal = strictEq(registers[r], acc);
-            const take = if (t.branchInfo().?.canonical == .jmp_if_strict_eq) equal else !equal;
+            const take = if (branch.canonical == .jmp_if_strict_eq) equal else !equal;
             if (take) {
                 ip = applyOffset(ip, off);
                 if (off < 0) {
@@ -2469,9 +2473,10 @@ pub fn runFrames(
             // without duplicating the body. Forward-only by emit; a
             // defensive backward offset still takes a GC safepoint.
             const r = code[ip];
-            const off = t.branchInfo().?.displacement(code, ip - 1);
-            ip += t.operandSize();
-            const canonical = t.branchInfo().?.canonical;
+            const branch = t.branchInfoForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
+            const canonical = branch.canonical;
             var take: bool = undefined;
             const fast: ?Value = switch (canonical) {
                 .jmp_if_not_lt => intCompare(.lt, registers[r], acc),
@@ -2522,8 +2527,9 @@ pub fn runFrames(
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
         .jmp_if_nullish, .jmp_if_nullish8, .jmp_if_nullish32 => |op_tag| {
-            const off = op_tag.branchInfo().?.displacement(code, ip - 1);
-            ip += op_tag.operandSize();
+            const branch = op_tag.branchInfoForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             if (acc.isNull() or acc.isUndefined()) {
                 ip = applyOffset(ip, off);
                 if (off < 0) {
@@ -2556,8 +2562,9 @@ pub fn runFrames(
         .loop_inc_lt, .loop_inc_lt8, .loop_inc_lt32 => |op_tag| {
             const r_counter = code[ip];
             const r_bound = code[ip + 1];
-            const off = op_tag.branchInfo().?.displacement(code, ip - 1);
-            ip += op_tag.operandSize();
+            const branch = op_tag.branchInfoInlineForDispatch();
+            const off = branch.displacement(code, ip - 1);
+            ip += branch.operand_offset + branch.width.byteSize();
             // Hot path: both operands int32, counter+1 doesn't
             // overflow. The branch back to the body is the
             // overwhelmingly common case (5M iterations of an


### PR DESCRIPTION
## What changed

- generate a 512-byte packed branch-metadata table at comptime from the existing branch-family definition
- return hot metadata through a scalar `u16` ABI, while directly probing only the compact `jmp_if_false` and `loop_inc_lt` handlers
- reuse one decoded record for displacement, canonical opcode, and instruction advance
- add an exhaustive invariant test covering every opcode, branch width, operand offset, and packed round trip
- record the local and pinned-CPU remote A/B results

## Why

Lantern resolved relative-branch metadata through an out-of-line switch on every executed branch, called it twice in two fused handlers, and then separately loaded the operand-size table. Profiles attributed `Op.branchInfo` self time to 2.72% of Richards, 1.86% of DeltaBlue, and 4.57% of Navier-Stokes samples.

## Impact

- pinned-core Linux interpreter macros: **0.979x** paired-ratio geometric mean (20 pairs)
- local arm64 interpreter macros: **0.981x** geometric mean (60 pairs)
- local production-tier macros: **0.984x** geometric mean (40 pairs)
- local `arith_loop`: **0.894x** (60 pairs)
- code size: +2,956 bytes total arm64 text (+0.071%) and +352 bytes constants

The bytecode wire format and dispatch count are unchanged.

## Validation

- `zig fmt --check src/bytecode/op.zig src/runtime/lantern/interpreter.zig`
- `zig build test-fast` — 9/9 steps, 3,342 pass / 260 skip
- focused branch, truthiness, and `loop_inc_lt` unit filters
- full non-`--only-failing` test262 — **48,653 pass / 1,324 fail (97.35%)**, exact merged-main pass set
- ReleaseFast arm64 codegen audit: five scalar calls plus two direct probes replace nine struct-return calls; all seven hot paths avoid `operand_size_by_opcode`
- exact-commit Linux x86_64 build and pinned-core A/B against `92ed61ef`
