### PR TITLE
Fuse consumed postfix register updates

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,100 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — consumed postfix register updates, host `Darwin 25.6.0 arm64`
+
+Bytecode telemetry isolated Crypto's consumed postfix register update as the
+largest remaining exact sequence. An instrumentation-only build from
+`b40518d8` (the compiler and macro sources are identical to merged baseline
+`da6e1ce7`; the intervening changes are property-handler-only) recorded
+118,864,402 logical instructions. It executed
+`ToNumeric → Star old → Inc` 2,983,837 times; the following `Star0` and
+`Star3` register writebacks identified the two dominant register sites.
+Re-running the same telemetry on the final bytecode measured
+**2,977,794 `PostIncReg`** and **226 `PostDecReg`** executions.
+Collapsing each six-op
+`Ldar; ToNumeric; Star old; Inc; Star binding; Ldar old` sequence to one
+dispatch removes **14,890,100 instructions**, or **12.53%** of Crypto's old
+dynamic total (118,864,402 → 103,974,302). Static Crypto bytecode also shrinks
+by 130 instructions and 187 bytes.
+
+The compiler now emits `PostIncReg` / `PostDecReg` for a consumed postfix
+update of a non-TDZ register binding. The opcode performs GetValue,
+ToNumeric, and the type-matched Number/BigInt bump; it commits only the
+bumped value to the binding while leaving the coerced **old** numeric value
+in the accumulator. Throwing coercion therefore leaves the binding
+unchanged. For object-to-BigInt coercion, the old BigInt is published through
+the frame accumulator before allocating the bumped BigInt, so it remains a
+GC root without temporarily mutating the binding.
+
+This follows existing interpreter prior art rather than inventing a novel
+result convention: V8's bytecode generator has an explicit TODO for proper
+`PostInc` / `PostDec` bytecodes after its current ToNumeric-and-save lowering
+([source](https://github.com/v8/v8/blob/0616192af6309f2121f27ad735485db602c11fa6/src/interpreter/bytecode-generator.cc#L7514-L7735)),
+while QuickJS already carries dedicated `post_inc` / `post_dec` opcodes
+([source](https://github.com/bellard/quickjs/blob/04be246001599f5995fa2f2d8c91a0f198d3f34c/quickjs-opcode.h#L218-L227)).
+The new forms remain an intentional JIT tier boundary: the old sequence was
+already refused by Bistromath and Ohaimark at `ToNumeric` / `Inc`, so
+coverage is unchanged.
+
+On 40 interleaved Lantern-only pairs, exact candidate/base SHA-256 binaries
+improved the six-macro geometric mean to **0.9960x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 242.07 | 241.74 | 1.005x | 44.0 |
+| deltablue | 175.39 | 173.52 | 0.993x | 15.2 |
+| crypto | 134.15 | 128.92 | 0.962x | 41.9 |
+| raytrace | 78.31 | 78.41 | 1.003x | 24.9 |
+| navier_stokes | 98.17 | 99.66 | 1.013x | 92.7 |
+| splay | 167.90 | 168.52 | 1.001x | 42.6 |
+
+Swapping the binaries confirmed a **0.9951x** candidate/main geometric mean.
+The inverted candidate ratios were **1.004x, 0.993x, 0.958x, 0.997x,
+1.025x, and 0.995x**, respectively. Thus the targeted Crypto gain is
+3.8–4.2%; the dispatch-table layout costs Navier 1.3–2.5%, but the suite
+geomean remains positive in both launch orders.
+
+The clean x86_64 gate used new `/tmp` checkouts at exact base `da6e1ce7`,
+verified the local source patch before building distinct ReleaseFast binaries,
+and pinned the driver plus inherited children to CPU 3. Thirty forward pairs
+improved the geometric mean to **0.9770x**:
+
+| bench | base_ms | head_ms | ratio | spread% |
+|---|---:|---:|---:|---:|
+| richards | 583.14 | 577.30 | 0.980x | 20.1 |
+| deltablue | 426.45 | 423.68 | 0.989x | 13.6 |
+| crypto | 392.69 | 363.39 | 0.920x | 25.2 |
+| raytrace | 211.40 | 202.76 | 0.957x | 23.6 |
+| navier_stokes | 249.72 | 253.70 | 1.020x | 24.5 |
+| splay | 481.84 | 484.07 | 0.999x | 16.7 |
+
+The swapped 30-pair run produced a **0.9802x** candidate/main geometric mean;
+its inverted candidate ratios were **0.984x, 0.981x, 0.918x, 0.964x,
+1.034x, and 1.003x**. Combining both launch orders gives **0.9786x**
+order-neutral: Crypto improves 8.1%, Navier gives back 2.7%, and the whole
+macro set improves 2.1%. Base/candidate binary SHA-256 prefixes were
+`416a20e3` / `59a1f528`; all 360 timed invocations succeeded.
+
+Two smaller encodings were measured and rejected. A single
+`PostUpdateReg r, delta` opcode made Crypto **1.021x** slower than the
+two-opcode form (the swapped comparison was **1.027x** slower after
+inversion) and regressed the six-macro baseline geomean to **1.0041x**.
+A `PostIncReg`-only hybrid avoided the nearly cold decrement opcode but
+landed at **0.9990x / 0.9955x** in 40-pair forward/swapped runs, for a
+combined **0.9972x** versus the symmetric pair's **0.9955x**. The extra
+opcode therefore earns its dispatch-table slot empirically, not merely for
+symmetry.
+
+Validation covered the complete ReleaseSafe unit suite (**3,332 pass / 261
+expected skip**), dedicated Int32/double/`-0`/NaN/infinity/overflow,
+string/Boolean/null/undefined, BigInt, object-coercion, Symbol, thrown
+coercion, failure-atomicity, and alternating-GC tests, plus the focused
+postfix increment/decrement test262 buckets in interpreter, forced-T1, and
+ReleaseSafe `gc_threshold=1` postures. The non-cached full sweep retained the
+merged pass set (**48,653 pass / 1,324 fail**, plus ShadowRealm **63 / 1**).
+Independent correctness and performance reviews found no actionable issue.
+
 ### 2026-07-30 — impossible property-probe gates, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Pinned-CPU `perf` profiles of exact merged main `b40518d8` found two pure

--- a/src/bytecode/chunk.zig
+++ b/src/bytecode/chunk.zig
@@ -1324,11 +1324,12 @@ pub const Builder = struct {
         }
     }
 
-    /// Emit a §13.4 register-binding update. Both variants share the
-    /// `[op][r:u8]` encoding; keeping the pair in one emitter prevents the
+    /// Emit a §13.4 register-binding update. All variants share the
+    /// `[op][r:u8]` encoding; keeping them in one emitter prevents the
     /// compiler and disassembler operand layouts from drifting apart.
     pub fn emitUpdateReg(self: *Builder, op: Op, span: Span, r: u8) !void {
-        std.debug.assert(op == .inc_reg or op == .dec_reg);
+        std.debug.assert(op == .inc_reg or op == .dec_reg or
+            op == .post_inc_reg or op == .post_dec_reg);
         try self.emitOp(op, span);
         try self.emitU8(r);
     }

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -1742,8 +1742,13 @@ pub const Compiler = struct {
         // the one-dispatch update while every old-value / TDZ-sensitive path
         // retains the existing explicit sequence.
         const need_old = !u.prefix and result_used;
-        if (binding.is_register and !binding.register_tdz and !need_old) {
-            const op: Op = if (u.op == .increment) .inc_reg else .dec_reg;
+        if (binding.is_register and !binding.register_tdz) {
+            const op: Op = if (need_old)
+                if (u.op == .increment) .post_inc_reg else .post_dec_reg
+            else if (u.op == .increment)
+                .inc_reg
+            else
+                .dec_reg;
             try self.builder.emitUpdateReg(op, u.span, binding.register);
             return;
         }
@@ -15770,18 +15775,32 @@ test "compiler: discarded non-TDZ register updates fuse into IncReg and DecReg" 
     try testing.expect(std.mem.indexOf(u8, dec_body, "ToNumeric") == null);
 }
 
-test "compiler: consumed postfix and TDZ register updates stay unfused" {
-    // A consumed postfix must reload the OLD numeric value, which IncReg does
-    // not preserve. A body-local `let` still carries register_tdz while its
-    // own initializer is running, so that site must retain the existing
-    // load/check/store sequence rather than hiding the ReferenceError
-    // ordering in the fused opcode.
-    const postfix_dump = try dumpExpr("(function(x){ return x++; })");
-    defer testing.allocator.free(postfix_dump);
-    const postfix_body = t0Of(postfix_dump);
-    try testing.expect(std.mem.indexOf(u8, postfix_body, "IncReg") == null);
-    try testing.expect(std.mem.indexOf(u8, postfix_body, "ToNumeric") != null);
+test "compiler: consumed postfix register updates fuse without an old-value temp" {
+    // §13.4 consumed postfix updates return the ToNumeric-coerced OLD value
+    // while committing the bumped value to the binding. A dedicated register
+    // form can perform both results without the six-dispatch
+    // Ldar/ToNumeric/Star/Inc-or-Dec/Star/Ldar sequence.
+    const inc_dump = try dumpExpr("(function(x){ return x++; })");
+    defer testing.allocator.free(inc_dump);
+    const inc_body = t0Of(inc_dump);
+    try testing.expect(std.mem.indexOf(u8, inc_body, "PostIncReg r0") != null);
+    try testing.expect(std.mem.indexOf(u8, inc_body, "ToNumeric") == null);
+    try testing.expect(std.mem.indexOf(u8, inc_body, "Star1") == null);
+    try testing.expect(std.mem.indexOf(u8, inc_body, "Ldar1") == null);
 
+    const dec_dump = try dumpExpr("(function(x){ return x--; })");
+    defer testing.allocator.free(dec_dump);
+    const dec_body = t0Of(dec_dump);
+    try testing.expect(std.mem.indexOf(u8, dec_body, "PostDecReg r0") != null);
+    try testing.expect(std.mem.indexOf(u8, dec_body, "ToNumeric") == null);
+    try testing.expect(std.mem.indexOf(u8, dec_body, "Star1") == null);
+    try testing.expect(std.mem.indexOf(u8, dec_body, "Ldar1") == null);
+}
+
+test "compiler: TDZ register updates stay unfused" {
+    // A body-local `let` still carries register_tdz while its own initializer
+    // is running, so that site must retain the existing load/check/store
+    // sequence rather than hiding the ReferenceError ordering in a fused op.
     const tdz_dump = try dumpExpr("(function(){ let x=++x; return x; })");
     defer testing.allocator.free(tdz_dump);
     const tdz_body = t0Of(tdz_dump);

--- a/src/bytecode/disasm.zig
+++ b/src/bytecode/disasm.zig
@@ -54,7 +54,7 @@ pub fn dump(allocator: std.mem.Allocator, chunk: *const Chunk) ![]u8 {
 
         // Format the operand, if any.
         switch (op) {
-            .ldar, .star, .inc_reg, .dec_reg => {
+            .ldar, .star, .inc_reg, .dec_reg, .post_inc_reg, .post_dec_reg => {
                 const r = chunk.code[i + 1];
                 try buf.print(allocator, " r{d}", .{r});
             },
@@ -472,6 +472,8 @@ test "disasm: register updates print their operand and preserve alignment" {
     const r1 = try b.reserveRegister();
     try b.emitUpdateReg(.inc_reg, span, r1);
     try b.emitUpdateReg(.dec_reg, span, r1);
+    try b.emitUpdateReg(.post_inc_reg, span, r1);
+    try b.emitUpdateReg(.post_dec_reg, span, r1);
     try b.emitOp(.return_, span);
     var chunk = try b.finish();
     defer chunk.deinit(testing.allocator);
@@ -482,7 +484,9 @@ test "disasm: register updates print their operand and preserve alignment" {
         \\(chunk regs=2 consts=0
         \\  0000 IncReg r1 [3..8]
         \\  0002 DecReg r1 [3..8]
-        \\  0004 Return [3..8]
+        \\  0004 PostIncReg r1 [3..8]
+        \\  0006 PostDecReg r1 [3..8]
+        \\  0008 Return [3..8]
         \\)
     , out);
 }

--- a/src/bytecode/liveness.zig
+++ b/src/bytecode/liveness.zig
@@ -209,7 +209,11 @@ pub fn effectOf(op: Op, code: []const u8, i: usize) Effect {
         // ── Read + write the same register ──
         // `[op][r:u8]` — read the old binding value and replace it with the
         // ToNumeric-bumped result.
-        .inc_reg, .dec_reg => .{ .reads = .{ code[i + 1], 0, 0 }, .n_reads = 1, .write = code[i + 1] },
+        .inc_reg, .dec_reg, .post_inc_reg, .post_dec_reg => .{
+            .reads = .{ code[i + 1], 0, 0 },
+            .n_reads = 1,
+            .write = code[i + 1],
+        },
         // `[op][r_counter:u8][r_bound:u8][off:i8|i16|i32]` — counter is read
         // (test + increment) and written (the bumped value).
         .loop_inc_lt, .loop_inc_lt8, .loop_inc_lt32 => .{ .reads = .{ code[i + 1], code[i + 2], 0 }, .n_reads = 2, .write = code[i + 1] },
@@ -754,6 +758,18 @@ test "liveness: effectOf classifies register operands" {
     try testing.expectEqual(@as(u8, 1), e_dec_reg.n_reads);
     try testing.expectEqual(@as(u8, 7), e_dec_reg.reads[0]);
     try testing.expectEqual(@as(?u8, 7), e_dec_reg.write);
+
+    var post_inc_reg = [_]u8{ byteOf(.post_inc_reg), 8 };
+    const e_post_inc_reg = effectOf(.post_inc_reg, &post_inc_reg, 0);
+    try testing.expectEqual(@as(u8, 1), e_post_inc_reg.n_reads);
+    try testing.expectEqual(@as(u8, 8), e_post_inc_reg.reads[0]);
+    try testing.expectEqual(@as(?u8, 8), e_post_inc_reg.write);
+
+    var post_dec_reg = [_]u8{ byteOf(.post_dec_reg), 9 };
+    const e_post_dec_reg = effectOf(.post_dec_reg, &post_dec_reg, 0);
+    try testing.expectEqual(@as(u8, 1), e_post_dec_reg.n_reads);
+    try testing.expectEqual(@as(u8, 9), e_post_dec_reg.reads[0]);
+    try testing.expectEqual(@as(?u8, 9), e_post_dec_reg.write);
 
     // call reads the [callee .. callee+argc] window.
     var call = [_]u8{ byteOf(.call), 4, 2, 0, 0 }; // r_callee=4, argc=2

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -1482,6 +1482,12 @@ pub const Op = enum(u8) {
     /// Targets live in `Chunk.switch_tables[table]`; every execution jumps to
     /// either one case body or the default target (no fallthrough edge).
     switch_smi,
+    /// `[op] [r:u8]` — consumed postfix register increment. Stores the
+    /// ToNumeric-bumped value in `registers[r]` while leaving the coerced OLD
+    /// numeric value in the accumulator. §13.4.
+    post_inc_reg,
+    /// `[op] [r:u8]` — decrement counterpart of `post_inc_reg`.
+    post_dec_reg,
 
     /// Authoritative instruction metadata. Adding an opcode requires one
     /// exhaustive entry here; consumers derive names, sizes and tier/control
@@ -1533,6 +1539,8 @@ pub const Op = enum(u8) {
             .dec => instruction("Dec", .none),
             .inc_reg => baselineInstruction("IncReg", .reg),
             .dec_reg => baselineInstruction("DecReg", .reg),
+            .post_inc_reg => instruction("PostIncReg", .reg),
+            .post_dec_reg => instruction("PostDecReg", .reg),
             .lda_smi8 => baselineInstruction("LdaSmi8", .i8),
             .lda_smi16 => baselineInstruction("LdaSmi16", .i16),
             .add_smi8 => baselineInstruction("AddSmi8", .reg_i8),
@@ -1928,6 +1936,7 @@ test "Op: instruction specs classify representative execution contracts" {
 
     try testing.expectEqual(BaselineStrategy.inline_, Op.add.spec().baseline);
     try testing.expectEqual(BaselineStrategy.inline_, Op.inc_reg.spec().baseline);
+    try testing.expectEqual(BaselineStrategy.unsupported, Op.post_inc_reg.spec().baseline);
     try testing.expectEqual(BaselineStrategy.unsupported, Op.await_.spec().baseline);
 }
 
@@ -2056,4 +2065,6 @@ test "Op: operandSize agrees with the documented encoding" {
     // Bistromath's unsupported-op scan to stay aligned on the next opcode.
     try testing.expectEqual(@as(u8, 1), Op.operandSize(.inc_reg));
     try testing.expectEqual(@as(u8, 1), Op.operandSize(.dec_reg));
+    try testing.expectEqual(@as(u8, 1), Op.operandSize(.post_inc_reg));
+    try testing.expectEqual(@as(u8, 1), Op.operandSize(.post_dec_reg));
 }

--- a/src/bytecode/regalloc.zig
+++ b/src/bytecode/regalloc.zig
@@ -174,6 +174,8 @@ fn definitelyOverwritesAccumulator(op: Op) bool {
         .lda_new_target,
         .inc_reg,
         .dec_reg,
+        .post_inc_reg,
+        .post_dec_reg,
         => true,
         else => false,
     };
@@ -910,9 +912,10 @@ test "regalloc(copy): production gate skips sparse chunks" {
 }
 
 test "regalloc(copy): register-update overwrites permit Mov" {
-    // IncReg / DecReg read and update their encoded register, then leave the
-    // bumped value in the accumulator; neither consumes the incoming value.
-    inline for (.{ Op.inc_reg, Op.dec_reg }) |update| {
+    // Register-update forms read and update their encoded register, then
+    // overwrite the accumulator with either the bumped or old numeric value;
+    // none consumes the incoming accumulator value.
+    inline for (.{ Op.inc_reg, Op.dec_reg, Op.post_inc_reg, Op.post_dec_reg }) |update| {
         var code = [_]u8{
             @intFromEnum(Op.ldar_1),
             @intFromEnum(Op.star),

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -2073,23 +2073,27 @@ pub fn runFrames(
             }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
-        .inc_reg, .dec_reg => |op_tag| {
+        .inc_reg, .dec_reg, .post_inc_reg, .post_dec_reg => |op_tag| {
             const r = code[ip];
             ip += 1;
+            const is_postfix = op_tag == .post_inc_reg or op_tag == .post_dec_reg;
+            const is_increment = op_tag == .inc_reg or op_tag == .post_inc_reg;
 
             // §13.4 GetValue → ToNumeric → type-matched unit →
             // PutValue. The source register remains the authoritative root
             // while object coercion re-enters JS; commit it only after both
             // conversion and bump succeed, so a throw leaves the binding
-            // unchanged. `acc = old` mirrors the explicit leading Ldar.
+            // unchanged. Postfix forms leave the coerced OLD numeric value
+            // in acc; prefix/discarded forms leave the bumped value.
             acc = registers[r];
             if (acc.isInt32()) {
-                const bumped = if (op_tag == .inc_reg)
+                const old = acc;
+                const bumped = if (is_increment)
                     intArith(.add, acc, Value.fromInt32(1)).?
                 else
                     intArith(.sub, acc, Value.fromInt32(1)).?;
-                acc = bumped;
                 registers[r] = bumped;
+                acc = if (is_postfix) old else bumped;
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
 
@@ -2105,10 +2109,18 @@ pub fn runFrames(
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
 
-            const delta: i32 = if (op_tag == .inc_reg) 1 else -1;
+            // A consumed postfix must keep a freshly coerced heap BigInt alive
+            // while incOrDec allocates the bumped BigInt. The raw source
+            // register may hold only the coercion object, so publish the old
+            // numeric value through the frame accumulator before that
+            // allocation. The binding register itself remains unchanged until
+            // the bump succeeds.
+            const old = acc;
+            if (is_postfix) f.accumulator = old;
+            const delta: i32 = if (is_increment) 1 else -1;
             if (try arith.incOrDec(realm, acc, delta)) |bumped| {
-                acc = bumped;
                 registers[r] = bumped;
+                acc = if (is_postfix) old else bumped;
             } else {
                 const ex = realm.pending_exception orelse try makeTypeError(realm, "Update failed");
                 realm.pending_exception = null;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -3215,6 +3215,98 @@ test "register update: object ToNumeric runs once and a throw does not store" {
     , "41:2:true:true");
 }
 
+test "consumed postfix register update returns coerced old and stores bumped new" {
+    // Function parameters are non-TDZ register bindings, so every update
+    // below executes PostIncReg/PostDecReg. §13.4 returns the
+    // ToNumeric-coerced OLD value—not the raw string/Boolean/null/undefined—
+    // while storing the type-matched bumped value back into the parameter.
+    try expectScriptStringWithBuiltins(
+        \\function inspect(x) {
+        \\  const old = x++;
+        \\  return typeof old + "," + String(old) + "," +
+        \\         typeof x + "," + String(x);
+        \\}
+        \\function inspectDown(x) {
+        \\  const old = x--;
+        \\  return typeof old + "," + String(old) + "," +
+        \\         typeof x + "," + String(x);
+        \\}
+        \\[
+        \\  inspect(41),
+        \\  inspect(1.5),
+        \\  inspect("41"),
+        \\  inspect(true),
+        \\  inspect(null),
+        \\  inspect(undefined),
+        \\  inspectDown(41)
+        \\].join("|");
+    , "number,41,number,42|number,1.5,number,2.5|number,41,number,42|number,1,number,2|number,0,number,1|number,NaN,number,NaN|number,41,number,40");
+}
+
+test "consumed postfix register update preserves Number edge values" {
+    // The old result must retain -0/NaN/Infinity identity while the binding
+    // receives the Number increment. Int32 overflow widens instead of
+    // trapping or wrapping.
+    try expectScriptStringWithBuiltins(
+        \\function edge(x) {
+        \\  const old = x++;
+        \\  return [old, x];
+        \\}
+        \\const z = edge(-0);
+        \\const n = edge(NaN);
+        \\const i = edge(Infinity);
+        \\const o = edge(2147483647);
+        \\[
+        \\  Object.is(z[0], -0), Object.is(z[1], 1),
+        \\  Number.isNaN(n[0]), Number.isNaN(n[1]),
+        \\  i[0] === Infinity, i[1] === Infinity,
+        \\  o[0] === 2147483647, o[1] === 2147483648
+        \\].join(":");
+    , "true:true:true:true:true:true:true:true");
+}
+
+test "consumed postfix register update preserves BigInt type and coerces once" {
+    // §13.4 selects a BigInt 1n unit after ToNumeric. Both increment and
+    // decrement return the old BigInt, and object coercion must happen once.
+    try expectScriptStringWithBuiltins(
+        \\let calls = 0;
+        \\function inc(x) {
+        \\  const old = x++;
+        \\  return typeof old + ":" + old + ":" + typeof x + ":" + x;
+        \\}
+        \\function dec(x) {
+        \\  const old = x--;
+        \\  return typeof old + ":" + old + ":" + typeof x + ":" + x;
+        \\}
+        \\const a = inc(5n);
+        \\const b = dec(-5n);
+        \\const c = inc({ valueOf() { calls++; return 9n; } });
+        \\a + "|" + b + "|" + c + ":" + calls;
+    , "bigint:5:bigint:6|bigint:-5:bigint:-6|bigint:9:bigint:10:1");
+}
+
+test "consumed postfix register update leaves binding unchanged on coercion throw" {
+    // A failed ToNumeric must not commit either the coerced or bumped value.
+    // Symbol failure exercises the engine-generated TypeError path as well as
+    // propagation of an exception thrown from user coercion.
+    try expectScriptStringWithBuiltins(
+        \\const marker = {};
+        \\let calls = 0;
+        \\function fail(x) {
+        \\  const original = x;
+        \\  try { return x++; }
+        \\  catch (e) { return (e === marker) + ":" + (x === original); }
+        \\}
+        \\function failSymbol(x) {
+        \\  const original = x;
+        \\  try { return x++; }
+        \\  catch (e) { return (e instanceof TypeError) + ":" + (x === original); }
+        \\}
+        \\const value = { valueOf() { calls++; throw marker; } };
+        \\fail(value) + ":" + calls + ":" + failSymbol(Symbol());
+    , "true:true:1:true:true");
+}
+
 test "register update: self-update in a let initializer preserves TDZ ReferenceError" {
     // `x` is register-promoted but still contains Hole while its own
     // initializer runs. This site must stay on the explicit load/check path;
@@ -7840,6 +7932,28 @@ test "GC: register update ToNumeric survives allocating JS re-entry" {
         \\});
         \\value + ":" + calls;
     , "41:1");
+}
+
+test "GC: consumed postfix register update roots coerced old BigInt across bump" {
+    // The source register roots the coercion object, not the fresh BigInt
+    // returned by valueOf. PostIncReg must publish that OLD BigInt as a frame
+    // root while allocating the bumped BigInt, then return old and store new.
+    try expectScriptStringUnderAlternatingGcPressure(
+        \\let calls = 0;
+        \\function post(x) {
+        \\  const old = x++;
+        \\  return typeof old + ":" + old + ":" + typeof x + ":" + x;
+        \\}
+        \\const result = post({
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    calls++;
+        \\    return BigInt("123456789012345678901234567890");
+        \\  }
+        \\});
+        \\result + ":" + calls;
+    , "bigint:123456789012345678901234567890:bigint:123456789012345678901234567891:1");
 }
 
 test "GC: generator wrapper iteration survives gc_threshold=1" {


### PR DESCRIPTION
## Summary

- add `PostIncReg` / `PostDecReg` tail opcodes for consumed postfix updates of non-TDZ register bindings
- preserve ECMAScript coercion semantics, failure atomicity, and the old-value GC root across BigInt allocation
- wire the opcodes through schema generation, disassembly, liveness, register allocation, compiler lowering, and focused runtime/GC coverage
- record reproducible arm64 and x86_64 benchmark results in `bench-results.md`

## Performance

Crypto executes 2,978,020 fused postfix operations per run. The new lowering reduces its logical instruction count from 118,864,402 to 103,974,302: 14,890,100 fewer dispatches (12.53%).

Paired macro runs against exact base `da6e1ce7`:

- arm64, 40 pairs per order: order-neutral geometric mean `0.9955`; Crypto about `0.960`
- x86_64, 30 pairs per order with driver and children pinned: order-neutral geometric mean `0.9786`; Crypto about `0.919`

Navier-Stokes regressed about 2.7% on x86_64, while the suite improved 2.14% overall. A one-opcode encoding and a `PostIncReg`-only hybrid were benchmarked and rejected because both performed worse than this two-opcode design.

## Validation

- `zig build test-fast --summary all`: 3,332 passed, 261 skipped
- focused compiler, opcode, disassembly, liveness, register-allocation, runtime, error-atomicity, and allocation-pressure GC tests
- postfix test262 pass sets unchanged in interpreter, Bistromath (`--jit`), and ReleaseSafe with `--gc-threshold=1`
- full non-cached test262 sweep unchanged: 48,653 passed / 1,324 failed; ShadowRealm 63 / 1
- two independent code/performance reviews found no actionable issues