### PR TITLE
Thread compact Smi stores

### DIFF
--- a/bench-results.md
+++ b/bench-results.md
@@ -17,6 +17,72 @@ new run against the previous section with the *same host*.
 
 ## History
 
+### 2026-08-04 — compact Smi `Star` successor threading, host `Linux 6.8.0-136-generic x86_64` (remote bench box)
+
+Exact merged main `c0b3c866` and candidate `09177511` used unchanged
+bytecode and JIT input. Instrumented Splay traces found **2,068,480**
+`LdaSmi8 -> Star` pairs: **99.232%** of its **2,084,482** compact Smi
+loads and **9.717%** of **21,287,879** logical instructions. The remaining
+16,002 compact loads retain ordinary decode.
+
+Lantern's merged Smi-load handler now recognizes only the operand-bearing
+general `Star` successor after checking the existing compact `Shr` edge. It
+writes the already-boxed Int32 accumulator to the successor's frame register,
+advances over the opcode and register operand, records the logical `Star`, and
+resumes at the shared decoder. `Star` preserves the accumulator and this path
+cannot allocate, re-enter JavaScript, throw, or decline. Compact `Star0..3`
+and `StarLdar` remain ordinary; bytecode, Bistromath, and Ohaimark are
+unchanged. The normal decoder stays the statically hinted fallthrough across
+the wider Smi family so unrelated successor layouts do not move.
+
+After normalizing only `direct-transfers`, the complete baseline/candidate
+Splay telemetry reports have the same SHA-256
+(`6f8aa5f5d1983c26574da8e0f88805476ff72610bf61faaf0d18a53aa7dd84a1`):
+identical output, static bytecode, logical instruction total, every
+opcode/pair/trigram row, and zero dropped sequences. Direct transfers move
+**98,392 -> 2,166,872**, exactly the **2,068,480** measured pairs. The final
+local arm64 native snapshot is slightly smaller: `runFrames` **345,048 -> 345,028**
+bytes (**-20**) and Mach-O `__TEXT` **5,095,584 -> 5,095,568** (**-16**).
+
+A first local 61-pair run in each physical launch role was discarded in full:
+Splay reported forward candidate/base **1.052x** at **160.4%** spread and
+reverse base/candidate **0.996x** at **26.4%** spread, a nominal neutral
+**1.0277x** in two different absolute timing regimes (269-300 ms versus
+~176 ms).
+The retained gate therefore used 41 interleaved pairs in each launch role on
+the remote box. The odd sample count avoids the current driver's even-N
+upper-middle selection. Forward is candidate/base, reverse is base/candidate,
+and neutral is `sqrt(forward / reverse)`:
+
+| bench | forward C/B | reverse B/C | neutral C/B |
+|---|---:|---:|---:|
+| richards | 0.998x | 1.010x | 0.994x |
+| deltablue | 1.002x | 1.015x | 0.994x |
+| crypto | 0.990x | 1.010x | 0.990x |
+| raytrace | 0.996x | 1.011x | 0.993x |
+| navier_stokes | 1.021x | 0.997x | 1.012x |
+| splay | 0.990x | 1.014x | 0.988x |
+| **geomean** |  |  | **0.995x** |
+
+The interpreter macro geometric mean is **0.9950x**. Targeted Splay is
+**0.9881x** (about **1.19%** faster), with both launch roles independently
+agreeing on the direction. The worst control is Navier-Stokes at **1.0120x**,
+inside the 2% retention gate. The production-default-tier control is flat:
+**0.9998x** geometric mean, Splay **0.9909x**, and worst fixture Crypto
+**1.0139x**. Remote ratio spreads remain high (17.0-47.7%), so the sub-percent
+aggregate is a directional retention signal rather than a precise magnitude;
+the target's two-role agreement, exact dispatch opportunity, small native
+shape, and bounded controls decide retention.
+
+Validation pins the register write, accumulator preservation, exact logical
+pair/trigram telemetry, one transfer per general `Star`, and deliberately
+ordinary `Star0..3` controls. Focused normal and stats-enabled tests passed,
+as did the wider instrumented Smi bucket. Non-cached test262 `language/`
+counts matched exact main at **22,122 pass / 1,070 known fail**. PR CI passed
+all 34 checks, including ReleaseSafe unit tests, cross-builds, full
+conformance/RSS, GC stress, JIT differential, and WASM smoke. Independent
+runtime/safety and test/maintainability reviews found no residual issue.
+
 ### 2026-07-31 — compact Smi `Shr` successor threading, host `Darwin 25.6.0 arm64`
 
 Exact merged main `2758c530` and the retained candidate used normal

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1087,6 +1087,17 @@ sampling by `/profile`.
   A separate 60+60 Crypto confirmation measured **0.9484x**; Splay,
   DeltaBlue, and `arith_loop` controls stayed inside the 2% gate. See
   `bench-results.md`.
