### PR TITLE
Thread compact Smi Shr successors

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,69 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-07-31 — compact Smi `Shr` successor threading, host `Darwin 25.6.0 arm64`
+
+Exact merged main `2758c530` and the retained candidate used normal
+ReleaseFast CLI SHA-256 binaries `42b8d24d` / `727c3c2d`. Instrumented
+Crypto traces found **4,646,114** `LdaSmi8 -> Shr` pairs: **5.175%** of
+Crypto's **89,774,038** logical instructions, **73.663%** of its compact
+Smi loads, and **99.936%** of its `Shr` executions. A temporary eligibility
+probe found **4,645,838** Int32 hits and only **276** slow-path declines
+(**99.994%** eligible). Splay executed **2,084,482** compact Smi loads but
+zero matching `Shr` successors.
+
+Lantern's existing merged Smi-load handler now recognizes only
+`LdaSmi8; Shr`. When the left operand is already Int32, it runs the shared
+signed-shift operation and consumes the successor opcode plus register
+operand. A Double, coercible object, or BigInt leaves `ip` on `Shr`, so the
+ordinary handler remains the sole ToNumeric / re-entry / mixed-numeric /
+throw implementation. The ordinary decode path remains the hinted
+fallthrough for Splay's zero-hit compact loads. Bytecode and both JIT tiers
+are unchanged.
+
+After normalizing only `direct-transfers`, the complete baseline/candidate
+Crypto telemetry reports are byte-identical: the dynamic instruction total
+and every opcode, pair, and trigram count remain exact, with no dropped
+sequences. `direct-transfers` moves **5,281,513 -> 9,927,351**, exactly the
+**4,645,838** new Int32 hits. The native cost is **52 bytes** in `runFrames`
+(**344,996 -> 345,048**) and **48 bytes** in Mach-O `__TEXT`
+(**5,095,536 -> 5,095,584**).
+
+The pinned x86_64 bench host was unreachable for three SSH attempts, so the
+retention gate used forty paired Lantern-only runs in each physical launch
+role on the local arm64 host. Forward is candidate/base, reverse is
+base/candidate after swapping the physical binaries, and neutral is
+`sqrt(forward / reverse)`:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 0.990x | 1.003x | 0.993x |
+| deltablue | 1.002x | 1.005x | 0.999x |
+| crypto | 0.959x | 1.056x | 0.953x |
+| raytrace | 0.982x | 1.021x | 0.981x |
+| navier_stokes | 0.984x | 1.022x | 0.981x |
+| splay | 0.994x | 1.018x | 0.988x |
+| **geomean** |  |  | **0.982x** |
+
+The order-neutral macro geometric mean is **0.9824x**, about **1.76%**
+faster, and every resolved workload is below 1.0x. Separate 60+60 targeted
+runs measured Crypto **0.9484x**, the zero-hit Splay watchpoint **0.9865x**,
+DeltaBlue **1.0100x**, and the zero-hit `arith_loop` control **1.0055x**;
+all pass the 2% regression gate. Local pair spreads were high, so the
+sub-percent control results and aggregate magnitude are directional rather
+than precise; the targeted and compute-six Crypto estimates agree on the
+material win.
+
+Validation pins modulo-32 shift counts, signed fill, operand order, exact
+logical telemetry, the deliberately ordinary wider-immediate path, and
+coexistence with the existing width-gated `BitAnd` transfer. Slow-path tests
+cover Double and object coercion, forced-GC re-entry, a caught coercion throw,
+and mixed BigInt/Number rejection. The complete ReleaseSafe unit suite
+passed. Exact-main and candidate right-shift test262 runs matched at **36
+pass / 1 known fail**, including the candidate at `gc-threshold=1`. The
+required non-cached full main sweep retained **48,653 pass / 1,324 known
+fail** in 65 seconds with no guard failure.
+
 ### 2026-07-31 — width-gated Smi `BitAnd` successor threading, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Exact merged main `7b5a04e5` and the retained candidate used normal

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1074,6 +1074,19 @@ sampling by `/profile`.
   40+40 forward/reverse A/B measured an order-neutral **0.9795x**
   interpreter macro geometric mean, with no workload regression above 2%;
   targeted Crypto measured **0.9710x**. See `bench-results.md`.
