### PR TITLE
Thread hot Smi BitAnd successors

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,79 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-31 — width-gated Smi `BitAnd` successor threading, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
+
+Exact merged main `7b5a04e5` and the retained candidate used normal
+ReleaseFast CLI SHA-256 binaries `8673fc48` / `7240c01a`. Instrumented
+Crypto traces found **3,158,688** `LdaSmi16 -> BitAnd` pairs and
+**1,488,595** full-width `LdaSmi -> BitAnd` pairs. The candidate bypassed
+the indirect successor dispatch on **4,646,882** of them: **99.991%** of
+the eligible pairs and **5.176%** of Crypto's **89,774,038** logical
+instructions. The remaining 401 pairs had a non-Int32 left operand and
+correctly entered the ordinary coercion path.
+
+The bytecode and both JIT tiers remain unchanged. Lantern's existing merged
+Smi-load handler recognizes only full-width and 16-bit loads followed by
+`BitAnd`; compact `LdaSmi8` is deliberately excluded because Splay executes
+it 2,084,482 times without a useful successor. On an Int32 left operand the
+load handler runs the same pure integer AND and consumes the successor opcode
+plus register operand. A Double, coercible object, or BigInt leaves `ip` on
+`BitAnd`, so its established ToNumeric / BigInt / throw path remains the sole
+slow implementation. `observeDirectActive` records the skipped opcode before
+ordinary decoding resumes, preserving logical telemetry.
+
+After normalizing only `direct-transfers`, the complete baseline/candidate
+Crypto reports are byte-identical: same static bytecode, dynamic instruction
+total, every opcode/pair/trigram row, and zero dropped sequences.
+`direct-transfers` moves **634,631 -> 5,281,513**, exactly the **4,646,882**
+new Int32 hits. The unlikely branch hint keeps the grouped load handler's
+dominant `LdaSmi8` / non-`BitAnd` decode path biased toward fallthrough. The
+native cost is **96 bytes**: `runFrames` **334,000 -> 334,096 bytes** and
+ELF `.text` **4,087,299 -> 4,087,395 bytes**.
+
+Forty paired Lantern-only runs in each physical launch role pinned the driver
+and every child process to CPU 3. Forward is candidate/base, reverse is
+base/candidate after swapping the physical binaries, and neutral is
+`sqrt(forward / reverse)`:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 0.937x | 1.057x | 0.942x |
+| deltablue | 0.985x | 1.007x | 0.989x |
+| crypto | 0.974x | 1.022x | 0.976x |
+| raytrace | 0.964x | 1.035x | 0.965x |
+| navier_stokes | 1.013x | 1.011x | 1.001x |
+| splay | 1.002x | 0.991x | 1.006x |
+| **geomean** |  |  | **0.979x** |
+
+The order-neutral macro geometric mean is **0.9795x**, about **2.05%**
+faster, and no workload crosses the 2% regression gate. Separate 60+60
+targeted runs measured Crypto **0.9710x** and the zero-hit `arith_loop`
+control **0.9895x**. Sixty-pair confirmations of the two layout watchpoints
+measured DeltaBlue **0.9881x** and Splay **1.0095x**.
+
+The small final shape matters. A V8-Ignition-style accumulator-immediate
+opcode family was prototyped (Ignition ships `BitwiseAndSmi`,
+`BitwiseOrSmi`, `BitwiseXorSmi`, and the three Smi shifts
+[in its bytecode set](https://github.com/v8/v8/blob/d405ed7c7b8141bb435ed5cf651163fa32e0d11a/src/interpreter/bytecodes.h#L225-L268)),
+but Cynic's appended handler regressed a zero-hit `arith_loop` control by
+**4.01%** and was rejected. Splitting `LdaSmi16` into a direct cross-handler
+edge triggered a whole-function LLVM phase change, grew `runFrames` by
+7,120 bytes, and regressed Navier-Stokes by **4.12%**. The first compact
+in-arm hybrid stayed at +96 bytes but regressed DeltaBlue by **3.00%**;
+retaining the normal decode path as the hinted fallthrough produced the
+gated result above. These rejected rungs are why wall-time and native-layout
+checks, not dispatch-count reduction alone, decide retention.
+
+Validation on the locked final snapshot covered both threaded widths, the
+deliberately ordinary Smi8 path, Int32 and Double operands, one-shot object
+coercion, a caught coercion throw, logical telemetry, and allocation-pressure
+GC. The complete ReleaseSafe unit suite passed **3,184 tests** with **464
+intentional skips**. Exact-main and candidate `bitwise-and` test262 pass
+lists were identical at **29 pass / 1 known fail**, including under
+`gc-threshold=1`. The required non-cached full sweep retained **48,653 pass /
+1,324 fail**, plus ShadowRealm **63 / 1**, with no pass-count change.
+
 ### 2026-07-30 — target-specific computed-receiver register reuse, host `Darwin 25.6.0 arm64`
 
 Exact stats-enabled ReleaseFast binaries from merged main `339818b0` and the

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1062,6 +1062,18 @@ sampling by `/profile`.
   measured **0.981x / 0.979x** interpreter macro geometric means on pinned
   x86_64 and **0.9952x / 0.9957x** on arm64. The arm64 production-tier
   control measured **0.9937x**. See `bench-results.md`.
+- **Width-gated Smi `BitAnd` successor threading (2026-07-31).** Lantern's
+  merged Smi-load handler now recognizes full-width / i16 integer masks
+  followed by `BitAnd` and executes the shared Int32 operation before the
+  next indirect dispatch. `LdaSmi8` is excluded to protect Splay's two
+  million nonmatching compact loads; non-Int32 left operands leave `ip` on
+  the ordinary `BitAnd` coercion / BigInt / throw path. Bytecode and both JIT
+  tiers are unchanged, and logical stats remain exactly comparable. Crypto
+  records **4,646,882** new direct transfers (**5.176%** of its logical
+  instructions), while the final native delta is 96 bytes. A pinned x86_64
+  40+40 forward/reverse A/B measured an order-neutral **0.9795x**
+  interpreter macro geometric mean, with no workload regression above 2%;
+  targeted Crypto measured **0.9710x**. See `bench-results.md`.
 - **Impossible property-probe gates (2026-07-30).** Strict property writes now
   reject keys that cannot begin a §7.1.21 canonical numeric spelling, walk to
   the first TypedArray ancestor, and only then pay for numeric parsing and

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1556,6 +1556,32 @@ pub fn runFrames(
             };
             ip += op_tag.operandSize();
             acc = Value.fromInt32(imm);
+
+            // Dense integer masks followed by BitAnd dominate the full-width
+            // and 16-bit Smi loads in the macro corpus. Thread their pure
+            // int32 fast path here while preserving the ordinary bytecode for
+            // both JIT tiers. Deliberately exclude LdaSmi8: Splay executes it
+            // over two million times without a useful BitAnd successor.
+            //
+            // If the LHS is not an Int32 (a Double, coercible object, or
+            // BigInt), leave `ip` on BitAnd so its existing slow path remains
+            // the sole conversion / re-entry / exception implementation.
+            if (op_tag != .lda_smi8 and
+                ip + 1 < code.len and
+                code[ip] == @intFromEnum(Op.bit_and))
+            {
+                // The grouped load arm is dominated overall by LdaSmi8 and
+                // non-BitAnd successors. Bias their ordinary decode path
+                // toward the laid-out fallthrough; matching masks take this
+                // side edge and remain highly predictable inside Crypto.
+                @branchHint(.unlikely);
+                const r = code[ip + 1];
+                if (intBitwise(.band, registers[r], acc)) |res| {
+                    ip += 2;
+                    if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.bit_and);
+                    acc = res;
+                }
+            }
             continue :dispatch try decodeNext(code, &ip, &committed);
         },
         .lda_constant => {

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1692,6 +1692,97 @@ test "lda_this property direct threading: instrumented run records transfer" {
     );
 }
 
