### PR TITLE
Fuse finalized Star and Ldar bytecodes

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,108 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — finalized `StarLdar` store/load fusion, host `Darwin 25.6.0 arm64`
+
+Exact merged-main and final-candidate bytecode telemetry over the six macro
+workloads recorded **17,500,773** executions of the new
+`StarLdar dst, src` opcode at **704 static fused sites**. Baseline logical
+instructions fell **348,164,417 → 330,663,644**: one dispatch removed per
+execution, or **5.03%** of the old total. Aggregate encoded bytecode shrank
+**45,664 → 45,392 bytes** (-272):
+
+| bench | baseline instructions | candidate instructions | `StarLdar` executions |
+|---|---:|---:|---:|
+| richards | 104,678,462 | 104,321,361 | 357,101 |
+| deltablue | 40,203,516 | 39,702,815 | 500,701 |
+| crypto | 103,974,302 | 91,262,914 | 12,711,388 |
+| raytrace | 16,246,778 | 15,928,519 | 318,259 |
+| navier_stokes | 61,219,557 | 58,160,156 | 3,059,401 |
+| splay | 21,841,802 | 21,287,879 | 553,923 |
+
+The post-regalloc pass works on finalized bytecode, after redundant reload,
+dead-store, and dead-accumulator-copy elimination. It fuses only
+distinct-register `Star dst; Ldar src` pairs whose load is not a branch,
+switch, or exception-handler entry. Generic/generic pairs shrink from four
+bytes to three and mixed compact/generic pairs stay at three; compact/compact
+pairs remain two bytes so re-emission never grows code after branch
+relaxation. `StarLdar` stores before loading, which defines the alias case
+even though the normal compiler gives same-register pairs the stronger
+reload-deletion rewrite. The shared re-emitter repatches branches, source
+positions, handlers, and switch tables. Lantern, Bistromath, and Ohaimark all
+execute the operation. Fusion also proves that a successor opcode exists:
+the resulting Lantern handler can decode that known-present byte directly
+instead of cloning the generic checked end-of-chunk error tail. On arm64 this
+keeps the handler to 44 bytes and `runFrames` just 8 bytes larger than main.
+
+Forty paired Lantern-only runs in each launch order used exact
+baseline/candidate binary SHA-256 prefixes `2da04af` / `c8b4764`. The forward
+runner reports candidate/base, the swapped runner reports base/candidate, and
+the order-neutral candidate/base ratio is
+`sqrt((forward C/B) / (reverse B/C))`:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 1.010x | 0.995x | 1.008x |
+| deltablue | 1.001x | 1.006x | 0.998x |
+| crypto | 0.961x | 1.043x | 0.960x |
+| raytrace | 0.985x | 1.013x | 0.986x |
+| navier_stokes | 0.980x | 1.027x | 0.977x |
+| splay | 0.996x | 1.015x | 0.991x |
+| **geomean** |  |  | **0.986x** |
+
+The order-neutral macro result is therefore **0.986x**, or **1.4% faster**.
+Only Richards regresses, by 0.8%. A separate 20-pair
+production-default-tier control measured a **0.988x** neutral geometric mean
+(about **1.2% faster**). Its per-workload neutral ratios were **0.997x,
+0.997x, 0.963x, 1.002x, 0.977x, and 0.992x**, respectively; natural tier-up
+and host noise make the aggregate the useful signal.
+
+The pinned-CPU x86_64 confirmation used exact base `7949d5f8` and candidate
+`62c6335f`, pinned the driver and inherited children to CPU 3, and verified
+baseline/candidate SHA-256 prefixes `f2e0b6e2` / `c4d7f531`. Forty pairs in
+each role produced:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 1.005x | 0.997x | 1.004x |
+| deltablue | 1.010x | 0.979x | 1.016x |
+| crypto | 0.973x | 1.024x | 0.975x |
+| raytrace | 0.997x | 1.003x | 0.997x |
+| navier_stokes | 0.963x | 1.026x | 0.969x |
+| splay | 0.999x | 1.005x | 0.997x |
+| **geomean** |  |  | **0.993x** |
+
+Thus the final x86_64 candidate improves the macro geomean by **0.7%**, with
+all workload regressions below the 2% gate. The VM remained noisy
+(21–47% per-run spreads in the decisive sample), so both launch roles matter.
+Its zero-hit `arith_loop` control measured **1.012x / 0.983x / 1.015x**
+forward, reverse, and neutral with 38–59% spreads; the raw macro gate above is
+the primary result.
+
+The compact decode is material rather than cosmetic. The first implementation
+used the generic checked decode tail, grew `runFrames` by 136 bytes, and
+failed the same x86_64 gate at **1.012x** neutral, including Richards
+**1.040x**, DeltaBlue **1.028x**, and RayTrace **1.025x**. Proving a successor
+and shrinking the handler to 44 bytes turned that cross-architecture
+regression into the retained result above.
+
+`array_iter` provides a dynamic-count check: two static sites execute
+**1,010,100** times, moving **14,091,633 → 13,081,533** logical instructions
+exactly as predicted. `arith_loop` and `prop_access` contain no eligible
+sites. `arith_loop` executes a compact/compact `Star3; Ldar1` pair five
+million times, but deliberately keeps its two-byte encoding; its 40-pair
+forward, reverse, and neutral timings were **0.988x / 1.012x / 0.988x**, so
+it serves as a dispatch-layout control rather than evidence from fused
+execution.
+
+Validation covered focused fusion, CFG/leader, re-emission, liveness,
+disassembly, Lantern alias-ordering, compiler-pipeline, forced Bistromath,
+and forced Ohaimark tests plus the complete ReleaseSafe unit suite. The
+language test262 pass list was byte-identical across interpreter, forced T1,
+and forced T2 at **22,122 pass / 1,070 known fail**. The non-cached full
+sweep retained **48,653 pass / 1,324 known fail**, plus ShadowRealm
+**63 / 1**.
+
 ### 2026-07-30 — consumed postfix register updates, host `Darwin 25.6.0 arm64`
 
 Bytecode telemetry isolated Crypto's consumed postfix register update as the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -996,6 +996,21 @@ sampling by `/profile`.
   instructions **1,509 → 1,456** (-3.5%), encoded bytes **3,122 →
   3,067** (-1.8%), and dynamic dispatches **107,516,101 →
   104,678,462** (-2.64%).
