### PR TITLE
Reuse computed receivers across distinct updates

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,116 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-30 — target-specific computed-receiver register reuse, host `Darwin 25.6.0 arm64`
+
+Exact stats-enabled ReleaseFast binaries from merged main `339818b0` and the
+candidate implementation (SHA-256 prefixes `7d06db73` / `58d647d3`) isolate
+the deterministic effect on Navier-Stokes. Logical instructions fell
+**58,160,156 → 53,605,322**, removing **4,554,834 dispatches (-7.83%)**.
+Static bytecode moved **1,934 → 1,916 instructions** and **4,546 → 4,499
+bytes**; the script-wide maximum register count remained 28. Fifteen source
+reads became eligible. Baseline `Mov → IncReg` pairs executed **4,587,520**
+times, including **4,456,448** `Mov → IncReg → LdaComputed8` triples.
+Removing the sites' 14 `Mov` snapshots and one `Star` snapshot also exposed
+the existing finalizer's reload/fusion rewrites.
+
+§13.3.2.1 property-access evaluation, via §13.3.3
+EvaluatePropertyAccessWithExpressionKey, fixes the receiver value before
+evaluating the computed key. Cynic therefore normally snapshots a
+register-bound receiver before a key that may write a register. For the
+specific `receiver[++index]` / `receiver[index++]` / decrement shapes, the
+compiler can resolve both bindings before emission: when the receiver and
+updated binding are distinct initialized register slots, the update cannot
+clobber the receiver. Final bytecode consequently changes from
+
+    Mov r_receiver, r_tmp
+    IncReg r_index
+    LdaComputed8 r_tmp
+
+to
+
+    IncReg r_index
+    LdaComputed8 r_receiver
+
+with no new opcode or dispatch-table entry. Same-register updates such as
+`a[++a]`, assignments, member/destructuring targets, env/global/TDZ
+bindings, captured receivers, and optional chains retain the snapshot or
+nullish-short-circuit path. The receiver remains a frame-register GC root
+while `ToNumeric` re-enters JavaScript.
+
+Representative interpreter prior art keeps the evaluated receiver separate
+while the key is evaluated: V8 Ignition visits the base into a register,
+evaluates a keyed property expression into the accumulator, then issues
+`LoadKeyedProperty(obj)` ([source](https://github.com/v8/v8/blob/f4a59ca0ef1286ac4eccda99a90fccf1aea1ac93/src/interpreter/bytecode-generator.cc#L6503-L6547),
+[call site](https://github.com/v8/v8/blob/f4a59ca0ef1286ac4eccda99a90fccf1aea1ac93/src/interpreter/bytecode-generator.cc#L6835-L6842));
+Hermes HBC lowers a computed read to `GetByVal(result, obj, prop)`
+([source](https://github.com/facebook/hermes/blob/ccc2a2f35267d5009d3fb24b61120357cdba0acb/lib/BCGen/HBC/ISel.cpp#L750-L774));
+and QuickJS's `get_array_el` consumes distinct object and property stack
+operands ([source](https://github.com/bellard/quickjs/blob/04be246001599f5995fa2f2d8c91a0f198d3f34c/quickjs-opcode.h#L140-L142)).
+Cynic's narrower contribution is reusing an already-bound receiver register
+when a target-specific write proof makes the extra snapshot unnecessary.
+
+Forty paired Lantern-only runs in each launch order used exact non-stats
+baseline/candidate SHA-256 binaries `8c49a670` / `64fe2890`. The forward
+runner reports candidate/base, the swapped runner reports base/candidate, and
+the order-neutral candidate/base ratio is
+`sqrt((forward C/B) / (reverse B/C))`. A first run immediately after
+compilation showed process-wide spreads as high as 892% and was discarded in
+full. A fresh 40+40 run after the other local jobs settled was materially
+less distorted, though its per-workload spreads still ranged from 7.1% to
+91.2%:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 0.998x | 0.998x | 1.000x |
+| deltablue | 1.001x | 0.997x | 1.002x |
+| crypto | 1.000x | 1.008x | 0.996x |
+| raytrace | 1.005x | 1.005x | 1.000x |
+| navier_stokes | 0.977x | 1.033x | 0.973x |
+| splay | 1.018x | 1.001x | 1.008x |
+| **geomean** |  |  | **0.996x** |
+
+The order-neutral arm64 macro estimate is **0.9964x**. Given the retained
+spread, the sub-percent geomean is a no-regression signal rather than a
+precise speedup magnitude. Navier-Stokes measures **0.9725x** across the two
+roles, while the worst resolved workload estimate is Splay at **1.0085x**.
+
+The pinned-CPU x86_64 confirmation used exact base `339818b0` and
+candidate `70368694`, normal ReleaseFast CLI SHA-256 prefixes `08d68fa5` /
+`3700c82d`, and an exact-main benchmark driver (`0e7c03a3`). The driver and
+all child processes inherited `taskset -c 3`. Forty pairs in each physical
+launch role produced:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 0.999x | 1.024x | 0.988x |
+| deltablue | 0.979x | 1.009x | 0.985x |
+| crypto | 1.002x | 1.009x | 0.997x |
+| raytrace | 1.019x | 1.016x | 1.001x |
+| navier_stokes | 0.966x | 1.025x | 0.971x |
+| splay | 1.005x | 0.977x | 1.014x |
+| **geomean** |  |  | **0.993x** |
+
+The neutral x86_64 geometric-mean estimate is **0.9925x**. Navier-Stokes
+measures **0.9708x**, and the worst workload is Splay at **1.0142x**, below
+the 2% retention gate. A separate 20-pair run in each
+production-default-tier role measured a **0.9955x** neutral geometric mean;
+its per-workload neutral ratios were **0.995x, 1.000x, 0.993x, 1.003x,
+0.970x, and 1.012x**, respectively. Interpreter spreads remained
+19.4–45.2%, and default-tier spreads 13.6–38.8%, so these sub-percent
+geomeans are directional retention evidence, not precise effect sizes.
+Crucially, both launch roles independently show the targeted Navier-Stokes
+improvement and every order-neutral workload stays inside the 2% gate.
+
+Validation covered prefix/postfix increment and decrement code generation,
+same-register and assignment fallback, capture during key coercion, and
+forced-GC re-entry. All eight relevant non-cached test262 buckets had
+identical tallies and displayed runtime-failure sets across Lantern, forced
+Bistromath, and forced Ohaimark. The complete ReleaseSafe unit suite retained
+**3,341 pass / 261 intentional skips / 0 fail**. The non-cached full test262
+sweep retained **48,653 pass / 1,324 known fail**, plus ShadowRealm
+**63 / 1**.
+
 ### 2026-07-30 — finalized `StarLdar` store/load fusion, host `Darwin 25.6.0 arm64`
 
 Exact merged-main and final-candidate bytecode telemetry over the six macro

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -996,6 +996,18 @@ sampling by `/profile`.
   instructions **1,509 → 1,456** (-3.5%), encoded bytes **3,122 →
   3,067** (-1.8%), and dynamic dispatches **107,516,101 →
   104,678,462** (-2.64%).
+- **Target-specific computed-receiver register reuse (2026-07-30).** For a
+  non-optional computed read whose receiver is an initialized, uncaptured
+  register binding and whose direct `++` / `--` key updates a distinct
+  resolved register, the compiler reads the receiver in place instead of
+  snapshotting it through a temporary. Same-register, assignment, member,
+  env/global/TDZ, captured, and optional-chain shapes fail closed. This
+  preserves §13.3.2.1 ordering and keeps the receiver rooted across
+  `ToNumeric` re-entry without adding an opcode. Navier-Stokes logical
+  instructions fell **58,160,156 → 53,605,322 (-7.83%)**. Paired arm64 and
+  pinned x86_64 interpreter macro geometric means were **0.996x** and
+  **0.993x** as directional retention signals, with no resolved workload
+  regression over 2%. See `bench-results.md`.
 - **Finalized `StarLdar` store/load fusion (2026-07-30).** After finalized
   CFG/liveness analysis, adjacent distinct-register `Star dst; Ldar src`
   pairs whose load is not a branch, switch, or handler entry collapse into
@@ -1643,14 +1655,15 @@ not measurements.
 
 7. **Peephole + CFG/liveness re-emission — shipped foundation.**
    Emit-time specializations cover common constants, low registers,
-   arithmetic idioms, calls, and comparisons; jump threading runs
-   over logical branch patches. Finalized chunks get CFG/liveness-
-   guarded dead-store re-emission, redundant same-register store/reload
-   deletion, and distinct-register `star_ldar` fusion; a load that is a
-   branch, switch, or handler entry is retained. Re-emission repairs relaxed
-   branches, source positions, exception handlers, and switch targets. More
-   rewrites remain profile-driven; unknown register effects fail
-   closed and merely skip liveness-dependent passes.
+   arithmetic idioms, calls, comparisons, and target-specific reuse of a
+   register-bound computed receiver across a distinct-binding update key;
+   jump threading runs over logical branch patches. Finalized chunks get
+   CFG/liveness-guarded dead-store re-emission, redundant same-register
+   store/reload deletion, and distinct-register `star_ldar` fusion; a load
+   that is a branch, switch, or handler entry is retained. Re-emission
+   repairs relaxed branches, source positions, exception handlers, and
+   switch targets. More rewrites remain profile-driven; unknown register
+   effects fail closed and merely skip liveness-dependent passes.
 
 8. **Frame register pool — shipped** (`b38f125`). Every
    JS-function call site (`call`, `call_method`, `new_call`,

--- a/src/bytecode/compiler.zig
+++ b/src/bytecode/compiler.zig
@@ -3155,7 +3155,7 @@ pub const Compiler = struct {
                 // circuit, so it keeps the copy path.)
                 if (!m.optional) {
                     if (self.tryRegisterBoundIdent(m.object.*)) |r_src| {
-                        if (!self.exprMayWriteRegister(key_expr)) {
+                        if (!self.exprMayWriteTargetRegister(key_expr, r_src)) {
                             try self.compileExpression(key_expr);
                             try self.builder.emitLdaComputed(m.span, r_src);
                             return;
@@ -5558,6 +5558,22 @@ pub const Compiler = struct {
             .await_ => |aw| self.exprMayWriteRegister(aw.argument),
             .import_call => |ic| self.exprMayWriteRegister(ic.source),
         };
+    }
+
+    /// Narrow target-specific proof for the hot §13.3.2.1
+    /// `receiver[++index]` shape. A direct update of a different resolved
+    /// register cannot clobber `target`; every other assignment/update shape
+    /// stays on the conservative receiver-snapshot path.
+    fn exprMayWriteTargetRegister(
+        self: *Compiler,
+        e: *const ast.expression.Expression,
+        target: u8,
+    ) bool {
+        var unwrapped = e;
+        while (unwrapped.* == .parenthesized) unwrapped = unwrapped.parenthesized.expression;
+        if (unwrapped.* != .update) return self.exprMayWriteRegister(e);
+        const written = self.tryRegisterBoundIdent(unwrapped.update.operand.*) orelse return true;
+        return written == target;
     }
 
     /// Returns the int32 value when `expr` is a Smi-representable
@@ -15492,6 +15508,54 @@ test "compiler: computed access a[i] with register-bound receiver reads the sour
     try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r0") != null);
     // …and the receiver-copy Star is gone (the body has no other Star).
     try testing.expect(std.mem.indexOf(u8, t0, "Star ") == null);
+}
+
+test "compiler: computed access a[++i] keeps a distinct register receiver in place" {
+    // §13.3.2.1 evaluates the receiver before the key, but `++i` cannot
+    // clobber the distinct register-bound receiver `a`. Read `a` in place
+    // instead of snapshotting it through `Ldar; Star`.
+    const got = try dumpExpr("(function(a,i){ return a[++i]; })");
+    defer testing.allocator.free(got);
+    const t0 = t0Of(got);
+    try testing.expect(std.mem.indexOf(u8, t0, "IncReg r1") != null);
+    try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r0") != null);
+    try testing.expect(std.mem.indexOf(u8, t0, "Star ") == null);
+}
+
+test "compiler: computed access keeps receiver across distinct postfix and decrement updates" {
+    const cases = [_]struct { source: []const u8, update: []const u8 }{
+        .{ .source = "(function(a,i){ return a[i++]; })", .update = "PostIncReg r1" },
+        .{ .source = "(function(a,i){ return a[--i]; })", .update = "DecReg r1" },
+    };
+    for (cases) |case| {
+        const got = try dumpExpr(case.source);
+        defer testing.allocator.free(got);
+        const t0 = t0Of(got);
+        try testing.expect(std.mem.indexOf(u8, t0, case.update) != null);
+        try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r0") != null);
+        try testing.expect(std.mem.indexOf(u8, t0, "Star ") == null);
+    }
+}
+
+test "compiler: computed access a[++a] snapshots its same-register receiver" {
+    // The direct-update proof compares resolved register identity. Updating
+    // the receiver binding itself must keep the pre-key receiver in a temp.
+    const got = try dumpExpr("(function(a){ return a[++a]; })");
+    defer testing.allocator.free(got);
+    const t0 = t0Of(got);
+    try testing.expect(std.mem.indexOf(u8, t0, "IncReg r0") != null);
+    try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r0") == null);
+    try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r1") != null);
+}
+
+test "compiler: computed access a[a=other] snapshots a before its key clobbers the receiver" {
+    // The target-specific proof must retain §13.3.2.1 evaluation order when
+    // the computed key writes the receiver register itself.
+    const got = try dumpExpr("(function(a,other){ return a[a=other]; })");
+    defer testing.allocator.free(got);
+    const t0 = t0Of(got);
+    try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r0") == null);
+    try testing.expect(std.mem.indexOf(u8, t0, "LdaComputed8 r2") != null);
 }
 
 test "compiler: member store o.x=v with register-bound receiver stores to the source register (no Ldar;Star copy)" {

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1777,6 +1777,41 @@ test "reg-move: computed read of a register-bound receiver" {
     try expectScriptInt("(function(a,i){ return a[i]; })([10,20,30], 1);", 20);
 }
 
+test "reg-move: computed read keeps receiver across a distinct register update" {
+    try expectScriptInt("(function(a,i){ return a[++i]; })([10,20,30], 0);", 20);
+}
+
+test "reg-move: same-register key update reads the pre-update receiver" {
+    // §13.3.2.1 fixes the base before evaluating `++a`. The update replaces
+    // the binding with Number 1, but the property read still targets the
+    // original object.
+    try expectScriptIntWithBuiltins(
+        "(function(a){ return a[++a]; })({ 1: 42, valueOf(){ return 0; } });",
+        42,
+    );
+}
+
+test "reg-move: distinct key coercion keeps the source-register receiver rooted" {
+    // Removing the snapshot leaves `a` rooted in its parameter register while
+    // ToNumeric(i) re-enters JS and forces a collection.
+    try expectScriptIntWithBuiltins(
+        \\let index = { valueOf(){ __collectGarbage(); return 0; } };
+        \\(function(a,i){ return a[++i]; })([10,20,30], index);
+    , 20);
+}
+
+test "reg-move: captured receiver keeps its pre-key snapshot" {
+    // A receiver captured by the key's coercion callback is not register-bound.
+    // §13.3.2.1 therefore keeps the conservative snapshot before `++i` can
+    // re-enter JS and replace `a`.
+    try expectScriptInt(
+        \\(function(a,i){
+        \\  i.valueOf = function(){ a = { 1: 99 }; return 0; };
+        \\  return a[++i];
+        \\})({ 1: 42 }, {});
+    , 42);
+}
+
 test "reg-move: member store to a register-bound receiver" {
     try expectScriptInt("(function(o,v){ o.x = v; return o.x; })({}, 7);", 7);
 }


### PR DESCRIPTION
## Summary

- make computed-property receiver snapshotting target-specific for direct `++` / `--` keys
- reuse an initialized, uncaptured receiver register when the updated binding resolves to a distinct register
- retain the conservative path for same-register, assignment, member, env/global/TDZ, captured, and optional-chain cases
- add codegen, old-receiver, capture/re-entry, and forced-GC regressions
- record deterministic bytecode telemetry and paired arm64/x86_64 gates

## Why

`compileMember` previously snapshotted a register-bound receiver whenever the
computed key contained *any* register update. That preserves ECMA-262
§§13.3.2.1/13.3.3 ordering, but it is unnecessarily conservative for hot
shapes such as `a[++i]`: resolving `a` and `i` to distinct register slots
proves the key cannot clobber the receiver binding.

The narrow proof removes the temporary without adding an opcode. Ambiguous
cases fail closed, and the receiver remains rooted in its frame register
while `ToNumeric` can re-enter JavaScript.

## Performance

- Navier-Stokes logical instructions: **58,160,156 → 53,605,322** (**-7.83%**)
- static Navier bytecode: **1,934 → 1,916 instructions**, **4,546 → 4,499 bytes**
- quiet arm64 40+40 order-neutral macro estimate: **0.9964x**; Navier **0.9725x**; worst workload **1.0085x**
- CPU-pinned x86_64 40+40 order-neutral macro estimate: **0.9925x**; Navier **0.9708x**; worst workload **1.0142x**
- x86_64 production-tier 20+20 control: **0.9955x**

The wall-time spreads remain high enough that the sub-percent suite geomeans
are directional retention signals, not precise effect sizes. Both launch
roles independently show the targeted Navier improvement, and every neutral
workload stays within the 2% gate.

## Validation

- `zig build test-fast`: **3,341 pass / 261 intentional skips / 0 fail**
- focused compiler/runtime computed-access and register-move tests
- relevant non-cached test262 buckets matched merged main exactly
- relevant Lantern / forced-Bistromath / forced-Ohaimark tallies and displayed runtime-failure sets matched
- full non-cached test262: **48,653 pass / 1,324 known fail / 0 skip**
- ShadowRealm feature sweep: **63 pass / 1 known fail**
- independent source and benchmark-math review; `zig fmt --check` and `git diff --check` clean