+// §13.15 ApplyStringOrNumericBinaryOperator / §13.10 shift operators.
+// Exact integer RHS literals use width-specific loads. Lantern threads the
+// `LdaSmi16; BitAnd` and full-width `LdaSmi; BitAnd` int32 fast paths while
+// preserving the ordinary bytecode stream for both JIT tiers.
+test "smi16 bit-and direct threading: instrumented run records transfer" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        \\function f(x) {
+        \\  const masked = x & 32767;
+        \\  const right = x >> 7;
+        \\  const left = x << 3;
+        \\  return masked + right + left;
+        \\}
+        \\f(257);
+    , 2315);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi16, .bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shr));
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shl));
+    try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+}
+
+test "full-width smi bit-and direct threading: instrumented run records transfer" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        \\function f(x) { return x & 16777215; }
+        \\f(16777217);
+    , 1);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi, .bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+}
+
+test "smi8 bit-and direct threading: compact masks stay on ordinary dispatch" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        \\function f(x) { return x & 7; }
+        \\f(9);
+    , 1);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .bit_and));
+    try testing.expectEqual(@as(u64, 0), stats.direct_transfers);
+}
+
+test "smi bit-and direct threading: slow coercion and caught throw stay exact" {
+    // The integer calls take the two inline width paths. The Double and
+    // object calls decline them with `ip` still on BitAnd, then enter the
+    // ordinary handler. Pin successful JS re-entry and exception unwinding
+    // so the optimization cannot accidentally skip or repeat ToNumeric
+    // effects.
+    try expectScriptStringWithBuiltins(
+        \\let calls = 0;
+        \\function mask(x) { return x & 32767; }
+        \\function wide(x) { return x & 16777215; }
+        \\const maskValue = {
+        \\  valueOf() { calls = calls + 1; return 32769; }
+        \\};
+        \\const wideValue = {
+        \\  valueOf() { calls = calls + 1; return 16777217; }
+        \\};
+        \\const integer = mask(32769);
+        \\const wideInteger = wide(16777217);
+        \\const doubled = mask(32769.9);
+        \\const masked = mask(maskValue);
+        \\const wideMasked = wide(wideValue);
+        \\let caught = 0;
+        \\try {
+        \\  mask({ valueOf() { throw 9; } });
+        \\} catch (e) {
+        \\  caught = e;
+        \\}
+        \\integer + ":" + wideInteger + ":" + doubled + ":" + masked + ":" +
+        \\  wideMasked + ":" + calls + ":" + caught;
+    , "1:1:1:1:1:2:9");
+}
+
 test "lda_this property direct threading: own data property" {
     try expectScriptIntWithBuiltins(
         "function read(){ return this.x; } let o = { x: 20 }; let first = read.call(o); o.x = 22; first + read.call(o);",

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1716,6 +1716,8 @@ test "smi16 bit-and direct threading: instrumented run records transfer" {
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi16, .bit_and));
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shr));
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shl));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.bit_and));
+    try testing.expectEqual(@as(u64, 0), stats.pairCount(.bit_and, .bit_and));
     try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
 }
 