+- **Finalized `StarLdar` store/load fusion (2026-07-30).** After finalized
+  CFG/liveness analysis, adjacent distinct-register `Star dst; Ldar src`
+  pairs whose load is not a branch, switch, or handler entry collapse into
+  one store-before-load `StarLdar dst src` dispatch. Compact/compact pairs
+  remain unchanged so post-relaxation re-emission never grows bytecode, and
+  Lantern, Bistromath, and Ohaimark share the operation. Six-macro telemetry
+  recorded **17,500,773** executions at **704 static fused sites**, reducing
+  logical instructions **348,164,417 → 330,663,644** (-5.03%). Forty paired
+  runs in each arm64 launch order measured an order-neutral **0.986x**
+  interpreter macro geometric mean; a production-default-tier control
+  measured **0.988x**. The fusion also proves a successor opcode exists, so
+  Lantern's compact decode keeps `runFrames` within 8 bytes of the prior
+  arm64 binary instead of duplicating the generic error tail. A pinned-CPU
+  x86_64 confirmation measured **0.993x**, with every workload regression
+  below 2%. See `bench-results.md`.
 - **Schema-derived operand-size lookup (2026-07-29).** Merged Lantern
   opcode-family handlers now advance `ip` through a 256-byte table generated
   at comptime from the authoritative `Op.spec()` metadata, replacing repeated
@@ -1603,9 +1618,9 @@ not measurements.
 5. **Profile-gated super-instructions — infrastructure shipped.**
    Static and dynamic opcode pair/trigram telemetry now identifies
    candidates; existing retained fusions include compare+branch,
-   property-call, counter-loop, `add_smi`, and `add_to_int32`
-   shapes. New opcodes must clear a paired wall-time gate, not just
-   reduce dispatch. A loose-equality+branch family cut Richards
+   property-call, counter-loop, `add_smi`, `add_to_int32`, and finalized
+   `star_ldar` store/load shapes. New opcodes must clear a paired wall-time
+   gate, not just reduce dispatch. A loose-equality+branch family cut Richards
    dispatch by 4.34% but regressed paired non-JIT wall time by 3.8%,
    so it was reverted. Continue only where profiles show a candidate
    and the end-to-end benchmark improves.
@@ -1630,10 +1645,10 @@ not measurements.
    Emit-time specializations cover common constants, low registers,
    arithmetic idioms, calls, and comparisons; jump threading runs
    over logical branch patches. Finalized chunks get CFG/liveness-
-   guarded dead-store re-emission and accumulator-aware adjacent
-   store/reload forwarding; a load that is a branch, switch, or
-   handler entry is retained. Re-emission repairs relaxed branches,
-   source positions, exception handlers, and switch targets. More
+   guarded dead-store re-emission, redundant same-register store/reload
+   deletion, and distinct-register `star_ldar` fusion; a load that is a
+   branch, switch, or handler entry is retained. Re-emission repairs relaxed
+   branches, source positions, exception handlers, and switch targets. More
    rewrites remain profile-driven; unknown register effects fail
    closed and merely skip liveness-dependent passes.
 

--- a/docs/handbook/compiler-engineering.md
+++ b/docs/handbook/compiler-engineering.md
@@ -148,7 +148,12 @@ The finalized-bytecode liveness pass builds a CFG, including every
 `switch_smi` successor, and fails closed on unknown register effects.
 It supports dead-store re-emission and accumulator forwarding for an
 adjacent `Star r; Ldar r` only when the load is not a branch, switch,
-or handler entry. This rewrite must run after branch finalization:
+or handler entry. A later pass applies the same entry proof to fuse an
+adjacent distinct-register `Star dst; Ldar src` into the store-before-load
+`StarLdar dst, src`; compact/compact pairs remain unfused so the finalized
+encoding never grows, and terminal pairs remain unfused so the handler can
+decode a proven-present successor without the generic end-of-chunk error
+tail. These rewrites must run after branch finalization:
 emission-time patch state does not yet know every incoming edge.
 Explicit register reads come from the opcode schema; instructions with
 implicit argument windows still require an explicit effect declaration.

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -15131,6 +15131,7 @@ fn compileScriptLikeChunk(
     _ = try regalloc.eliminateRedundantStoreLoads(allocator, &chunk);
     _ = try regalloc.eliminateDeadStores(allocator, &chunk);
     _ = try regalloc.eliminateDeadAccumulatorCopies(allocator, &chunk);
+    _ = try regalloc.fuseStoreLoads(allocator, &chunk);
     try realm.heap.pinChunk(&chunk);
     return chunk;
 }
@@ -15335,6 +15336,7 @@ pub fn compileModuleAsChunk(
     _ = try regalloc.eliminateRedundantStoreLoads(allocator, &chunk);
     _ = try regalloc.eliminateDeadStores(allocator, &chunk);
     _ = try regalloc.eliminateDeadAccumulatorCopies(allocator, &chunk);
+    _ = try regalloc.fuseStoreLoads(allocator, &chunk);
     try realm.heap.pinChunk(&chunk);
     return chunk;
 }
@@ -15370,6 +15372,7 @@ pub fn compileExpressionAsChunk(
     _ = try regalloc.eliminateRedundantStoreLoads(allocator, &chunk);
     _ = try regalloc.eliminateDeadStores(allocator, &chunk);
     _ = try regalloc.eliminateDeadAccumulatorCopies(allocator, &chunk);
+    _ = try regalloc.fuseStoreLoads(allocator, &chunk);
     try realm.heap.pinChunk(&chunk);
     return chunk;
 }
