### PR TITLE
Direct-thread this-property loads in Lantern

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,62 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — direct-threaded `this` property loads, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Interleaved A/B on one pinned CPU: runtime head `7e93321a` against exact
+merged main `808ff428`, 30 pairs in Lantern-only (`--no-jit`). Instrumented
+traces identified `LdaThis -> LdaProperty8` as the largest remaining adjacent
+opcode opportunity: **18,364,389** transitions across the six macros, or
+**5.058%** of 363,054,517 logical instructions. The pair covers **71.214%**
+of all `LdaThis` executions. All 502 static sites use the compact property
+encoding, and their matching source spans identify direct
+`this.IdentifierName` expressions.
+
+Head leaves the bytecode and both JIT tiers unchanged. After the existing
+§9.1.1.3.4 GetThisBinding / derived-constructor TDZ gate succeeds,
+`LdaThis` recognizes a following compact property load, advances past that
+opcode byte, records it as a logical instruction, and directly continues into
+the existing property handler. This removes one indirect dispatch while
+retaining the single OrdinaryGet implementation for own/prototype ICs,
+getters, Proxy traps, primitives, and module namespaces. Opt-in telemetry now
+reports the bypass separately as `direct-transfers`; all opcode, pair, and
+trigram counts remain logical and therefore compare exactly with the
+pre-change traces.
+
+The forward-order interpreter geometric mean improved to **0.981x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 590.51 | 578.88 | 0.979x | 16.5 |
+| deltablue | 468.26 | 449.37 | 0.968x | 23.5 |
+| crypto | 385.64 | 379.05 | 0.979x | 19.5 |
+| raytrace | 198.29 | 195.71 | 0.993x | 15.8 |
+| navier_stokes | 267.30 | 258.13 | 0.967x | 21.0 |
+| splay | 447.29 | 455.15 | 1.002x | 28.2 |
+
+Because the runner always launches runtime head before baseline within a pair,
+the binaries were then swapped while retaining the same harness and pinned
+CPU. Inverting those median ratios produced a **0.979x** candidate/main
+geometric mean; the per-fixture candidate ratios were **0.998x, 0.967x,
+0.958x, 0.989x, 0.968x, and 0.997x**, respectively. Thus the x86 signal
+survives launch order despite the shared host's 15–30% process-level spread.
+
+A quieter `Darwin 25.6.0 arm64` confirmation measured **0.9952x** forward
+and **0.9957x** with the binaries swapped, also over 30 pairs. The matching
+production-tier macro control was **0.9937x**. Targeted 50-pair controls
+priced the new branch directly: `method_call`, whose `LdaThis` sites match
+about half the time, improved to **0.982x**; zero-match
+`class_instantiate` moved to **1.021x**, below the 5% stable-regression gate.
+`prop_access` (no `LdaThis`) stayed at **1.000x**.
+
+Validation covered the full ReleaseSafe unit suite; focused test262 buckets
+held their exact pass sets (`property-accessors` 21/0,
+`statements/class` 4347/6, `expressions/class` 4043/6, and optional chaining
+40/0). The property-accessor bucket also remained 21/0 under forced
+Bistromath and forced Ohaimark. Inline tests pin IC fill/hit, a prototype
+getter re-entering through forced GC, Proxy receiver identity, the direct
+derived-constructor TDZ, and a lexical arrow's shared `super_called_cell`.
+
 ### 2026-07-30 — packed branch-metadata lookup, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Interleaved A/B on one pinned CPU: runtime head `83f2ac76` against exact

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -254,11 +254,12 @@ feedback boundary are in [ohaimark.md](ohaimark.md).
 
 An opt-in instrumentation build (`-Dbytecode-stats=true`, then
 `cynic run --bytecode-stats`) reports static encoding widths and