@@ -1732,6 +1734,8 @@ test "full-width smi bit-and direct threading: instrumented run records transfer
     , 1);
 
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi, .bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.bit_and));
+    try testing.expectEqual(@as(u64, 0), stats.pairCount(.bit_and, .bit_and));
     try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
 }
 
@@ -1767,20 +1771,35 @@ test "smi bit-and direct threading: slow coercion and caught throw stay exact" {
         \\const wideValue = {
         \\  valueOf() { calls = calls + 1; return 16777217; }
         \\};
+        \\const gcValue = {
+        \\  valueOf() {
+        \\    calls = calls + 1;
+        \\    __collectGarbage();
+        \\    return 32769;
+        \\  }
+        \\};
         \\const integer = mask(32769);
         \\const wideInteger = wide(16777217);
         \\const doubled = mask(32769.9);
         \\const masked = mask(maskValue);
         \\const wideMasked = wide(wideValue);
+        \\const gcMasked = mask(gcValue);
         \\let caught = 0;
         \\try {
         \\  mask({ valueOf() { throw 9; } });
         \\} catch (e) {
         \\  caught = e;
         \\}
+        \\let bigintError = "none";
+        \\try {
+        \\  mask(1n);
+        \\} catch (e) {
+        \\  bigintError = e.constructor.name;
+        \\}
         \\integer + ":" + wideInteger + ":" + doubled + ":" + masked + ":" +
-        \\  wideMasked + ":" + calls + ":" + caught;
-    , "1:1:1:1:1:2:9");
+        \\  wideMasked + ":" + gcMasked + ":" + calls + ":" + caught + ":" +
+        \\  bigintError;
+    , "1:1:1:1:1:1:3:9:TypeError");
 }
 
 test "lda_this property direct threading: own data property" {

--- a/test262-results.md
+++ b/test262-results.md
@@ -136,6 +136,20 @@ top-line score.
 
 ## History
 
+### 2026-07-31 — cynic `7b5a04e`, test262 `de8e621c`
+
+| passing | failing | total | pass% | Δ pass | elapsed |
+|---:|---:|---:|---:|---:|---:|
+| 48653 | 1324 | 49977 | 97.35 % | ±0 | 1m 50s |
+
+Biggest movers:
+
+- `built-ins/Temporal` +4603
+- `built-ins/Date` +594
+- `built-ins/DataView` +550
+- `built-ins/Iterator` +514
+- `built-ins/Atomics` +381
+
 ### 2026-07-29 — cynic `654fc093`, test262 `de8e621cdb`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
@@ -147,14 +161,6 @@ top-line score.
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 48653 | 1324 | 49977 | 97.35 % | ±0 | 2m 00s |
-
-Biggest movers:
-
-- `built-ins/Temporal` +4603
-- `built-ins/Date` +594
-- `built-ins/DataView` +550
-- `built-ins/Iterator` +514
-- `built-ins/Atomics` +381
 
 ### 2026-07-08 — cynic `05c71887`, test262 `de8e621cdb`
 

--- a/test262-results.md
+++ b/test262-results.md
@@ -136,19 +136,11 @@ top-line score.
 
 ## History
 
-### 2026-07-31 — cynic `7b5a04e`, test262 `de8e621c`
+### 2026-07-31 — cynic `9c6a451`, test262 `de8e621c`
 
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 48653 | 1324 | 49977 | 97.35 % | ±0 | 1m 50s |
-
-Biggest movers:
-
-- `built-ins/Temporal` +4603
-- `built-ins/Date` +594
-- `built-ins/DataView` +550
-- `built-ins/Iterator` +514
-- `built-ins/Atomics` +381
 
 ### 2026-07-29 — cynic `654fc093`, test262 `de8e621cdb`
 
@@ -161,6 +153,14 @@ Biggest movers:
 | passing | failing | total | pass% | Δ pass | elapsed |
 |---:|---:|---:|---:|---:|---:|
 | 48653 | 1324 | 49977 | 97.35 % | ±0 | 2m 00s |
+
+Biggest movers:
+
+- `built-ins/Temporal` +4603
+- `built-ins/Date` +594
+- `built-ins/DataView` +550
+- `built-ins/Iterator` +514
+- `built-ins/Atomics` +381
 
 ### 2026-07-08 — cynic `05c71887`, test262 `de8e621cdb`
 


### PR DESCRIPTION
## Summary

- Thread full-width and i16 Smi `BitAnd` successors through Lantern's existing Int32 fast path.
- Preserve the ordinary bytecode and both JIT tiers; non-Int32 operands still use the canonical coercion/BigInt/throw path.
- Deliberately exclude `LdaSmi8` to avoid charging Splay's 2.08 million nonmatching compact loads.
- Add direct-transfer, exclusion, Double, coercion, and caught-throw coverage plus benchmark and conformance history.

## Why

Crypto executes 3,158,688 `LdaSmi16 -> BitAnd` pairs and 1,488,595 full-width `LdaSmi -> BitAnd` pairs. The retained implementation bypasses 4,646,882 indirect successor dispatches while keeping all logical bytecode telemetry unchanged.

Broader opcode and split-handler prototypes were rejected because they regressed zero-hit workloads or caused a whole-function LLVM layout phase change. The retained in-arm hybrid adds only 96 native bytes and uses an unlikely side edge so the dominant ordinary decode path remains favored.

## Performance

Pinned x86_64, CPU 3, 40+40 paired physical roles:

- six-macro neutral geometric mean: `0.9795x` (2.05% faster)
- targeted Crypto 60+60: `0.9710x`
- zero-hit `arith_loop` 60+60: `0.9895x`
- worst macro: Splay `1.0055x`
- 60+60 confirmations: DeltaBlue `0.9881x`, Splay `1.0095x`

No workload crossed the 2% regression ceiling.

## Validation

- Focused bytecode-stats/coercion tests: 4/4 pass
- Full ReleaseSafe units: 3,184 pass, 464 intentional skips
- Exact-main/candidate `bitwise-and` test262 pass lists: identical at 29 pass / 1 known fail
- ReleaseSafe `gc-threshold=1` bitwise-and sweep: identical 29/1 result
- Full non-cached test262: 48,653 pass / 1,324 fail, no change
- ShadowRealm sweep: 63 pass / 1 fail, no change
- Complete Crypto stats reports are byte-identical after normalizing only `direct-transfers`
