### PR TITLE
Avoid impossible property probes in Lantern

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,77 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — impossible property-probe gates, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Pinned-CPU `perf` profiles of exact merged main `b40518d8` found two pure
+classification paths doing work before the runtime knew that their result
+could matter:
+
+- `typedArrayChainSetDecision` accounted for **4.26%** of Navier-Stokes and
+  **2.46%** of Crypto callgraph cycles. It ran
+  §7.1.21 CanonicalNumericIndexString parsing and NumberToString round-tripping
+  before discovering that the receiver's prototype chain contained no
+  TypedArray.
+- `tryFillSyntheticPrototypeLoadIC` accounted for about **2.5%** of Richards
+  and **9.8%** of DeltaBlue inclusive cycles. The macro posture is
+  `--unhardened`, so the override-mistake installation pass creates zero
+  `SyntheticAccessor` cells, but every eligible named-load miss still probed
+  shapes, property tables, accessors, and the prototype chain.
+
+Head first rejects property keys whose leading byte cannot begin any canonical
+numeric spelling (decimal digit, `-`, `I`, or `N`), then walks to the first
+TypedArray ancestor, and only then performs the full canonical parse. The
+prototype walk and parser are both pure, so their order is unobservable and the
+first TypedArray still owns the §10.4.5.6 decision. Separately, the synthetic
+load-IC fill helper returns immediately when the realm's authoritative
+`synth_accessor_cells` table is empty. Snapshot restore repopulates that table
+before execution, making its emptiness a stronger capability test than the
+mutable hardened-posture flag. The gate deliberately remains inside the
+outlined helper: call-site forms removed its prologue too, but destabilized the
+giant dispatch handlers enough to regress unrelated macros.
+
+On `Darwin 25.6.0 arm64`, 40 interleaved Lantern-only pairs improved the macro
+geometric mean to **0.9702x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 237.36 | 231.16 | 0.976x | 6.3 |
+| deltablue | 183.06 | 166.94 | 0.911x | 3.9 |
+| crypto | 131.68 | 128.86 | 0.983x | 6.1 |
+| raytrace | 76.14 | 75.87 | 1.000x | 4.5 |
+| navier_stokes | 99.49 | 95.13 | 0.957x | 14.9 |
+| splay | 160.44 | 159.88 | 0.997x | 4.5 |
+
+Swapping the binaries produced a **0.9666x** candidate/main geometric mean;
+the inverted per-fixture ratios were **0.974x, 0.910x, 0.981x, 0.994x,
+0.955x, and 0.988x**.
+
+The clean x86_64 rebuild used a distinct install prefix and SHA-256, then ran
+30 pairs with the driver and both children pinned to CPU 3. Forward order
+improved the geometric mean to **0.9688x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 579.16 | 572.64 | 0.981x | 22.8 |
+| deltablue | 448.12 | 419.89 | 0.940x | 24.4 |
+| crypto | 382.54 | 367.47 | 0.959x | 41.1 |
+| raytrace | 204.15 | 200.15 | 0.981x | 25.6 |
+| navier_stokes | 261.76 | 247.02 | 0.954x | 24.5 |
+| splay | 469.12 | 462.61 | 0.999x | 18.9 |
+
+The swapped run confirmed a **0.9760x** candidate/main geometric mean; its
+inverted ratios were **0.984x, 0.946x, 0.961x, 0.992x, 0.970x, and 1.004x**.
+Thus Splay is order-sensitive but statistically flat, while the five resolved
+signals all improve.
+
+Validation covered the complete ReleaseSafe unit suite (**3,350 pass / 261
+expected skip**), the focused TypedArray Integer-Indexed `[[Set]]` test262
+bucket (**53 / 53**), and the hardened-JavaScript suite (**36 / 36**).
+Regression tests pin canonical sentinels (`-0`, `NaN`, and both infinities),
+same- versus different-receiver coercion, valid and noncanonical inherited
+writes, plus ordinary data and fused-method prototype loads in a realm with no
+synthetic cells.
+
 ### 2026-07-30 — direct-threaded `this` property loads, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Interleaved A/B on one pinned CPU: runtime head `7e93321a` against exact

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1035,6 +1035,16 @@ sampling by `/profile`.
   measured **0.981x / 0.979x** interpreter macro geometric means on pinned
   x86_64 and **0.9952x / 0.9957x** on arm64. The arm64 production-tier
   control measured **0.9937x**. See `bench-results.md`.