+- **Compact Smi `Shr` successor threading (2026-07-31).** Crypto telemetry
+  found **4,646,114** `LdaSmi8 -> Shr` transitions, **5.175%** of all logical
+  instructions; **4,645,838** (**99.994%**) had an Int32 left operand. The
+  merged Smi-load handler now executes those signed shifts before the next
+  indirect dispatch, while non-Int32 operands leave `ip` on the ordinary
+  ToNumeric / BigInt / throw path. Splay's **2,084,482** zero-hit compact
+  loads retain ordinary decode as the hinted fallthrough. Bytecode, logical
+  telemetry, and both JIT tiers remain unchanged; `runFrames` grows 52 bytes.
+  A 40+40 role-swapped arm64 A/B measured an order-neutral **0.9824x** macro
+  geometric mean and **0.9530x** on Crypto, with every workload below 1.0x.
+  A separate 60+60 Crypto confirmation measured **0.9484x**; Splay,
+  DeltaBlue, and `arith_loop` controls stayed inside the 2% gate. See
+  `bench-results.md`.
 - **Impossible property-probe gates (2026-07-30).** Strict property writes now
   reject keys that cannot begin a §7.1.21 canonical numeric spelling, walk to
   the first TypedArray ancestor, and only then pay for numeric parsing and

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1557,23 +1557,31 @@ pub fn runFrames(
             ip += op_tag.operandSize();
             acc = Value.fromInt32(imm);
 
-            // Dense integer masks followed by BitAnd dominate the full-width
-            // and 16-bit Smi loads in the macro corpus. Thread their pure
-            // int32 fast path here while preserving the ordinary bytecode for
-            // both JIT tiers. Deliberately exclude LdaSmi8: Splay executes it
-            // over two million times without a useful BitAnd successor.
+            // Compact signed shifts and dense integer masks dominate their
+            // respective Smi widths in the macro corpus. Thread the pure
+            // int32 fast paths here while preserving the ordinary bytecode
+            // for both JIT tiers.
             //
             // If the LHS is not an Int32 (a Double, coercible object, or
-            // BigInt), leave `ip` on BitAnd so its existing slow path remains
-            // the sole conversion / re-entry / exception implementation.
-            if (op_tag != .lda_smi8 and
-                ip + 1 < code.len and
-                code[ip] == @intFromEnum(Op.bit_and))
-            {
-                // The grouped load arm is dominated overall by LdaSmi8 and
-                // non-BitAnd successors. Bias their ordinary decode path
-                // toward the laid-out fallthrough; matching masks take this
-                // side edge and remain highly predictable inside Crypto.
+            // BigInt), leave `ip` on the successor so its existing slow path
+            // remains the sole conversion / re-entry / exception
+            // implementation.
+            if (op_tag == .lda_smi8) {
+                if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.shr)) {
+                    // Splay executes over two million compact loads without
+                    // this successor. Keep ordinary decode as fallthrough;
+                    // matching Crypto shifts take the predictable side edge.
+                    @branchHint(.unlikely);
+                    const r = code[ip + 1];
+                    if (intBitwise(.shr, registers[r], acc)) |res| {
+                        ip += 2;
+                        if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.shr);
+                        acc = res;
+                    }
+                }
+            } else if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.bit_and)) {
+                // Bias ordinary decode toward the laid-out fallthrough;
+                // matching masks remain highly predictable inside Crypto.
                 @branchHint(.unlikely);
                 const r = code[ip + 1];
                 if (intBitwise(.band, registers[r], acc)) |res| {

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1694,8 +1694,9 @@ test "lda_this property direct threading: instrumented run records transfer" {
 
 // §13.15 ApplyStringOrNumericBinaryOperator / §13.10 shift operators.
 // Exact integer RHS literals use width-specific loads. Lantern threads the
-// `LdaSmi16; BitAnd` and full-width `LdaSmi; BitAnd` int32 fast paths while
-// preserving the ordinary bytecode stream for both JIT tiers.
+// compact `LdaSmi8; Shr`, `LdaSmi16; BitAnd`, and full-width
+// `LdaSmi; BitAnd` int32 fast paths while preserving the ordinary bytecode
+// stream for both JIT tiers.
 test "smi16 bit-and direct threading: instrumented run records transfer" {
     if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
 
@@ -1706,19 +1707,107 @@ test "smi16 bit-and direct threading: instrumented run records transfer" {
     try expectScriptInt(
         \\function f(x) {
         \\  const masked = x & 32767;
-        \\  const right = x >> 7;
+        \\  const right = x >> 39;
         \\  const left = x << 3;
-        \\  return masked + right + left;
+        \\  const unsigned = x >>> 39;
+        \\  return masked + right + left + unsigned;
         \\}
-        \\f(257);
-    , 2315);
+        \\f(-257);
+    , 33584881);
 
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi16, .bit_and));
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shr));
     try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shl));
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shr_u));
     try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.shr));
     try testing.expectEqual(@as(u64, 0), stats.pairCount(.bit_and, .bit_and));