-dynamic opcode/pair/trigram frequencies. Normal builds compile the
-dispatch counters out. The CFG/liveness pass uses the same schema,
-models dense-switch N-way edges, and fails closed when an implicit
-register effect is not understood. Accumulator forwarding is a
-post-finalization rewrite: `Star r; Ldar r` loses the load only when
+dynamic logical opcode/pair/trigram frequencies plus the number of
+logical opcodes entered by a direct-threaded transfer. Normal builds
+compile the dispatch counters out. The CFG/liveness pass uses the same
+schema, models dense-switch N-way edges, and fails closed when an
+implicit register effect is not understood. Accumulator forwarding is
+a post-finalization rewrite: `Star r; Ldar r` loses the load only when
 the finalized leader set proves no branch, switch, or handler can enter
 between the pair.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -933,9 +933,9 @@ built-ins, accessor / legacy-global aliases), and the
   peephole / IC work.
 - Opt-in bytecode telemetry: build with `-Dbytecode-stats=true`,
   then run `cynic run --bytecode-stats <file>`. Reports static
-  nested-chunk bytes / operand-width fit plus dynamic opcode,
-  pair, and trigram frequencies; normal builds compile the
-  counters out.
+  nested-chunk bytes / operand-width fit plus dynamic logical
+  opcode, pair, and trigram frequencies and direct-transfer
+  counts; normal builds compile the counters out.
 - `zig build test262 -- ...` parser and runtime modes; harness
   loads `harness/sta.js` + `assert.js` automatically; per-file
   outcome on `--verbose`; failure list on `--list-failures=N`;
@@ -1024,6 +1024,17 @@ sampling by `/profile`.
   **0.979x** interpreter macro geometric mean; 60-pair arm64 confirmation
   measured **0.981x**, with `arith_loop` at **0.894x**. See
   `bench-results.md`.
+- **Direct-threaded `this` property loads (2026-07-30).** Instrumented
+  compute-six traces found **18,364,389** `LdaThis -> LdaProperty8`
+  transitions, **5.058%** of all logical instructions and **71.214%** of
+  `LdaThis` executions. After the existing derived-constructor TDZ gate,
+  Lantern now recognizes the compact successor and continues directly into
+  the unchanged property-load handler, bypassing one indirect dispatch.
+  Bytecode, logical telemetry, and both JIT tiers remain unchanged; opt-in
+  stats expose the bypass count separately. Thirty-pair forward/reverse A/Bs
+  measured **0.981x / 0.979x** interpreter macro geometric means on pinned
+  x86_64 and **0.9952x / 0.9957x** on arm64. The arm64 production-tier
+  control measured **0.9937x**. See `bench-results.md`.
 - **Bistromath continuation + hardened-load closure (2026-07-16).**
   Catch/finally PCs now receive compiled reentry stubs in the shared
   bytecode-continuation table; the driver invokes Lantern's real unwinder

--- a/docs/handbook/compiler-engineering.md
+++ b/docs/handbook/compiler-engineering.md
@@ -136,12 +136,13 @@ The wire format is compact but scalable:
 
 `-Dbytecode-stats=true` compiles instrumentation; `cynic run
 --bytecode-stats file.js` then reports nested-chunk instruction/byte
-counts, operand-width fit, and dynamic opcode/pair/trigram frequencies.
-The flag is compile-time so normal binaries contain no counter access.
-Use those traces plus paired wall-time measurements before retaining a
-new super-instruction. A 2026-07 loose-equality branch fusion removed
-4.34% of Richards dispatches but made paired non-JIT wall time 3.8%
-slower, so it was reverted.
+counts, operand-width fit, dynamic logical opcode/pair/trigram
+frequencies, and direct-threaded transfer counts. The flag is
+compile-time so normal binaries contain no counter access. Use those
+traces plus paired wall-time measurements before retaining a new
+super-instruction. A 2026-07 loose-equality branch fusion removed 4.34%
+of Richards dispatches but made paired non-JIT wall time 3.8% slower,
+so it was reverted.
 
 The finalized-bytecode liveness pass builds a CFG, including every
 `switch_smi` successor, and fails closed on unknown register effects.

