### PR TITLE
Root binary coercion intermediates across GC re-entry

### DIFF
--- a/docs/test262-upstream-gaps.md
+++ b/docs/test262-upstream-gaps.md
@@ -1493,3 +1493,48 @@ the corpus under the relevant section's directory before adding.
   distinguish `0 * -0` and related Double cases, but none covers a negative
   nonzero integer multiplied by int32 `+0`, the representation boundary that
   exposed this bug.
+
+### Binary coercion intermediates were unrooted across right-operand re-entry
+
+- **Fixed in:** `9d5964a9` (2026-07-30)
+- **Spec:** §13.15.4 ApplyStringOrNumericBinaryOperator; §13.12
+  bitwise operators; §7.2.13 IsLessThan. Each evaluates/coerces the
+  left operand before the right, and the resulting primitive must
+  remain live until the abstract operation completes.
+- **Reproducer:**
+
+  ```js
+  var lhs = { valueOf() {
+    return BigInt("12345678901234567890"); // fresh heap primitive
+  } };
+  var rhs = { valueOf() {
+    var junk = [];
+    for (var i = 0; i < 300; i++) junk.push({ i: i });
+    return 2n; // allocation + user-code re-entry can trigger GC
+  } };
+  lhs * rhs;  // must be 24691357802469135780n
+  lhs + rhs;  // must be 12345678901234567892n
+  lhs & rhs;  // must be 2n
+  lhs > rhs;  // must be true
+  ```
+
+- **Before fix:** the freshly coerced left BigInt lived only in a
+  Zig local while the right operand's `valueOf` re-entered JavaScript.
+  Under allocation-pressure GC it was swept before the operator used
+  it: arithmetic, addition, and bitwise paths dereferenced poisoned
+  BigInt limbs and aborted the host; relational comparison silently
+  returned `false`.
+- **After fix:** binary coercion paths open a `HandleScope` only when
+  an operand is a JavaScript object that can re-enter, root both raw
+  operands, and pin each primitive result before the next coercion.
+  Primitive Number / BigInt / String hot paths remain allocation-free.
+  Standalone and fused relational handlers share the same rooting
+  contract.
+- **Suggested fixture shape:** positive · runtime fixtures under
+  `language/expressions/{multiplication,addition,bitwise-and,
+  greater-than}/` asserting left-to-right `valueOf` order and the
+  values above. A normal test262 run cannot require a collection, so
+  the host-abort portion needs an engine GC-stress mode (or repeated
+  allocation large enough to cross a collector threshold); the
+  portable fixtures still protect the observable coercion order and
+  result types.

--- a/src/runtime/lantern/arith.zig
+++ b/src/runtime/lantern/arith.zig
@@ -258,14 +258,37 @@ pub fn toNumericPrimitive(realm: *Realm, value: Value) RunError!?Value {
     return value;
 }
 
