### PR TITLE
Raise WASM smoke timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,12 +199,13 @@ jobs:
   wasm-build:
     name: WASM build smoke
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     # Catches freestanding-incompatible regressions before they
     # hit `gh-pages` on merge. Builds without `wasm-opt` (no
-    # Binaryen download, ~6 min cold → ~3 min); the post-merge
-    # `playground.yml` re-builds with `wasm-opt -Oz` for the
-    # deploy. We just want the compile signal.
+    # Binaryen download); recent PR runs take ~10–14 min, so the
+    # budget leaves headroom for normal runner/cache variance. The
+    # post-merge `playground.yml` re-builds with `wasm-opt -Oz`
+    # for the deploy. We just want the compile signal.
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2


### PR DESCRIPTION
## Summary

- raise the `wasm-build` job timeout from 15 to 20 minutes
- update the stale timing comment to reflect recent PR runs

## Why

Recent successful `zig build wasm` PR jobs take roughly 10–14 minutes. A PR #91 attempt reached the exact 15-minute budget without a build diagnostic, while an isolated retry completed in 13m57s; a recent main run also hit the same timeout. This leaves too little allowance for ordinary runner and cache variance.

The 20-minute limit retains a finite hang bound while avoiding these false cancellations. This changes CI only; runtime and product behavior are untouched.

## Checks

- `actionlint -color`
- `git diff --check`
- independent subagent review: no actionable findings