+    try testing.expectEqual(@as(u64, 0), stats.pairCount(.shr, .shr));
+    try testing.expectEqual(@as(u64, 2), stats.direct_transfers);
+}
+
+test "smi8 shr direct threading: instrumented run records one transfer" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    // The result pins operand order, modulo-32 shift counts, and signed fill:
+    // -257 >> 39 is -3, while 39 >> -257 is 0.
+    try expectScriptInt(
+        \\function f(x) { return x >> 39; }
+        \\f(-257);
+    , -3);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .shr));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.shr));
+    try testing.expectEqual(@as(u64, 0), stats.pairCount(.shr, .shr));
     try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+}
+
+test "smi8 shr direct threading: wider shift immediates stay ordinary" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        \\function wide(x) { return x >> 128; }
+        \\wide(257);
+    , 257);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi16, .shr));
+    try testing.expectEqual(@as(u64, 0), stats.direct_transfers);
+}
+
+test "smi8 shr direct threading: slow coercion and caught throw stay exact" {
+    // Int32 takes the inline path. Double, object, and BigInt calls must
+    // decline it with `ip` still on Shr so the ordinary handler alone owns
+    // ToNumeric re-entry, GC rooting, mixed-numeric rejection, and unwind.
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptStringUnderGcPressure(
+        \\let trace = "";
+        \\function shift(x) { return x >> 39; }
+        \\const value = {
+        \\  valueOf() { trace += "O"; return -1024; }
+        \\};
+        \\const gcValue = {
+        \\  valueOf() {
+        \\    trace += "G";
+        \\    __collectGarbage();
+        \\    return 1024;
+        \\  }
+        \\};
+        \\const doubled = shift(1024.9);
+        \\const shifted = shift(value);
+        \\const gcShifted = shift(gcValue);
+        \\let caught = 0;
+        \\try {
+        \\  shift({ valueOf() { trace += "T"; throw 9; } });
+        \\} catch (e) {
+        \\  caught = e;
+        \\}
+        \\let bigintError = "none";
+        \\try {
+        \\  shift(1n);
+        \\} catch (e) {
+        \\  bigintError = e.constructor.name;
+        \\}
+        \\doubled + ":" + shifted + ":" + gcShifted + ":" + trace + ":" +
+        \\  caught + ":" + bigintError;
+    , "8:-8:8:OGT:9:TypeError");
+
+    if (comptime bytecode_stats.enabled) {
+        try testing.expectEqual(@as(u64, 5), stats.pairCount(.lda_smi8, .shr));
+        try testing.expectEqual(@as(u64, 5), stats.opcodeCount(.shr));
+        try testing.expectEqual(@as(u64, 0), stats.pairCount(.shr, .shr));
+        try testing.expectEqual(@as(u64, 0), stats.direct_transfers);
+    }
 }
 
 test "full-width smi bit-and direct threading: instrumented run records transfer" {


### PR DESCRIPTION
## Summary

- Thread the measured `LdaSmi8; Shr` Int32 successor inside Lantern's existing merged Smi-load handler.
- Preserve the ordinary `Shr` handler as the sole non-Int32 coercion, re-entry, BigInt, and exception path.
- Keep bytecode and both JIT tiers unchanged while preserving logical opcode/pair/trigram telemetry.
- Add adversarial fast/slow-path tests and record the telemetry, native-size, and A/B retention evidence.

## Why

Crypto executes 4,646,114 `LdaSmi8 -> Shr` pairs (5.175% of its 89,774,038 logical instructions). A temporary eligibility probe found 4,645,838 Int32 hits and only 276 declines (99.994% eligible). Splay executes 2,084,482 compact Smi loads but no matching successors, so ordinary decode remains the hinted fallthrough.

## Performance

- 40+40 role-swapped arm64 compute-six: **0.9824x** order-neutral geometric mean; every workload below 1.0x.
- 60+60 targeted Crypto: **0.9484x**; Splay, DeltaBlue, and `arith_loop` controls remained within the 2% gate.
- Logical telemetry is identical after normalizing only `direct-transfers`; the counter rises by exactly 4,645,838.
- Native cost: **+52 bytes** in `runFrames`, **+48 bytes** in Mach-O `__TEXT`.

The pinned x86_64 bench host was unreachable for three SSH attempts, so the retained wall-time evidence is explicitly role-swapped arm64. Local spreads make sub-percent controls directional; the targeted and compute-six Crypto estimates agree on the material win.

## Validation

- `zig build test-fast`
- `zig build test-fast -Dbytecode-stats=true -Dtest-filter='smi8 shr direct threading'`
- right-shift test262 baseline/candidate parity: **36 pass / 1 known fail**, including candidate `--gc-threshold=1`
- guarded non-cached full main test262: **48,653 pass / 1,324 known fail**, no guard failure
- `zig fmt --check src/runtime/lantern/interpreter.zig src/runtime/lantern/tests.zig`
- `git diff --check`

Three independent final reviews covered runtime/GC/IP safety, test completeness, and benchmark arithmetic/provenance; all returned no actionable findings.