@@ -15500,6 +15503,16 @@ test "compiler: member store o.x=v with register-bound receiver stores to the so
     const t0 = t0Of(got);
     try testing.expect(std.mem.indexOf(u8, t0, "StaProperty8 k0 r0") != null);
     try testing.expect(std.mem.indexOf(u8, t0, "Star ") == null);
+}
+
+test "compiler: finalized call-argument shuffles fuse Star then Ldar" {
+    const got = try dumpExpr("(function(o,a,b,c){ return o.m(a,b,c); })");
+    defer testing.allocator.free(got);
+    const body = t0Of(got);
+    // Saving one argument and immediately loading the next is the hot
+    // multi-argument-call shape. The finalized CFG proves each load is
+    // fallthrough-only before the post-regalloc fusion runs.
+    try testing.expect(std.mem.indexOf(u8, body, "StarLdar") != null);
 }
 
 test "compiler: a trailing statement's completion register traffic is eliminated" {

--- a/src/bytecode/disasm.zig
+++ b/src/bytecode/disasm.zig
@@ -63,6 +63,11 @@ pub fn dump(allocator: std.mem.Allocator, chunk: *const Chunk) ![]u8 {
                 const dst = chunk.code[i + 2];
                 try buf.print(allocator, " r{d} r{d}", .{ src, dst });
             },
+            .star_ldar => {
+                const dst = chunk.code[i + 1];
+                const src = chunk.code[i + 2];
+                try buf.print(allocator, " r{d} r{d}", .{ dst, src });
+            },
             .add, .add_to_int32, .sub, .mul, .div, .mod, .pow, .bit_and, .bit_or, .bit_xor, .shl, .shr, .shr_u, .eq, .strict_eq, .neq, .strict_neq, .lt, .gt, .le, .ge, .instanceof_, .array_spread => {
                 const r = chunk.code[i + 1];
                 try buf.print(allocator, " r{d}", .{r});

--- a/src/bytecode/liveness.zig
+++ b/src/bytecode/liveness.zig
@@ -205,6 +205,13 @@ pub fn effectOf(op: Op, code: []const u8, i: usize) Effect {
         .star => Effect.writeReg(code[i + 1]),
         .star_0, .star_1, .star_2, .star_3 => Effect.writeReg(@intFromEnum(op) - @intFromEnum(Op.star_0)),
         .mov => .{ .reads = .{ code[i + 1], 0, 0 }, .n_reads = 1, .write = code[i + 2] },
+        // Store happens before load. For an aliasing pair, the load reads the
+        // just-written value rather than the old register contents, so there
+        // is no old-value read to keep live.
+        .star_ldar => if (code[i + 1] == code[i + 2])
+            Effect.writeReg(code[i + 1])
+        else
+            .{ .reads = .{ code[i + 2], 0, 0 }, .n_reads = 1, .write = code[i + 1] },
 
         // ── Read + write the same register ──
         // `[op][r:u8]` — read the old binding value and replace it with the
@@ -737,6 +744,19 @@ test "liveness: effectOf classifies register operands" {
     const e_mov = effectOf(.mov, &mov, 0);
     try testing.expectEqual(@as(u8, 1), e_mov.reads[0]);
     try testing.expectEqual(@as(?u8, 2), e_mov.write);
+
+    // StarLdar stores dst before loading src. Distinct registers read the
+    // source's old value; an alias reads the just-written value and therefore
+    // has no old-value read in the liveness model.
+    var star_ldar = [_]u8{ byteOf(.star_ldar), 2, 4 };
+    const e_star_ldar = effectOf(.star_ldar, &star_ldar, 0);
+    try testing.expectEqual(@as(u8, 1), e_star_ldar.n_reads);
+    try testing.expectEqual(@as(u8, 4), e_star_ldar.reads[0]);
+    try testing.expectEqual(@as(?u8, 2), e_star_ldar.write);
+    var star_ldar_alias = [_]u8{ byteOf(.star_ldar), 3, 3 };
+    const e_star_ldar_alias = effectOf(.star_ldar, &star_ldar_alias, 0);
+    try testing.expectEqual(@as(u8, 0), e_star_ldar_alias.n_reads);
+    try testing.expectEqual(@as(?u8, 3), e_star_ldar_alias.write);
 
     // loop_inc_lt reads counter+bound, writes counter.
     var lil = [_]u8{ byteOf(.loop_inc_lt), 1, 2, 0, 0 };

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -1488,6 +1488,12 @@ pub const Op = enum(u8) {
     post_inc_reg,
     /// `[op] [r:u8]` — decrement counterpart of `post_inc_reg`.
     post_dec_reg,
+    /// `[op] [dst:u8] [src:u8]` — store the accumulator in `dst`,
+    /// then load `src` into the accumulator. The order is observable when
+    /// `dst == src`: the load sees the value just stored. Finalized-bytecode
+    /// fusion emits this for adjacent `Star dst; Ldar src` pairs whose load
+    /// is not a control-flow entry.
+    star_ldar,
 
     /// Authoritative instruction metadata. Adding an opcode requires one
     /// exhaustive entry here; consumers derive names, sizes and tier/control
@@ -1541,6 +1547,7 @@ pub const Op = enum(u8) {
             .dec_reg => baselineInstruction("DecReg", .reg),
             .post_inc_reg => instruction("PostIncReg", .reg),
             .post_dec_reg => instruction("PostDecReg", .reg),
+            .star_ldar => baselineInstruction("StarLdar", .reg_reg),
             .lda_smi8 => baselineInstruction("LdaSmi8", .i8),
             .lda_smi16 => baselineInstruction("LdaSmi16", .i16),
             .add_smi8 => baselineInstruction("AddSmi8", .reg_i8),
@@ -1925,6 +1932,7 @@ test "Op: every variant has one authoritative instruction spec" {
 test "Op: instruction specs classify representative execution contracts" {
     try testing.expectEqual(OperandLayout.none, Op.lda_undefined.spec().layout);
     try testing.expectEqual(OperandLayout.reg, Op.ldar.spec().layout);
+    try testing.expectEqual(OperandLayout.reg_reg, Op.star_ldar.spec().layout);
     try testing.expectEqual(OperandLayout.reg_i32, Op.add_smi.spec().layout);
     try testing.expectEqual(OperandLayout.reg_i16, Op.jmp_if_strict_eq.spec().layout);
     try testing.expectEqual(OperandLayout.u16_reg_u8_u16_u16, Op.call_property.spec().layout);
@@ -1936,6 +1944,7 @@ test "Op: instruction specs classify representative execution contracts" {
 
     try testing.expectEqual(BaselineStrategy.inline_, Op.add.spec().baseline);
     try testing.expectEqual(BaselineStrategy.inline_, Op.inc_reg.spec().baseline);
+    try testing.expectEqual(BaselineStrategy.inline_, Op.star_ldar.spec().baseline);
     try testing.expectEqual(BaselineStrategy.unsupported, Op.post_inc_reg.spec().baseline);
     try testing.expectEqual(BaselineStrategy.unsupported, Op.await_.spec().baseline);
 }
@@ -2002,6 +2011,7 @@ test "Op: operandSize agrees with the documented encoding" {
     // register: `[op] [r:u8] [profile:u16]`.
     try testing.expectEqual(@as(u8, 3), Op.operandSize(.div));
     try testing.expectEqual(@as(u8, 2), Op.operandSize(.mov));
+    try testing.expectEqual(@as(u8, 2), Op.operandSize(.star_ldar));
     try testing.expectEqual(@as(u8, 2), Op.operandSize(.lda_constant));
     try testing.expectEqual(@as(u8, 2), Op.operandSize(.jmp));
     try testing.expectEqual(@as(u8, 4), Op.operandSize(.lda_smi));

--- a/src/bytecode/op.zig
+++ b/src/bytecode/op.zig
@@ -1492,7 +1492,7 @@ pub const Op = enum(u8) {
     /// then load `src` into the accumulator. The order is observable when
     /// `dst == src`: the load sees the value just stored. Finalized-bytecode
     /// fusion emits this for adjacent `Star dst; Ldar src` pairs whose load
-    /// is not a control-flow entry.
+    /// is not a control-flow entry and whose pair has a successor opcode.
     star_ldar,
 
     /// Authoritative instruction metadata. Adding an opcode requires one

--- a/src/bytecode/regalloc.zig
+++ b/src/bytecode/regalloc.zig
@@ -35,6 +35,7 @@ const SourcePos = chunk_mod.SourcePos;
 const Handler = chunk_mod.Handler;
 const SwitchTable = chunk_mod.SwitchTable;
 const liveness = @import("liveness.zig");
+const disasm = @import("disasm.zig");
 
 fn isPureStore(op: Op) bool {
     return switch (op) {
@@ -98,6 +99,104 @@ fn eliminateRedundantStoreLoadsOne(allocator: std.mem.Allocator, chunk: *Chunk) 
     if (dead.items.len == 0) return 0;
     try reEmitDropping(allocator, chunk, dead.items);
     return dead.items.len;
+}
+
+/// Fuse adjacent `Star dst; Ldar src` into `StarLdar dst src` after the
+/// finalized CFG proves the load has no other predecessor. Pairs whose two
+/// compact encodings occupy only two bytes are retained: the replacement is
+/// three bytes, and the shared post-relaxation re-emitter deliberately never
+/// grows code (an already-selected i8 branch might otherwise overflow).
+///
+/// Run this after dead-store elimination so a dead `Star` can still disappear
+/// instead of being hidden inside the fused instruction. Recurses through all
+/// function- and class-owned chunks.
+pub fn fuseStoreLoads(allocator: std.mem.Allocator, chunk: *Chunk) !usize {
+    var replaced = try fuseStoreLoadsOne(allocator, chunk);
+    for (chunk.function_templates) |*t| replaced += try fuseStoreLoads(allocator, &t.chunk);
+    for (chunk.class_templates) |*class| {
+        replaced += try fuseStoreLoads(allocator, &class.constructor_chunk);
+        for (class.instance_methods) |*method| replaced += try fuseStoreLoads(allocator, &method.chunk);
+        for (class.static_methods) |*method| replaced += try fuseStoreLoads(allocator, &method.chunk);
+        for (class.instance_fields) |*field| if (field.init_chunk) |*init| {
+            replaced += try fuseStoreLoads(allocator, init);
+        };
+        for (class.static_fields) |*field| if (field.init_chunk) |*init| {
+            replaced += try fuseStoreLoads(allocator, init);
+        };
+        for (class.static_blocks) |*block| replaced += try fuseStoreLoads(allocator, block);
+    }
+    return replaced;
+}
+
+/// Cheap syntactic gate before allocating CFG/liveness state. It deliberately
+/// ignores leader status; false positives merely pay for analysis, while a
+/// false negative would miss a legal fusion.
+fn hasPotentialStoreLoadFusion(code: []const u8) bool {
+    var i: u32 = 0;
+    while (i < code.len) {
+        const store_op: Op = @enumFromInt(code[i]);
+        const load_start = i + 1 + Op.operandSize(store_op);
+        if (isPureStore(store_op) and load_start < code.len) {
+            const load_op: Op = @enumFromInt(code[load_start]);
+            if (loadTarget(load_op, code, load_start)) |src| {
+                const pair_end = load_start + 1 + Op.operandSize(load_op);
+                if (pair_end - i >= 3 and storeTarget(store_op, code, i) != src) return true;
+            }
+        }
+        i = load_start;
+    }
+    return false;
+}
+
+fn fuseStoreLoadsOne(allocator: std.mem.Allocator, chunk: *Chunk) !usize {
+    const code = chunk.code;
+    if (code.len == 0 or !hasPotentialStoreLoadFusion(code)) return 0;
+
+    var a = try liveness.analyze(allocator, code, chunk.register_count, chunk.handlers, chunk.switch_tables);
+    defer a.deinit();
+
+    var replacements: std.ArrayListUnmanaged(Replacement) = .empty;
+    defer replacements.deinit(allocator);
+
+    var i: u32 = 0;
+    while (i < code.len) {
+        const store_op: Op = @enumFromInt(code[i]);
+        const load_start = i + 1 + Op.operandSize(store_op);
+        if (!isPureStore(store_op) or load_start >= code.len or isLeaderOff(a.leaders, load_start)) {
+            i = load_start;
+            continue;
+        }
+
+        const load_op: Op = @enumFromInt(code[load_start]);
+        const src = loadTarget(load_op, code, load_start) orelse {
+            i = load_start;
+            continue;
+        };
+        const pair_end = load_start + 1 + Op.operandSize(load_op);
+        if (pair_end - i < 3) {
+            i = pair_end;
+            continue;
+        }
+        const dst = storeTarget(store_op, code, i);
+        // Same-register pairs have the stronger `Ldar`-deletion rewrite.
+        // The normal pipeline runs it first. Skipping aliases here also avoids
+        // weakening class-owned pairs not reached by that older pass.
+        if (dst == src) {
+            i = pair_end;
+            continue;
+        }
+
+        try replacements.append(allocator, .{
+            .start = i,
+            .end = pair_end,
+            .bytes = .{ @intFromEnum(Op.star_ldar), dst, src },
+        });
+        i = pair_end;
+    }
+
+    if (replacements.items.len == 0) return 0;
+    try reEmit(allocator, chunk, &.{}, replacements.items);
+    return replacements.items.len;
 }
 
 /// Drop dead `Star` instructions in `chunk` (and recurse into nested
@@ -374,8 +473,9 @@ fn reEmit(
             if (ri < replacements.len and replacements[ri].start == old) {
                 const replacement = replacements[ri];
                 const new_self = new_off[old];
-                // Keep the load's source mapping on Mov; discard mappings for
-                // the absorbed store so none points into Mov's operands.
+                // Keep the first instruction's source mapping on the fused
+                // replacement; discard mappings for absorbed instructions so
+                // none points into the replacement's operands.
                 while (sp_i < chunk.source_positions.len and chunk.source_positions[sp_i].offset == old) : (sp_i += 1) {
                     try new_sp.append(allocator, .{ .offset = new_self, .span = chunk.source_positions[sp_i].span });
                 }
@@ -780,6 +880,231 @@ test "regalloc(store-load): load at a branch target is kept" {
 
     try testing.expectEqual(@as(usize, 0), try eliminateRedundantStoreLoadsOne(testing.allocator, &chunk));
     try testing.expectEqualSlices(u8, &code, chunk.code);
+}
+
+test "regalloc(store-load fusion): adjacent distinct registers emit and disassemble StarLdar" {
+    var code = [_]u8{
+        @intFromEnum(Op.lda_one),
+        @intFromEnum(Op.star),
+        3,
+        @intFromEnum(Op.ldar_2),
+        @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 1), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqualSlices(u8, &.{
+        @intFromEnum(Op.lda_one),
+        @intFromEnum(Op.star_ldar),
+        3,
+        2,
+        @intFromEnum(Op.return_),
+    }, chunk.code);
+
+    const got = try disasm.dump(testing.allocator, &chunk);
+    defer testing.allocator.free(got);
+    try testing.expect(std.mem.indexOf(u8, got, "StarLdar r3 r2") != null);
+}
+
+test "regalloc(store-load fusion): both mixed encodings fuse without growing code" {
+    {
+        var code = [_]u8{
+            @intFromEnum(Op.star_2),
+            @intFromEnum(Op.ldar),
+            3,
+            @intFromEnum(Op.return_),
+        };
+        var chunk = try mkChunk(&code);
+        defer testing.allocator.free(chunk.code);
+        try testing.expectEqual(@as(usize, 1), try fuseStoreLoadsOne(testing.allocator, &chunk));
+        try testing.expectEqualSlices(u8, &.{
+            @intFromEnum(Op.star_ldar), 2, 3,
+            @intFromEnum(Op.return_),
+        }, chunk.code);
+    }
+    {
+        var code = [_]u8{
+            @intFromEnum(Op.star),
+            3,
+            @intFromEnum(Op.ldar_2),
+            @intFromEnum(Op.return_),
+        };
+        var chunk = try mkChunk(&code);
+        defer testing.allocator.free(chunk.code);
+        try testing.expectEqual(@as(usize, 1), try fuseStoreLoadsOne(testing.allocator, &chunk));
+        try testing.expectEqualSlices(u8, &.{
+            @intFromEnum(Op.star_ldar), 3, 2,
+            @intFromEnum(Op.return_),
+        }, chunk.code);
+    }
+}
+
+test "regalloc(store-load fusion): compact pair is not grown" {
+    var code = [_]u8{
+        @intFromEnum(Op.star_2),
+        @intFromEnum(Op.ldar_3),
+        @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqualSlices(u8, &code, chunk.code);
+}
+
+test "regalloc(store-load fusion): load at a branch target is not fused" {
+    // The jump reaches Ldar without executing the preceding Star. Folding
+    // both into the fallthrough instruction would lose that entry point.
+    var code = [_]u8{
+        @intFromEnum(Op.jmp),     1,                     0, // after=3, +1 -> Ldar at 4
+        @intFromEnum(Op.star_2),  @intFromEnum(Op.ldar), 3,
+        @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqualSlices(u8, &code, chunk.code);
+}
+
+test "regalloc(store-load fusion): handler and switch targets are not fused" {
+    {
+        var code = [_]u8{
+            @intFromEnum(Op.star_2),
+            @intFromEnum(Op.ldar),
+            4,
+            @intFromEnum(Op.return_),
+        };
+        var handlers = [_]Handler{.{
+            .start_pc = 0,
+            .end_pc = 1,
+            .handler_pc = 1,
+            .catch_register = 5,
+        }};
+        var chunk: Chunk = .{
+            .code = try testing.allocator.dupe(u8, &code),
+            .constants = &.{},
+            .source_positions = &.{},
+            .handlers = &handlers,
+            .function_templates = &.{},
+            .class_templates = &.{},
+            .register_count = 6,
+        };
+        defer testing.allocator.free(chunk.code);
+        try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+        try testing.expectEqualSlices(u8, &code, chunk.code);
+    }
+    {
+        var code = [_]u8{
+            @intFromEnum(Op.switch_smi), 0,                     0, 0,
+            @intFromEnum(Op.star_2),     @intFromEnum(Op.ldar), 4, @intFromEnum(Op.return_),
+            @intFromEnum(Op.return_),
+        };
+        var targets = [_]u32{5};
+        var tables = [_]SwitchTable{.{ .min = 0, .targets = &targets, .default_target = 8 }};
+        var chunk: Chunk = .{
+            .code = try testing.allocator.dupe(u8, &code),
+            .constants = &.{},
+            .source_positions = &.{},
+            .handlers = &.{},
+            .switch_tables = &tables,
+            .function_templates = &.{},
+            .class_templates = &.{},
+            .register_count = 5,
+        };
+        defer testing.allocator.free(chunk.code);
+        try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+        try testing.expectEqualSlices(u8, &code, chunk.code);
+    }
+}
+
+test "regalloc(store-load fusion): a target at Star keeps the legal fusion" {
+    var code = [_]u8{
+        @intFromEnum(Op.jmp),     1,                        0, // after=3, +1 -> Star at 4
+        @intFromEnum(Op.lda_one), @intFromEnum(Op.star_2),  @intFromEnum(Op.ldar),
+        3,                        @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 1), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqual(Op.star_ldar, @as(Op, @enumFromInt(chunk.code[4])));
+    try testing.expectEqual(@as(u32, 4), liveness.branchTarget(.jmp, chunk.code, 0).?);
+}
+
+test "regalloc(store-load fusion): shrinking pair repatches a crossing branch" {
+    var code = [_]u8{
+        @intFromEnum(Op.lda_true),
+        @intFromEnum(Op.jmp_if_false), 4,                        0, // after=4, +4 -> Return at 8
+        @intFromEnum(Op.star),         2,                        @intFromEnum(Op.ldar),
+        3,                             @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 1), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqual(@as(usize, code.len - 1), chunk.code.len);
+    try testing.expectEqual(@as(u32, 7), liveness.branchTarget(.jmp_if_false, chunk.code, 1).?);
+    try testing.expectEqual(Op.return_, @as(Op, @enumFromInt(chunk.code[7])));
+}
+
+test "regalloc(store-load fusion): the public pipeline leaves same-register cleanup stronger" {
+    var code = [_]u8{
+        @intFromEnum(Op.star),    3,
+        @intFromEnum(Op.ldar),    3,
+        @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 1), try eliminateRedundantStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqualSlices(u8, &.{
+        @intFromEnum(Op.star),    3,
+        @intFromEnum(Op.return_),
+    }, chunk.code);
+}
+
+test "regalloc(store-load fusion): recurses into a class-owned constructor chunk" {
+    var outer_code = [_]u8{@intFromEnum(Op.return_)};
+    var constructor_code = [_]u8{
+        @intFromEnum(Op.star),    3,
+        @intFromEnum(Op.ldar),    2,
+        @intFromEnum(Op.return_),
+    };
+    const constructor = try mkChunk(&constructor_code);
+    var classes = [_]chunk_mod.ClassTemplate{.{
+        .name = null,
+        .span = .{ .start = 0, .end = 0 },
+        .has_heritage = false,
+        .private_prefix = "",
+        .constructor_chunk = constructor,
+        .constructor_param_count = 0,
+        .instance_methods = &.{},
+        .static_methods = &.{},
+        .instance_fields = &.{},
+        .static_fields = &.{},
+        .static_blocks = &.{},
+        .static_element_order = &.{},
+    }};
+    defer testing.allocator.free(classes[0].constructor_chunk.code);
+    var outer: Chunk = .{
+        .code = try testing.allocator.dupe(u8, &outer_code),
+        .constants = &.{},
+        .source_positions = &.{},
+        .handlers = &.{},
+        .function_templates = &.{},
+        .class_templates = &classes,
+        .register_count = 1,
+    };
+    defer testing.allocator.free(outer.code);
+
+    try testing.expectEqual(@as(usize, 1), try fuseStoreLoads(testing.allocator, &outer));
+    try testing.expectEqualSlices(u8, &.{
+        @intFromEnum(Op.star_ldar), 3, 2,
+        @intFromEnum(Op.return_),
+    }, classes[0].constructor_chunk.code);
 }
 
 test "regalloc(copy): dead accumulator Ldar-Star becomes Mov" {

--- a/src/bytecode/regalloc.zig
+++ b/src/bytecode/regalloc.zig
@@ -140,7 +140,7 @@ fn hasPotentialStoreLoadFusion(code: []const u8) bool {
             const load_op: Op = @enumFromInt(code[load_start]);
             if (loadTarget(load_op, code, load_start)) |src| {
                 const pair_end = load_start + 1 + Op.operandSize(load_op);
-                if (pair_end - i >= 3 and storeTarget(store_op, code, i) != src) return true;
+                if (pair_end < code.len and pair_end - i >= 3 and storeTarget(store_op, code, i) != src) return true;
             }
         }
         i = load_start;
@@ -173,7 +173,10 @@ fn fuseStoreLoadsOne(allocator: std.mem.Allocator, chunk: *Chunk) !usize {
             continue;
         };
         const pair_end = load_start + 1 + Op.operandSize(load_op);
-        if (pair_end - i < 3) {
+        // StarLdar uses the smaller known-present decode tail. Finalized
+        // compiler chunks normally end in an explicit transfer, but retain a
+        // terminal pair defensively so the fused opcode always has a successor.
+        if (pair_end >= code.len or pair_end - i < 3) {
             i = pair_end;
             continue;
         }
@@ -945,6 +948,20 @@ test "regalloc(store-load fusion): compact pair is not grown" {
         @intFromEnum(Op.star_2),
         @intFromEnum(Op.ldar_3),
         @intFromEnum(Op.return_),
+    };
+    var chunk = try mkChunk(&code);
+    defer testing.allocator.free(chunk.code);
+
+    try testing.expectEqual(@as(usize, 0), try fuseStoreLoadsOne(testing.allocator, &chunk));
+    try testing.expectEqualSlices(u8, &code, chunk.code);
+}
+
+test "regalloc(store-load fusion): terminal pair keeps checked end-of-chunk decode" {
+    var code = [_]u8{
+        @intFromEnum(Op.star),
+        3,
+        @intFromEnum(Op.ldar),
+        2,
     };
     var chunk = try mkChunk(&code);
     defer testing.allocator.free(chunk.code);

--- a/src/runtime/bistromath/bistromath.zig
+++ b/src/runtime/bistromath/bistromath.zig
@@ -989,6 +989,10 @@ const Compiler = struct {
                     try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try m.emit(a64.strImm(.x9, regs_reg, regSlot(code[i + 2])));
                 },
+                .star_ldar => {
+                    try m.emit(a64.strImm(acc_reg, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(a64.ldrImm(acc_reg, regs_reg, regSlot(code[i + 2])));
+                },
                 .inc_reg, .dec_reg => {
                     // §13.4 fast path. The bytecode's general semantics are
                     // ToNumeric + a Number/BigInt unit; Bistromath handles the
@@ -2487,6 +2491,43 @@ test "jit bistromath: fused register updates compile without blocking tier-up" {
     const js = g_chunk.jit_state.?;
     try testing.expectEqual(Chunk.JitState.Tier.compiled, js.bistromath.code.tier);
     try testing.expect(js.bistromath.entry() != null);
+}
+
+test "jit bistromath: StarLdar compiles and preserves argument arithmetic" {
+    if (comptime !supported) return error.SkipZigTest;
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+
+    const src =
+        \\function mix(a, b, c, d) { return (a + b) + (c + d); }
+        \\mix(1, 2, 3, 4);
+        \\mix(10, 20, 30, 40);
+    ;
+    const program = try parser_mod.parseScript(arena.allocator(), src, null);
+    var chunk = try bc_compiler.compileScriptAsChunk(testing.allocator, &realm, &program, src, null);
+    defer chunk.deinit(testing.allocator);
+    const body = templateNamed(&chunk, "mix");
+    var saw_star_ldar = false;
+    var pc: usize = 0;
+    while (pc < body.code.len) {
+        const op: Op = @enumFromInt(body.code[pc]);
+        saw_star_ldar = saw_star_ldar or op == .star_ldar;
+        pc += 1 + Op.operandSize(op);
+    }
+    try testing.expect(saw_star_ldar);
+
+    const value = switch (try interpreter.run(testing.allocator, &realm, &chunk)) {
+        .value, .yielded => |result| result,
+        .thrown => return error.UncaughtException,
+    };
+    try testing.expectEqual(Value.fromInt32(100).bits, value.bits);
+    const state = body.jit_state.?;
+    try testing.expectEqual(Chunk.JitState.Tier.compiled, state.bistromath.code.tier);
+    try testing.expect(state.bistromath.entry() != null);
 }
 
 test "jit bistromath: make_environment(0) with env reads dont_compiles" {

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1053,6 +1053,19 @@ inline fn decodeNext(code: []const u8, ip: *usize, committed: *bool) RunError!Op
     return op;
 }
 
+/// StarLdar is produced only when finalized-bytecode fusion proves a
+/// successor instruction exists. Keeping that invariant out of the generic
+/// error-union decoder avoids cloning its checked failure tail into the new
+/// threaded handler.
+inline fn decodeNextKnownPresent(code: []const u8, ip: *usize, committed: *bool) Op {
+    committed.* = false;
+    const b = code[ip.*];
+    ip.* += 1;
+    const op: Op = @enumFromInt(b);
+    if (comptime bytecode_stats.enabled) bytecode_stats.observeActive(op);
+    return op;
+}
+
 /// Re-derive the loop-persistent dispatch state from the top frame,
 /// then decode the next opcode. Used after any step that swaps the
 /// active frame (call push / return pop) or repositions it (an
@@ -1576,7 +1589,7 @@ pub fn runFrames(
             ip += 2;
             registers[dst] = acc;
             acc = registers[src];
-            continue :dispatch try decodeNext(code, &ip, &committed);
+            continue :dispatch decodeNextKnownPresent(code, &ip, &committed);
         },
         .lda_hole => {
             acc = Value.hole_;

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1570,6 +1570,14 @@ pub fn runFrames(
             registers[dst] = registers[src];
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
+        .star_ldar => {
+            const dst = code[ip];
+            const src = code[ip + 1];
+            ip += 2;
+            registers[dst] = acc;
+            acc = registers[src];
+            continue :dispatch try decodeNext(code, &ip, &committed);
+        },
         .lda_hole => {
             acc = Value.hole_;
             continue :dispatch try decodeNext(code, &ip, &committed);

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -112,6 +112,39 @@ fn expectScriptStringWithBuiltins(source: []const u8, expected: []const u8) !voi
     try testing.expectEqualStrings(expected, s.flatBytes());
 }
 
+test "lantern: StarLdar stores before loading when registers alias" {
+    const Op = op_mod.Op;
+    const code = [_]u8{
+        @intFromEnum(Op.lda_zero),
+        @intFromEnum(Op.star),
+        1,
+        @intFromEnum(Op.lda_one),
+        @intFromEnum(Op.star_ldar),
+        1,
+        1,
+        @intFromEnum(Op.return_),
+    };
+    const chunk: chunk_mod.Chunk = .{
+        .code = &code,
+        .constants = &.{},
+        .source_positions = &.{},
+        .handlers = &.{},
+        .function_templates = &.{},
+        .class_templates = &.{},
+        .register_count = 2,
+    };
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+
+    const result = try run(testing.allocator, &realm, &chunk);
+    const value = switch (result) {
+        .value, .yielded => |v| v,
+        .thrown => return error.UncaughtException,
+    };
+    try testing.expect(value.isInt32());
+    try testing.expectEqual(@as(i32, 1), value.asInt32());
+}
+
 /// Unhardened-realm variant of `expectScriptIntWithBuiltins`. Use
 /// when the test monkey-patches a primordial (e.g. installs an
 /// indexed accessor on `Object.prototype`) or probes a descriptor

--- a/src/runtime/ohaimark/driver_test.zig
+++ b/src/runtime/ohaimark/driver_test.zig
@@ -3,6 +3,7 @@ const std = @import("std");
 const chunk_mod = @import("../../bytecode/chunk.zig");
 const Builder = chunk_mod.Builder;
 const compiler_mod = @import("../../bytecode/compiler.zig");
+const Op = @import("../../bytecode/op.zig").Op;
 const parser_mod = @import("../../parser/parser.zig");
 const Span = @import("../../source.zig").Span;
 const lantern = @import("../lantern/interpreter.zig");
@@ -141,6 +142,42 @@ test "Ohaimark forced function entry compiles and completes through normal dispa
     try testing.expectEqual(@as(u64, 2), realm.heap.ohaimark_stats.executed_entries);
     try testing.expectEqual(@as(u64, 2), realm.heap.ohaimark_stats.completed_entries);
     try testing.expectEqual(@as(u64, 0), realm.heap.ohaimark_stats.guard_exits);
+}
+
+test "Ohaimark forced function entry compiles StarLdar" {
+    if (comptime !driver.supported) return error.SkipZigTest;
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    realm.ohaimark_enabled = true;
+    realm.ohaimark_threshold_override = 1;
+
+    const source =
+        \\function mix() {
+        \\  let a = 1; let b = 2; let c = 3; let d = 4;
+        \\  return (a + b) + (c + d);
+        \\}
+        \\mix();
+        \\mix();
+    ;
+    var chunk = try compileScript(&realm, source);
+    defer chunk.deinit(testing.allocator);
+    const body = templateNamed(&chunk, "mix");
+    var saw_star_ldar = false;
+    var pc: usize = 0;
+    while (pc < body.code.len) {
+        const op: Op = @enumFromInt(body.code[pc]);
+        saw_star_ldar = saw_star_ldar or op == .star_ldar;
+        pc += 1 + Op.operandSize(op);
+    }
+    try testing.expect(saw_star_ldar);
+
+    const value = try runValue(&realm, &chunk);
+    try testing.expectEqual(Value.fromInt32(10).bits, value.bits);
+    const state = body.jit_state.?;
+    try testing.expectEqual(chunk_mod.Chunk.JitState.Tier.compiled, state.ohaimark.tier);
+    try testing.expect(state.ohaimark.entry() != null);
 }
 
 test "Ohaimark warmth continues through a compiled Bistromath caller" {

--- a/src/runtime/ohaimark/ir.zig
+++ b/src/runtime/ohaimark/ir.zig
@@ -554,6 +554,10 @@ const Builder = struct {
                     const value = try readRegister(registers, self.chunk.code[pc + 1]);
                     try writeRegister(registers, self.chunk.code[pc + 2], value);
                 },
+                .star_ldar => {
+                    try writeRegister(registers, self.chunk.code[pc + 1], accumulator);
+                    accumulator = try readRegister(registers, self.chunk.code[pc + 2]);
+                },
                 .add, .sub, .mul, .div => |binary| {
                     const lhs = try readRegister(registers, self.chunk.code[pc + 1]);
                     const payload: Payload = if (binary.hasBinaryTypeProfile()) blk: {


### PR DESCRIPTION
## Summary

- fuse finalized adjacent `Star dst; Ldar src` bytecodes when CFG entry and encoding-size proofs permit
- execute the store-before-load operation in Lantern, Bistromath, and Ohaimark
- preserve compact/compact pairs and same-register reload deletion
- cover CFG leaders, branch repatching, liveness, disassembly, nested class chunks, interpreter aliasing, and both native tiers

## Performance

- six-macro dynamic instructions: 348,164,417 → 330,663,644 (-5.03%, exactly 17,500,773 fewer dispatches)
- 704 static fused sites; aggregate bytecode: 45,664 → 45,392 bytes
- arm64 Lantern-only, 40 pairs in both roles: 0.986x order-neutral macro geomean (1.4% faster)
- arm64 production-default tier, 20 pairs in both roles: 0.988x order-neutral macro geomean (1.2% faster)
- zero-hit `arith_loop` layout control: 0.988x order-neutral
- compact known-successor decode keeps `runFrames` within 8 bytes of main and the new handler at 44 bytes
- pinned x86_64 Lantern-only, 40 pairs in both roles: 0.993x order-neutral macro geomean; every workload regression <2%

## Validation

- focused Debug and ReleaseSafe fusion/tier tests: pass
- full `zig build test-fast --summary all`: 9/9 steps pass
- interpreter vs forced Bistromath language test262: identical 22,122 pass / 1,070 known failures
- interpreter vs forced Ohaimark language test262: identical 22,122 pass / 1,070 known failures
- full non-cached test262: baseline-identical 48,653 pass / 1,324 known failures
- ShadowRealm feature sweep: baseline-identical 63 pass / 1 known failure