--- a/src/bytecode/stats.zig
+++ b/src/bytecode/stats.zig
@@ -93,6 +93,7 @@ pub const DynamicStats = struct {
     pairs: [pair_capacity]SequenceCell = @splat(.{}),
     trigrams: [trigram_capacity]SequenceCell = @splat(.{}),
     instructions: u64 = 0,
+    direct_transfers: u64 = 0,
     dropped_pairs: u64 = 0,
     dropped_trigrams: u64 = 0,
     previous: [2]Op = undefined,
@@ -117,6 +118,11 @@ pub const DynamicStats = struct {
             self.previous[1] = op;
             self.previous_len = 2;
         }
+    }
+
+    pub fn observeDirect(self: *DynamicStats, op: Op) void {
+        self.observe(op);
+        self.direct_transfers +|= 1;
     }
 
     pub fn resetSequence(self: *DynamicStats) void {
@@ -159,6 +165,12 @@ pub fn activate(stats: *DynamicStats) Activation {
 pub noinline fn observeActive(op: Op) void {
     if (comptime enabled) {
         if (active_dynamic) |stats| stats.observe(op);
+    }
+}
+
+pub noinline fn observeDirectActive(op: Op) void {
+    if (comptime enabled) {
+        if (active_dynamic) |stats| stats.observeDirect(op);
     }
 }
 
@@ -282,8 +294,9 @@ pub fn formatReport(
         if (count != 0) try op_rows.append(allocator, .{ .op = op, .count = count });
     }
     std.mem.sort(OpcodeRow, op_rows.items, {}, rowLessThan(OpcodeRow));
-    try out.print(allocator, "dynamic: instructions={d} dropped-pairs={d} dropped-trigrams={d}\n", .{
+    try out.print(allocator, "dynamic: instructions={d} direct-transfers={d} dropped-pairs={d} dropped-trigrams={d}\n", .{
         dynamic.instructions,
+        dynamic.direct_transfers,
         dynamic.dropped_pairs,
         dynamic.dropped_trigrams,
     });
@@ -369,6 +382,18 @@ test "bytecode stats: dynamic scan records opcode pairs and trigrams" {
     try testing.expectEqual(@as(u64, 1), stats.trigramCount(.add, .star, .add));
 }
 
+test "bytecode stats: direct-threaded transfer preserves logical sequence telemetry" {
+    var stats: DynamicStats = .{};
+    stats.observe(.lda_this);
+    stats.observeDirect(.lda_property8);
+
+    try testing.expectEqual(@as(u64, 2), stats.instructions);
+    try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.lda_this));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.lda_property8));
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_this, .lda_property8));
+}
+
 test "bytecode stats: report exposes encoding and dispatch hot spots" {
     var static: StaticStats = .{};
     static.instructions = 3;
@@ -378,10 +403,12 @@ test "bytecode stats: report exposes encoding and dispatch hot spots" {
     dynamic.observe(.add);
     dynamic.observe(.star);
     dynamic.observe(.add);
+    dynamic.direct_transfers = 1;
 
     const report = try formatReport(testing.allocator, &static, &dynamic, 8);
     defer testing.allocator.free(report);
     try testing.expect(std.mem.indexOf(u8, report, "static: chunks=0 instructions=3 bytes=7") != null);
+    try testing.expect(std.mem.indexOf(u8, report, "direct-transfers=1") != null);
     try testing.expect(std.mem.indexOf(u8, report, "Add 2") != null);
     try testing.expect(std.mem.indexOf(u8, report, "Add -> Star 1") != null);
     try testing.expect(std.mem.indexOf(u8, report, "Add -> Star -> Add 1") != null);

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -5314,6 +5314,20 @@ pub fn runFrames(
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
             acc = f.this_value;
+
+            // `this.name` is the hottest adjacent opcode pair in the
+            // macro corpus. Thread its compact form directly into the
+            // existing §13.3.4.1 property-load arm: the bytecode and
+            // both JIT tiers still see the ordinary two-op sequence,
+            // while T0 avoids one indirect dispatch. Keep the
+            // GetThisBinding gate above this transfer so a derived
+            // constructor's uninitialised `this` still throws before
+            // any property lookup.
+            if (ip < code.len and code[ip] == @intFromEnum(Op.lda_property8)) {
+                ip += 1;
+                if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.lda_property8);
+                continue :dispatch .lda_property8;
+            }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
 

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -5317,12 +5317,12 @@ pub fn runFrames(
 
             // `this.name` is the hottest adjacent opcode pair in the
             // macro corpus. Thread its compact form directly into the
-            // existing §13.3.4.1 property-load arm: the bytecode and
-            // both JIT tiers still see the ordinary two-op sequence,
-            // while T0 avoids one indirect dispatch. Keep the
-            // GetThisBinding gate above this transfer so a derived
-            // constructor's uninitialised `this` still throws before
-            // any property lookup.
+            // existing §13.3.4 EvaluatePropertyAccessWithIdentifierKey
+            // load arm: the bytecode and both JIT tiers still see the
+            // ordinary two-op sequence, while T0 avoids one indirect
+            // dispatch. Keep the GetThisBinding gate above this
+            // transfer so a derived constructor's uninitialised `this`
+            // still throws before any property lookup.
             if (ip < code.len and code[ip] == @intFromEnum(Op.lda_property8)) {
                 ip += 1;
                 if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.lda_property8);

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1607,6 +1607,85 @@ test "lda_property_reg: string-primitive receiver via register form" {
     try expectScriptInt("(function(s){ return s.length; })('hello');", 5);
 }
 
+// §9.1.1.3.4 GetThisBinding followed by §13.3.4.1 property access.
+// The interpreter direct-threads this common pair into the existing
+// lda_property8 handler; these tests pin the observable boundary.
+test "lda_this property direct threading: own data property" {
+    try expectScriptIntWithBuiltins(
+        "function read(){ return this.x; } let o = { x: 20 }; let first = read.call(o); o.x = 22; first + read.call(o);",
+        42,
+    );
+}
+
+test "lda_this property direct threading: getter keeps receiver rooted across reentry" {
+    try expectScriptStringWithBuiltins(
+        \\let calls = 0;
+        \\function read(){ return this.x; }
+        \\class Box {
+        \\  constructor(){ this.y = 41; }
+        \\  get x(){
+        \\    calls = calls + 1;
+        \\    __collectGarbage();
+        \\    return this.y + 1;
+        \\  }
+        \\}
+        \\let o = new Box();
+        \\"" + read.call(o) + "/" + calls;
+    , "42/1");
+}
+
+test "lda_this property direct threading: Proxy get receives the original receiver" {
+    try expectScriptStringWithBuiltins(
+        \\let calls = 0;
+        \\function read(){ return this.x; }
+        \\let target = { x: 7 };
+        \\let proxy = new Proxy(target, {
+        \\  get(t, key, receiver) {
+        \\    if (key === "x") calls = calls + 1;
+        \\    return receiver === proxy ? t[key] : -1;
+        \\  }
+        \\});
+        \\"" + read.call(proxy) + "/" + calls;
+    , "7/1");
+}
+
+test "lda_this property direct threading: derived-constructor TDZ stays catchable" {
+    try expectScriptStringWithBuiltins(
+        \\let caught = "none";
+        \\class Base {}
+        \\class Derived extends Base {
+        \\  constructor() {
+        \\    try { this.x; }
+        \\    catch (error) { caught = error.constructor.name; }
+        \\    super();
+        \\  }
+        \\}
+        \\new Derived();
+        \\caught;
+    , "ReferenceError");
+}
+
+test "lda_this property direct threading: lexical this follows super-called cell" {
+    try expectScriptStringWithBuiltins(
+        \\let before = "none";
+        \\let after = -1;
+        \\class Base {
+        \\  constructor(){ this.x = 42; }
+        \\}
+        \\class Derived extends Base {
+        \\  constructor() {
+        \\    const read = () => this.x;
+        \\    try { read(); }
+        \\    catch (error) { before = error.constructor.name; }
+        \\    super();
+        \\    after = read();
+        \\  }
+        \\}
+        \\new Derived();
+        \\before + ":" + after;
+    , "ReferenceError:42");
+}
+
 // Redundant-register-move elimination: the access/store reads the
 // receiver straight from its register (no Ldar;Star copy) and the
 // script completion drops the redundant reload. Values must be

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -13,6 +13,7 @@ const RunResult = lantern.RunResult;
 const run = lantern.run;
 const evaluateScript = lantern.evaluateScript;
 const op_mod = @import("../../bytecode/op.zig");
+const bytecode_stats = @import("../../bytecode/stats.zig");
 const chunk_mod = @import("../../bytecode/chunk.zig");
 const disasm = @import("../../bytecode/disasm.zig");
 const Span = @import("../../source.zig").Span;
@@ -1611,6 +1612,24 @@ test "lda_property_reg: string-primitive receiver via register form" {
 // EvaluatePropertyAccessWithIdentifierKey. The interpreter
 // direct-threads this common pair into the existing lda_property8
 // handler; these tests pin the observable boundary.
+test "lda_this property direct threading: instrumented run records transfer" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        "let o = { x: 42, read: function(){ return this.x; } }; o.read();",
+        42,
+    );
+    try testing.expect(stats.direct_transfers > 0);
+    try testing.expectEqual(
+        stats.direct_transfers,
+        stats.pairCount(.lda_this, .lda_property8),
+    );
+}
+
 test "lda_this property direct threading: own data property" {
     try expectScriptIntWithBuiltins(
         "function read(){ return this.x; } let o = { x: 20 }; let first = read.call(o); o.x = 22; first + read.call(o);",

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1607,9 +1607,10 @@ test "lda_property_reg: string-primitive receiver via register form" {
     try expectScriptInt("(function(s){ return s.length; })('hello');", 5);
 }
 
-// §9.1.1.3.4 GetThisBinding followed by §13.3.4.1 property access.
-// The interpreter direct-threads this common pair into the existing
-// lda_property8 handler; these tests pin the observable boundary.
+// §9.1.1.3.4 GetThisBinding followed by §13.3.4
+// EvaluatePropertyAccessWithIdentifierKey. The interpreter
+// direct-threads this common pair into the existing lda_property8
+// handler; these tests pin the observable boundary.
 test "lda_this property direct threading: own data property" {
     try expectScriptIntWithBuiltins(
         "function read(){ return this.x; } let o = { x: 20 }; let first = read.call(o); o.x = 22; first + read.call(o);",


### PR DESCRIPTION
## Summary

- direct-thread the existing `LdaThis -> LdaProperty8` sequence into the shared property-load handler
- preserve logical opcode/pair/trigram telemetry and report bypassed indirect dispatches separately
- cover IC fill/hit, prototype getter GC re-entry, Proxy receiver identity, and derived/lexical `this` TDZ behavior

## Performance

- 18,364,389 transfers across the compute-six macros (5.058% of logical instructions)
- pinned x86_64 30-pair macro geomean: 0.981x forward / 0.979x reverse
- arm64 30-pair macro geomean: 0.9952x forward / 0.9957x reverse
- arm64 production-tier control: 0.9937x

## Validation

- `zig build test-fast --summary all` (9/9)
- test262 property-accessors: 21/0, including forced Bistromath and Ohaimark
- test262 statements/class: 4347/6 (unchanged)
- test262 expressions/class: 4043/6 (unchanged)
- test262 optional-chaining: 40/0