+- **Impossible property-probe gates (2026-07-30).** Strict property writes now
+  reject keys that cannot begin a §7.1.21 canonical numeric spelling, walk to
+  the first TypedArray ancestor, and only then pay for numeric parsing and
+  NumberToString round-tripping. The synthetic prototype-load IC fill helper
+  likewise returns immediately when the realm owns zero
+  `SyntheticAccessor` cells — the exact state of `--unhardened` realms and a
+  snapshot-stable capability test. Pinned forward/reverse interpreter A/Bs
+  measured **0.9702x / 0.9666x** macro geometric means on arm64 and
+  **0.9688x / 0.9760x** on x86_64, with no resolved workload regression. See
+  `bench-results.md`.
 - **Bistromath continuation + hardened-load closure (2026-07-16).**
   Catch/finally PCs now receive compiled reentry stubs in the shared
   bytecode-continuation table; the driver invokes Lantern's real unwinder

--- a/docs/inline-caches.md
+++ b/docs/inline-caches.md
@@ -245,8 +245,13 @@ All on `origin/main`:
 - **`LoadICCell` has data and synthetic-accessor modes.** Own data uses
   `(shape, slot)`. Prototype data adds prototype identity/shape/revision and
   loads `proto.slots[slot]`. Frozen synthetic accessors use the same guards