+- **Compact Smi `Star` successor threading (2026-08-04).** Splay telemetry
+  found **2,068,480** `LdaSmi8 -> Star` transitions: **99.232%** of its
+  compact Smi loads and **9.717%** of all logical instructions. The merged
+  load handler now performs that pure general-register store before the next
+  indirect dispatch while preserving the accumulator; compact `Star0..3`,
+  bytecode, and both JIT tiers stay unchanged. Normalized logical telemetry
+  is byte-identical, direct transfers rise by exactly **2,068,480**, and
+  `runFrames` shrinks by 20 bytes. A remote 41+41 role-swapped A/B
+  measured Splay **0.9881x**, a **0.9950x** Lantern macro geometric mean,
+  and a **0.9998x** production-tier control; the worst workload was
+  **1.0139x**, inside the 2% gate. See `bench-results.md`.
 - **Impossible property-probe gates (2026-07-30).** Strict property writes now
   reject keys that cannot begin a §7.1.21 canonical numeric spelling, walk to
   the first TypedArray ancestor, and only then pay for numeric parsing and

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1557,20 +1557,20 @@ pub fn runFrames(
             ip += op_tag.operandSize();
             acc = Value.fromInt32(imm);
 
-            // Compact signed shifts and dense integer masks dominate their
-            // respective Smi widths in the macro corpus. Thread the pure
-            // int32 fast paths here while preserving the ordinary bytecode
-            // for both JIT tiers.
+            // Compact signed shifts, general register stores, and dense
+            // integer masks dominate their respective Smi widths in the
+            // macro corpus. Thread the pure completions here while preserving
+            // the ordinary bytecode for both JIT tiers.
             //
-            // If the LHS is not an Int32 (a Double, coercible object, or
-            // BigInt), leave `ip` on the successor so its existing slow path
-            // remains the sole conversion / re-entry / exception
-            // implementation.
+            // For arithmetic successors, a non-Int32 LHS (a Double,
+            // coercible object, or BigInt) leaves `ip` on the successor so
+            // its existing slow path remains the sole conversion / re-entry /
+            // exception implementation. The Star completion is an
+            // unconditional frame-register store.
             if (op_tag == .lda_smi8) {
                 if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.shr)) {
-                    // Splay executes over two million compact loads without
-                    // this successor. Keep ordinary decode as fallthrough;
-                    // matching Crypto shifts take the predictable side edge.
+                    // Keep ordinary decode as fallthrough; matching Crypto
+                    // shifts take the predictable side edge.
                     @branchHint(.unlikely);
                     const r = code[ip + 1];
                     if (intBitwise(.shr, registers[r], acc)) |res| {
@@ -1578,6 +1578,18 @@ pub fn runFrames(
                         if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.shr);
                         acc = res;
                     }
+                } else if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.star)) {
+                    // Splay overwhelmingly stores these compact constants in
+                    // a general register. Star preserves the accumulator, so
+                    // this pure frame write can complete before dispatch.
+                    // Keep ordinary decode laid out as fallthrough across the
+                    // whole Smi family; the dynamic predictor learns Splay's
+                    // hot side edge without moving unrelated handlers.
+                    @branchHint(.unlikely);
+                    const r = code[ip + 1];
+                    ip += 2;
+                    registers[r] = acc;
+                    if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.star);
                 }
             } else if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.bit_and)) {
                 // Bias ordinary decode toward the laid-out fallthrough;

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1692,11 +1692,99 @@ test "lda_this property direct threading: instrumented run records transfer" {
     );
 }
 