+/// Root both bytecode-produced operands before a binary abstract operation
+/// starts coercing either one. The first coercion can return a fresh heap
+/// primitive, and the second can re-enter JavaScript and trigger GC. Primitive
+/// pairs cannot re-enter, so keep those hot paths allocation-free.
+pub fn openBinaryCoercionScope(realm: *Realm, lhs: Value, rhs: Value) error{OutOfMemory}!?*heap_mod.HandleScope {
+    if (!heap_mod.isJSObject(lhs) and !heap_mod.isJSObject(rhs)) return null;
+    const scope = realm.heap.openScope() catch return error.OutOfMemory;
+    errdefer scope.close();
+    scope.push(lhs) catch return error.OutOfMemory;
+    scope.push(rhs) catch return error.OutOfMemory;
+    return scope;
+}
+
 pub fn numericBinary(realm: *Realm, comptime op: NumericOp, lhs: Value, rhs: Value) RunError!?Value {
+    // Either coercion may re-enter JavaScript and trigger GC. Keep both raw
+    // operands rooted for the whole abstract operation, then pin each fresh
+    // primitive result before starting the next coercion. In particular, a
+    // lhs `valueOf` can return a newly allocated BigInt that otherwise has no
+    // root while rhs `valueOf` runs.
+    const scope = try openBinaryCoercionScope(realm, lhs, rhs);
+    defer if (scope) |s| s.close();
+
     // §13.15.4 ApplyStringOrNumericBinaryOperator step 1 — call
     // ToPrimitive on each operand (hint "number") before any
     // numeric coercion. Spec sequencing matters: lhs first, then
     // rhs. A throw inside `valueOf` / `toString` / Symbol.toPrim
     // bubbles via `pending_exception`.
     const l = (try toNumericPrimitive(realm, lhs)) orelse return null;
+    if (scope) |s| s.push(l) catch return error.OutOfMemory;
     const r = (try toNumericPrimitive(realm, rhs)) orelse return null;
+    if (scope) |s| s.push(r) catch return error.OutOfMemory;
 
     // §6.1.6.2 — once both sides are primitives, BigInt + Number
     // is an unconditional TypeError. Pure-BigInt math went through
@@ -383,11 +406,16 @@ fn bigintShiftTooLarge(shift: BigIntValue) bool {
 }
 
 pub fn bitwiseBinary(realm: *Realm, comptime op: BitwiseOp, lhs: Value, rhs: Value) RunError!?Value {
+    const scope = try openBinaryCoercionScope(realm, lhs, rhs);
+    defer if (scope) |s| s.close();
+
     // §13.12 BitwiseOp — spec evaluates lhs then rhs, then
     // ToNumeric on each. We already have the bytecode-evaluated
     // values in registers, so we only owe the ToNumeric step.
     const l = (try toNumericPrimitive(realm, lhs)) orelse return null;
+    if (scope) |s| s.push(l) catch return error.OutOfMemory;
     const r = (try toNumericPrimitive(realm, rhs)) orelse return null;
+    if (scope) |s| s.push(r) catch return error.OutOfMemory;
 
     // BigInt mixing — bitwise ops on BigInt are not yet supported
     // by the interpreter, but mixed Number+BigInt must still throw
@@ -586,19 +614,24 @@ pub fn addValues(realm: *Realm, lhs: Value, rhs: Value) RunError!?Value {
     // code surface via `pending_exception`.
     var l = lhs;
     var r = rhs;
+    const scope = try openBinaryCoercionScope(realm, lhs, rhs);
+    defer if (scope) |s| s.close();
+
     // §13.15.4 step 1: `lprim = ? ToPrimitive(lval)`. Only fires when
     // a side is a JS Object — Symbol / BigInt primitives short-
     // circuit the no-op call (and a recursive `toPrimitive` on them
     // would still return the value as-is per §7.1.1 step 2).
-    if (heap_mod.isJSObject(l) or heap_mod.isJSObject(r)) {
+    if (scope) |s| {
         l = intrinsics_mod.toPrimitive(realm, l, .default) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.NativeThrew => return null,
         };
+        s.push(l) catch return error.OutOfMemory;
         r = intrinsics_mod.toPrimitive(realm, r, .default) catch |err| switch (err) {
             error.OutOfMemory => return error.OutOfMemory,
             error.NativeThrew => return null,
         };
+        s.push(r) catch return error.OutOfMemory;
     }
     // §13.15.4 — Symbol primitives never participate in `+`. Even
     // when one side is already string-typed, a Symbol on the other

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -2189,18 +2189,22 @@ pub fn runFrames(
                 acc = res;
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
+            const scope = try arith.openBinaryCoercionScope(realm, registers[r], acc);
+            defer if (scope) |s| s.close();
             const lhs = try coerceForCompare(allocator, realm, frames, f, ip, registers[r], .number);
             if (lhs == .uncaught) return .{ .thrown = lhs.uncaught };
             if (lhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(lhs.ok) catch return error.OutOfMemory;
             const rhs = try coerceForCompare(allocator, realm, frames, f, ip, acc, .number);
             if (rhs == .uncaught) return .{ .thrown = rhs.uncaught };
             if (rhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(rhs.ok) catch return error.OutOfMemory;
             acc = relational(.lt, realm, lhs.ok, rhs.ok) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.NativeThrew => {
@@ -2222,18 +2226,22 @@ pub fn runFrames(
                 acc = res;
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
+            const scope = try arith.openBinaryCoercionScope(realm, registers[r], acc);
+            defer if (scope) |s| s.close();
             const lhs = try coerceForCompare(allocator, realm, frames, f, ip, registers[r], .number);
             if (lhs == .uncaught) return .{ .thrown = lhs.uncaught };
             if (lhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(lhs.ok) catch return error.OutOfMemory;
             const rhs = try coerceForCompare(allocator, realm, frames, f, ip, acc, .number);
             if (rhs == .uncaught) return .{ .thrown = rhs.uncaught };
             if (rhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(rhs.ok) catch return error.OutOfMemory;
             acc = relational(.gt, realm, lhs.ok, rhs.ok) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.NativeThrew => {
@@ -2255,18 +2263,22 @@ pub fn runFrames(
                 acc = res;
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
+            const scope = try arith.openBinaryCoercionScope(realm, registers[r], acc);
+            defer if (scope) |s| s.close();
             const lhs = try coerceForCompare(allocator, realm, frames, f, ip, registers[r], .number);
             if (lhs == .uncaught) return .{ .thrown = lhs.uncaught };
             if (lhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(lhs.ok) catch return error.OutOfMemory;
             const rhs = try coerceForCompare(allocator, realm, frames, f, ip, acc, .number);
             if (rhs == .uncaught) return .{ .thrown = rhs.uncaught };
             if (rhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(rhs.ok) catch return error.OutOfMemory;
             acc = relational(.le, realm, lhs.ok, rhs.ok) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.NativeThrew => {
@@ -2288,18 +2300,22 @@ pub fn runFrames(
                 acc = res;
                 continue :dispatch try decodeNext(code, &ip, &committed);
             }
+            const scope = try arith.openBinaryCoercionScope(realm, registers[r], acc);
+            defer if (scope) |s| s.close();
             const lhs = try coerceForCompare(allocator, realm, frames, f, ip, registers[r], .number);
             if (lhs == .uncaught) return .{ .thrown = lhs.uncaught };
             if (lhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(lhs.ok) catch return error.OutOfMemory;
             const rhs = try coerceForCompare(allocator, realm, frames, f, ip, acc, .number);
             if (rhs == .uncaught) return .{ .thrown = rhs.uncaught };
             if (rhs == .handled) {
                 committed = true;
                 continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
             }
+            if (scope) |s| s.push(rhs.ok) catch return error.OutOfMemory;
             acc = relational(.ge, realm, lhs.ok, rhs.ok) catch |err| switch (err) {
                 error.OutOfMemory => return error.OutOfMemory,
                 error.NativeThrew => {
@@ -2499,18 +2515,22 @@ pub fn runFrames(
             if (fast) |res| {
                 take = !res.asBool();
             } else {
+                const scope = try arith.openBinaryCoercionScope(realm, registers[r], acc);
+                defer if (scope) |s| s.close();
                 const lhs = try coerceForCompare(allocator, realm, frames, f, ip, registers[r], .number);
                 if (lhs == .uncaught) return .{ .thrown = lhs.uncaught };
                 if (lhs == .handled) {
                     committed = true;
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
+                if (scope) |s| s.push(lhs.ok) catch return error.OutOfMemory;
                 const rhs = try coerceForCompare(allocator, realm, frames, f, ip, acc, .number);
                 if (rhs == .uncaught) return .{ .thrown = rhs.uncaught };
                 if (rhs == .handled) {
                     committed = true;
                     continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
                 }
+                if (scope) |s| s.push(rhs.ok) catch return error.OutOfMemory;
                 const res = (switch (canonical) {
                     .jmp_if_not_lt => relational(.lt, realm, lhs.ok, rhs.ok),
                     .jmp_if_not_le => relational(.le, realm, lhs.ok, rhs.ok),

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -7956,6 +7956,155 @@ test "GC: consumed postfix register update roots coerced old BigInt across bump"
     , "bigint:123456789012345678901234567890:bigint:123456789012345678901234567891:1");
 }
 
+test "GC: numeric binary coercion roots fresh lhs primitive across rhs re-entry" {
+    // Coercing the lhs returns a fresh BigInt that lives only in the native
+    // arithmetic helper while rhs coercion allocates and collects. The
+    // abstract operation must root that intermediate primitive.
+    try expectScriptStringUnderAlternatingGcPressure(
+        \\function multiply(a, b) { return a * b; }
+        \\let order = "";
+        \\const lhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "L";
+        \\    return BigInt("12345678901234567890");
+        \\  }
+        \\};
+        \\const rhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "R";
+        \\    return 2n;
+        \\  }
+        \\};
+        \\const product = multiply(lhs, rhs);
+        \\typeof product + ":" + product + ":" + order;
+    , "bigint:24691357802469135780:LR");
+}
+
+test "GC: addition coercion roots fresh lhs primitive across rhs re-entry" {
+    // Addition has its own ToPrimitive path because of string concatenation,
+    // but it owes the same lifetime guarantee between left and right
+    // coercion as the other binary operators.
+    try expectScriptStringUnderAlternatingGcPressure(
+        \\function add(a, b) { return a + b; }
+        \\let order = "";
+        \\const lhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "L";
+        \\    return BigInt("12345678901234567890");
+        \\  }
+        \\};
+        \\const rhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "R";
+        \\    return 2n;
+        \\  }
+        \\};
+        \\const result = add(lhs, rhs);
+        \\typeof result + ":" + result + ":" + order;
+    , "bigint:12345678901234567892:LR");
+}
+
+test "GC: bitwise binary coercion roots fresh lhs primitive across rhs re-entry" {
+    // Like arithmetic, bitwise ToNumeric holds the freshly coerced lhs only
+    // in a native local while coercing the rhs. That primitive must survive
+    // allocation-pressure collection during the second user-code re-entry.
+    try expectScriptStringUnderAlternatingGcPressure(
+        \\function bitAnd(a, b) { return a & b; }
+        \\let order = "";
+        \\const lhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "L";
+        \\    return BigInt("12345678901234567890");
+        \\  }
+        \\};
+        \\const rhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "R";
+        \\    return 255n;
+        \\  }
+        \\};
+        \\const result = bitAnd(lhs, rhs);
+        \\typeof result + ":" + result + ":" + order;
+    , "bigint:210:LR");
+}
+
+test "GC: relational coercion roots fresh lhs primitive across rhs re-entry" {
+    // IsLessThan also keeps the freshly coerced lhs in a native local while
+    // rhs coercion can re-enter JavaScript and collect.
+    try expectScriptStringUnderAlternatingGcPressure(
+        \\function greaterThan(a, b) { return a > b; }
+        \\let order = "";
+        \\const lhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "L";
+        \\    return BigInt("12345678901234567890");
+        \\  }
+        \\};
+        \\const rhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "R";
+        \\    return 2n;
+        \\  }
+        \\};
+        \\const result = greaterThan(lhs, rhs);
+        \\result + ":" + order;
+    , "true:LR");
+}
+
+test "GC: fused relational branch roots fresh lhs primitive across rhs re-entry" {
+    const source =
+        \\function greaterThan(a, b) {
+        \\  if (a > b) return "yes";
+        \\  return "no";
+        \\}
+        \\let order = "";
+        \\const lhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "L";
+        \\    return BigInt("12345678901234567890");
+        \\  }
+        \\};
+        \\const rhs = {
+        \\  valueOf() {
+        \\    const junk = [];
+        \\    for (let i = 0; i < 20; i++) junk.push({ i });
+        \\    order += "R";
+        \\    return 2n;
+        \\  }
+        \\};
+        \\greaterThan(lhs, rhs) + ":" + order;
+    ;
+
+    // Keep this regression tied to the separately implemented fused
+    // compare-and-branch handler rather than silently falling back to `Gt`.
+    var shape_realm = Realm.init(testing.allocator);
+    defer shape_realm.deinit();
+    try installBuiltinsAllFeatures(&shape_realm);
+    const out = try compileAndDisassemble(&shape_realm, source);
+    defer testing.allocator.free(out);
+    try testing.expect(std.mem.indexOf(u8, out, "JmpIfNotGt") != null);
+
+    try expectScriptStringUnderAlternatingGcPressure(source, "yes:LR");
+}
+
 test "GC: generator wrapper iteration survives gc_threshold=1" {
     // `for (v of g())` opens an iterator on the wrapper JSObject
     // returned by the generator call. The wrapper sits in the


### PR DESCRIPTION
## Summary

- root raw binary operands and each freshly coerced primitive across right-operand JavaScript re-entry
- cover arithmetic, addition, bitwise, standalone relational, and fused relational handlers
- keep primitive Number, BigInt, String, and comparison paths allocation-free
- record the missing portable test262/GC-stress coverage

## Root cause

Left-operand coercion could return a fresh heap BigInt held only in a native local. Coercing the right operand then re-entered JavaScript and could trigger GC, sweeping that BigInt before the operator used it. Arithmetic, addition, and bitwise paths could abort in BigInt code; relational comparison could silently return the wrong result.

## Validation

- focused Debug regressions: pass
- focused ReleaseSafe regressions under alternating minor/major GC pressure: pass
- full `zig build test-fast`: pass
- pre/post `language/expressions` test262: identical 10,308 pass / 395 known failures
- ReleaseSafe `language/expressions` with `--gc-threshold=1`: 10,308 pass / 395 known failures
- full test262: baseline-identical 48,653 pass / 1,324 known failures