-  but load `synthetic_value`. Global loads reuse the data layout and store
-  `GlobalBindings.decl_revision` in the revision field.
+  but load `synthetic_value`. The outlined synthetic-fill helper first checks
+  the realm's authoritative `synth_accessor_cells` table: an unhardened realm
+  installs no cells, while snapshot restore repopulates the table before
+  execution, so an empty table proves that the shape/accessor/prototype probe
+  cannot succeed. Keeping this gate inside the outlined helper preserves the
+  layout of Lantern's large named-load handlers. Global loads reuse the data
+  layout and store `GlobalBindings.decl_revision` in the revision field.
 - **`StoreICCell` owns write-only state.** Same-shape writes cache the slot.
   Transition writes additionally cache
   `pre_shape`/`post_shape`, prototype guards, and `proto_struct_epoch` before

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -12875,11 +12875,26 @@ const TAChainSetResult = struct {
 };
 
 fn typedArrayChainSetDecision(obj: *JSObject, key: []const u8, recv: Value) TAChainSetResult {
-    const ta_mod = @import("../builtins/typed_array.zig");
-    const num = ta_mod.canonicalNumericIndex(key) orelse return .{ .decision = .not_applicable };
+    // §7.1.21 CanonicalNumericIndexString — every accepted spelling
+    // starts with a decimal digit, "-", "I" (Infinity), or "N" (NaN).
+    // Reject ordinary named properties before either walking the
+    // prototype chain or entering the full parse/NumberToString
+    // round trip.
+    if (key.len == 0) return .{ .decision = .not_applicable };
+    switch (key[0]) {
+        '0'...'9', '-', 'I', 'N' => {},
+        else => return .{ .decision = .not_applicable },
+    }
+
     var cursor: ?*JSObject = obj;
     while (cursor) |c| : (cursor = c.prototype) {
         if (c.getTypedView()) |tv| {
+            // The prototype walk is side-effect-free. Defer the
+            // comparatively expensive canonical-number parse until a
+            // TypedArray is actually present; ordinary object/Array
+            // chains cannot observe or use its result.
+            const ta_mod = @import("../builtins/typed_array.zig");
+            const num = ta_mod.canonicalNumericIndex(key) orelse return .{ .decision = .not_applicable };
             const recv_obj = heap_mod.valueAsPlainObject(recv);
             const same_receiver = (recv_obj == c);
             if (same_receiver) {

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -12825,6 +12825,10 @@ fn tryFillSyntheticPrototypeLoadIC(
     key: []const u8,
     cell: *LoadICCell,
 ) ?Value {
+    // `--unhardened` skips override-mistake installation, while snapshot
+    // restore repopulates this table before execution. Its emptiness is
+    // therefore the exact proof that no SyntheticAccessor can exist.
+    if (realm.synth_accessor_cells.items.len == 0) return null;
     const recv_shape = recv.shape orelse return null;
     if (recv_shape.lookup(key) != null or recv.ownDataContains(key) or recv.hasAccessor(key)) return null;
     if (chainHasProxy(recv)) return null;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -12322,6 +12322,23 @@ test "proto-load IC: built-in Array.prototype.push hot loop" {
     , 100);
 }
 
+test "synthetic proto-load IC gate: unhardened ordinary data and method loads" {
+    try expectScriptIntUnhardened(
+        \\const proto = {
+        \\  value: 3,
+        \\  method: function () { return this.own; },
+        \\};
+        \\const obj = Object.create(proto);
+        \\obj.own = 4;
+        \\let total = 0;
+        \\for (let i = 0; i < 50; i++) {
+        \\  total += obj.value;
+        \\  total += obj.method();
+        \\}
+        \\total;
+    , 350);
+}
+
 test "proto-load IC: class instance method on hot loop" {
     // Class methods land on `C.prototype.m`, so every `c.m()` is a
     // prototype-load. Without the proto IC, the slow path walks

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -597,6 +597,35 @@ test "double-key: typed array double index" {
     try expectScriptIntWithBuiltins("var ta = new Float64Array(3); ta[1.0] = 7; ta[2.0] = 9; ta[1] + ta[2];", 16);
 }
 
+test "TypedArray chain Set preserves canonical sentinel and receiver semantics" {
+    try expectScriptIntWithBuiltins(
+        \\var ta = new Float64Array(1);
+        \\var child = Object.create(ta);
+        \\var coerces = 0;
+        \\var value = { valueOf: function () { coerces++; return 7; } };
+        \\ta.NaN = value;
+        \\ta.Infinity = value;
+        \\ta["-Infinity"] = value;
+        \\ta["-0"] = value;
+        \\var sameReceiverCoerces = coerces === 4;
+        \\child.NaN = value;
+        \\child.Infinity = value;
+        \\child["-Infinity"] = value;
+        \\child["-0"] = value;
+        \\var inheritedInvalidSkips = coerces === 4 &&
+        \\    !Object.hasOwn(child, "NaN") &&
+        \\    !Object.hasOwn(child, "Infinity") &&
+        \\    !Object.hasOwn(child, "-Infinity") &&
+        \\    !Object.hasOwn(child, "-0");
+        \\child["0"] = 11;
+        \\child["1.0"] = 12;
+        \\var ordinaryWrites = Object.hasOwn(child, "0") &&
+        \\    child["0"] === 11 && ta[0] === 0 &&
+        \\    Object.hasOwn(child, "1.0") && child["1.0"] === 12;
+        \\sameReceiverCoerces && inheritedInvalidSkips && ordinaryWrites ? 1 : 0;
+    , 1);
+}
+
 test "interpreter: relational operators" {
     try expectBool("1 < 2;", true);
     try expectBool("2 < 1;", false);


### PR DESCRIPTION
## Summary

- reject keys that cannot begin a CanonicalNumericIndexString, then defer the full numeric parse until the first TypedArray ancestor is known to exist
- skip synthetic prototype-load IC probing when the realm owns zero SyntheticAccessor cells
- add focused receiver/coercion and unhardened prototype-load regressions
- record the bidirectional arm64 and x86_64 benchmark results

## Performance

Lantern-only six-macro geometric means against merged main `b40518d8`:

- arm64, 40 pairs: `0.9702x` forward / `0.9666x` with binaries swapped
- x86_64 pinned CPU, 30 pairs: `0.9688x` forward / `0.9760x` with binaries swapped

The forward arm64 run improved Richards 2.4%, DeltaBlue 8.9%, Crypto 1.7%, Navier-Stokes 4.3%, and Splay 0.3%; Raytrace was flat. The forward x86_64 run improved five macros by 1.9–6.0%, with Splay flat.

## Validation

- `zig build test-fast --summary all` — 3,350 pass / 261 expected skip
- `zig build test262 -- --filter=built-ins/TypedArrayConstructors/internals/Set/ --quiet --threads=1` — 53 / 53 pass
- `zig build test-ses` — 36 / 36 pass
- independent diff review — no correctness, spec, GC/snapshot, test, or style findings