+// V8 Ignition's Star and QuickJS's set_loc share Cynic's non-consuming store
+// contract: write the register while preserving the accumulator. Lantern
+// threads only the measured operand-bearing `LdaSmi8; Star` pair; compact
+// Star0..3 and StarLdar retain ordinary dispatch.
+test "smi8 star direct threading: stores register and preserves accumulator" {
+    const Op = op_mod.Op;
+    const code = [_]u8{
+        @intFromEnum(Op.lda_smi8),
+        39,
+        @intFromEnum(Op.star),
+        4,
+        @intFromEnum(Op.star),
+        5,
+        @intFromEnum(Op.lda_smi8),
+        3,
+        @intFromEnum(Op.add),
+        4,
+        @intFromEnum(Op.add),
+        5,
+        @intFromEnum(Op.return_),
+    };
+    const chunk: chunk_mod.Chunk = .{
+        .code = &code,
+        .constants = &.{},
+        .source_positions = &.{},
+        .handlers = &.{},
+        .function_templates = &.{},
+        .class_templates = &.{},
+        .register_count = 6,
+    };
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    const result = try run(testing.allocator, &realm, &chunk);
+    const value = switch (result) {
+        .value, .yielded => |v| v,
+        .thrown => return error.UncaughtException,
+    };
+
+    // The first Star writes r4. Because Star leaves the accumulator intact,
+    // the second Star also writes 39 to r5: (3 + r4) + r5 == 81.
+    try testing.expect(value.isInt32());
+    try testing.expectEqual(@as(i32, 81), value.asInt32());
+
+    if (comptime bytecode_stats.enabled) {
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star));
+        try testing.expectEqual(@as(u64, 2), stats.opcodeCount(.star));
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.star, .star));
+        try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+    }
+}
+
+test "smi8 star direct threading: compiled store and telemetry stay exact" {
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    // The first four stores use Star0..3 and remain ordinary controls. Only
+    // x uses the measured general `LdaSmi8; Star r4` shape; y then overwrites
+    // the accumulator through a non-store successor.
+    try expectScriptInt(
+        \\(function() {
+        \\  let a = 2, b = 3, c = 4, d = 5, x = 39, y = 40;
+        \\  return x + y + a + b + c + d;
+        \\})();
+    , 93);
+
+    if (comptime bytecode_stats.enabled) {
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star));
+        try testing.expectEqual(
+            @as(u64, 1),
+            stats.trigramCount(.lda_smi8, .star, .lda_smi8),
+        );
+        try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.star));
+        try testing.expectEqual(@as(u64, 0), stats.pairCount(.star, .star));
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star_0));
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star_1));
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star_2));
+        try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi8, .star_3));
+        try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+    }
+}
+
 // §13.15 ApplyStringOrNumericBinaryOperator / §13.10 shift operators.
 // Exact integer RHS literals use width-specific loads. Lantern threads the
 // compact `LdaSmi8; Shr`, `LdaSmi16; BitAnd`, and full-width
 // `LdaSmi; BitAnd` int32 fast paths while preserving the ordinary bytecode
 // stream for both JIT tiers.
+
 test "smi16 bit-and direct threading: instrumented run records transfer" {
     if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
 


### PR DESCRIPTION
## Summary

- complete a general `Star` successor directly from Lantern's compact `LdaSmi8` arm
- preserve the accumulator, logical bytecode telemetry, bytecode format, and both JIT tiers
- add raw-bytecode and compiled-source tests for register storage, accumulator preservation, logical stats, and the intentionally excluded `Star0..3` controls
- record the retained benchmark in `bench-results.md` and the performance roadmap

## Why this shape

Splay executes 2,068,480 `LdaSmi8 -> Star` pairs: 99.232% of its compact Smi loads and 9.717% of all logical instructions. `Star` is a pure frame-register write and cannot allocate, re-enter JavaScript, throw, or decline, so the pair can skip one interpreter dispatch without adding an opcode or changing JIT input.

V8 Ignition's `Star` and QuickJS's `set_loc` use the same non-consuming store contract: the destination changes while the accumulator remains intact.

## Deterministic gates

- Splay output: identical
- static bytecode and logical opcode/pair/trigram report: identical SHA-256 after normalizing only `direct-transfers`
- direct transfers: 98,392 -> 2,166,872, exactly +2,068,480
- `runFrames`: 345,048 -> 345,028 bytes (-20)
- Mach-O `__TEXT`: 5,095,584 -> 5,095,568 bytes (-16)
- non-cached test262 `language/`: 22,122 pass / 1,070 fail before and after

## Remote performance gate

The first local 61+61 Splay sample was discarded in full because its two launch roles occupied different absolute timing regimes and reported 160.4% / 26.4% spread. The retained gate used 41 interleaved pairs in each launch role on the serialized remote box. For forward `F = candidate/base` and reverse `R = base/candidate`, neutral candidate/base is `sqrt(F/R)`.

| interpreter fixture | neutral C/B |
|---|---:|
| Richards | 0.994x |
| DeltaBlue | 0.994x |
| Crypto | 0.990x |
| RayTrace | 0.993x |
| NavierStokes | 1.012x |
| Splay | 0.988x |
| **geomean** | **0.995x** |

- Splay: 0.990x forward and 1.014x reverse, so both roles independently agree that the candidate is faster; neutral 0.9881x (about 1.19%)
- interpreter geomean: 0.9950x; worst control: 1.0120x
- default-tier geomean: 0.9998x; Splay: 0.9909x; worst control: 1.0139x
- every interpreter and default-tier fixture stays below the 1.020 retention limit

Remote ratio spreads remain high, so these are directional retention results rather than precise effect sizes. The target's two-role agreement, exact opportunity count, small native shape, and bounded controls decide retention.

## Checks and review

- `zig build test-fast -Dtest-filter='smi8 star direct threading'`
- `zig build test-fast -Dbytecode-stats=true -Dtest-filter='smi8 star direct threading'`
- `zig build test-fast -Dbytecode-stats=true -Dtest-filter=smi8`
- `zig fmt --check src/runtime/lantern/interpreter.zig src/runtime/lantern/tests.zig`
- `git diff --check`
- all 34 GitHub checks green on the code commit
- independent runtime/safety review: no findings
- independent test/maintainability review: findings addressed, no residual blocker
- independent perf/docs review: raw calculations and recorded claims verified
