### PR TITLE
Close Smi BitAnd threading review gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,13 @@ jobs:
             zig build test-fast --summary all
           fi
 
+      - name: Bytecode direct-threading tests
+        if: runner.os == 'Linux'
+        # The optimization witnesses inspect compile-time-gated dynamic
+        # opcode telemetry, so the normal instrumentation-off unit build
+        # skips them. Keep one focused stats-enabled build in CI.
+        run: zig build test-fast --summary all -Dbytecode-stats=true -Dtest-filter='direct threading'
+
       - name: SES positive-coverage tests
         # Runs the hand-written tests under `tests/ses/` against the
         # installed cynic CLI (hardened by default). Each fixture

--- a/bench-results.md
+++ b/bench-results.md
@@ -83,8 +83,47 @@ all 34 checks, including ReleaseSafe unit tests, cross-builds, full
 conformance/RSS, GC stress, JIT differential, and WASM smoke. Independent
 runtime/safety and test/maintainability reviews found no residual issue.
 
+### 2026-08-04 — composed Smi successor review follow-up, host `Linux 6.8.0-136-generic x86_64` (remote bench box)
+
+Exact merged main `c0b3c866` and reviewed candidate `93d6b48a` used normal
+ReleaseFast CLI SHA-256 binaries `64a249fe` / `39baf91a`. This run closes the
+integration-evidence gap left by the separate `BitAnd` and compact `Shr`
+measurements below: the candidate preserves main's `LdaSmi8 -> Shr` transfer
+and changes only wider-Smi non-Int32 `BitAnd` successors to consume the
+successor and enter the shared `bitwiseBinary` operation once.
+
+Composed Crypto telemetry retains **89,774,038** logical instructions and
+moves `direct-transfers` **9,927,351 -> 9,927,752**, exactly the 401 slow
+`BitAnd` successors that now bypass redispatch. On the pinned Zig toolchain,
+`runFrames` grows **853 bytes** (**331,431 -> 332,284**) and GNU `size` text
+grows **848 bytes** (**4,783,898 -> 4,784,746**).
+
+Twenty interleaved pairs compared the exact artifacts back-to-back. The
+Lantern-only macro geometric mean is **1.0087x**; the production-tier macro
+geometric mean is **1.0015x**. No row crosses the benchmark runner's canonical
+regression threshold: a move must exceed both 5% and one-third of its ratio
+spread. The Lantern macro rows were:
+
+| bench | candidate/base | spread |
+|---|---:|---:|
+| richards | 1.012x | 16% |
+| deltablue | 1.016x | 26% |
+| crypto | 1.038x | 20% |
+| raytrace | 0.985x | 42% |
+| navier_stokes | 1.034x | 23% |
+| splay | 0.969x | 21% |
+| **geomean** | **1.0087x** | |
+
+The exact slow-path controls measured `bit_and_double` **1.019x** with 35%
+spread and `bit_and_object` **1.037x** with 22% spread. The complete 20-fixture
+micro suite likewise produced no flagged row. Spreads remain high on this
+shared host, so these are retention gates for the composed artifact, not
+claims of a precise effect size.
+
 ### 2026-07-31 — compact Smi `Shr` successor threading, host `Darwin 25.6.0 arm64`
 
+This historical isolation predates the direct `BitAnd` slow-transfer review
+amendment; the exact composed-artifact confirmation is recorded above.
 Exact merged main `2758c530` and the retained candidate used normal
 ReleaseFast CLI SHA-256 binaries `42b8d24d` / `727c3c2d`. Instrumented
 Crypto traces found **4,646,114** `LdaSmi8 -> Shr` pairs: **5.175%** of
@@ -148,6 +187,8 @@ fail** in 65 seconds with no guard failure.
 
 ### 2026-07-31 — width-gated Smi `BitAnd` successor threading, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
+This historical isolation predates compact `Shr` successor threading; the
+exact composed-artifact confirmation is recorded above.
 Exact merged main `7b5a04e5` and the retained candidate used normal
 ReleaseFast CLI SHA-256 binaries `4152253e` / `7d808bff`. Instrumented
 Crypto traces found **3,158,688** `LdaSmi16 -> BitAnd` pairs and

--- a/bench-results.md
+++ b/bench-results.md
@@ -149,75 +149,95 @@ fail** in 65 seconds with no guard failure.
 ### 2026-07-31 — width-gated Smi `BitAnd` successor threading, host `Linux 6.8.0-117-generic x86_64` (remote bench box)
 
 Exact merged main `7b5a04e5` and the retained candidate used normal
-ReleaseFast CLI SHA-256 binaries `8673fc48` / `7240c01a`. Instrumented
+ReleaseFast CLI SHA-256 binaries `4152253e` / `7d808bff`. Instrumented
 Crypto traces found **3,158,688** `LdaSmi16 -> BitAnd` pairs and
-**1,488,595** full-width `LdaSmi -> BitAnd` pairs. The candidate bypassed
-the indirect successor dispatch on **4,646,882** of them: **99.991%** of
-the eligible pairs and **5.176%** of Crypto's **89,774,038** logical
-instructions. The remaining 401 pairs had a non-Int32 left operand and
-correctly entered the ordinary coercion path.
+**1,488,595** full-width `LdaSmi -> BitAnd` pairs. All **4,647,283** eligible
+pairs bypassed the indirect successor dispatch, or **5.177%** of Crypto's
+**89,774,038** logical instructions. Of those, **4,646,882** (**99.991%**)
+completed the Int32 fast path; the remaining 401 had a non-Int32 left operand
+and correctly entered the shared coercion path.
 
 The bytecode and both JIT tiers remain unchanged. Lantern's existing merged
 Smi-load handler recognizes only full-width and 16-bit loads followed by
 `BitAnd`; compact `LdaSmi8` is deliberately excluded because Splay executes
 it 2,084,482 times without a useful successor. On an Int32 left operand the
 load handler runs the same pure integer AND and consumes the successor opcode
-plus register operand. A Double, coercible object, or BigInt leaves `ip` on
-`BitAnd`, so its established ToNumeric / BigInt / throw path remains the sole
-slow implementation. `observeDirectActive` records the skipped opcode before
-ordinary decoding resumes, preserving logical telemetry.
+plus register operand. A Double, coercible object, or BigInt also consumes the
+successor, then enters the shared `bitwiseBinary` ToNumeric / BigInt / throw
+operation exactly once. This avoids both a second Int32 probe and a second
+dispatch without creating another coercion implementation. Both outcomes use
+`observeDirectActive` because the successor dispatch was bypassed, while its
+logical opcode and transition remain present in telemetry.
 
 After normalizing only `direct-transfers`, the complete baseline/candidate
 Crypto reports are byte-identical: same static bytecode, dynamic instruction
 total, every opcode/pair/trigram row, and zero dropped sequences.
-`direct-transfers` moves **634,631 -> 5,281,513**, exactly the **4,646,882**
-new Int32 hits. The unlikely branch hint keeps the grouped load handler's
-dominant `LdaSmi8` / non-`BitAnd` decode path biased toward fallthrough. The
-native cost is **96 bytes**: `runFrames` **334,000 -> 334,096 bytes** and
-ELF `.text` **4,087,299 -> 4,087,395 bytes**.
+`direct-transfers` moves **634,631 -> 5,281,914**, exactly the **4,647,283**
+new dispatch bypasses: 4,646,882 Int32 hits and 401 transfers into the shared
+slow path. The unlikely branch hint keeps the grouped load handler's dominant
+`LdaSmi8` / non-`BitAnd` decode path biased toward fallthrough. The native
+cost in the pinned-Zig Linux x86_64 ReleaseFast build is **894 bytes** in
+`runFrames` (**331,289 -> 332,183**) and **896 bytes** in GNU `size` text
+(**4,783,754 -> 4,784,650**).
 
-Forty paired Lantern-only runs in each physical launch role pinned the driver
-and every child process to CPU 3. Forward is candidate/base, reverse is
-base/candidate after swapping the physical binaries, and neutral is
-`sqrt(forward / reverse)`:
+The runner's even-sample median was corrected during review to average the two
+middle samples; every number below was rerun after that fix. Forty paired
+Lantern-only runs in each physical launch role pinned the driver and every
+child process to CPU 0. Forward is candidate/base, reverse is base/candidate
+after swapping the physical binaries, and neutral is
+`sqrt(forward / reverse)`. Spread is `(max-min)/median` of paired ratios:
 
-| bench | forward C/B | reverse B/C | neutral C/B |
-|---|---:|---:|---:|
-| richards | 0.937x | 1.057x | 0.942x |
-| deltablue | 0.985x | 1.007x | 0.989x |
-| crypto | 0.974x | 1.022x | 0.976x |
-| raytrace | 0.964x | 1.035x | 0.965x |
-| navier_stokes | 1.013x | 1.011x | 1.001x |
-| splay | 1.002x | 0.991x | 1.006x |
-| **geomean** |  |  | **0.979x** |
+| bench | forward C/B | spread | reverse B/C | spread | neutral C/B |
+|---|---:|---:|---:|---:|---:|
+| richards | 0.976x | 22.1% | 1.025x | 19.3% | 0.9758x |
+| deltablue | 1.002x | 18.3% | 1.006x | 21.7% | 0.9980x |
+| crypto | 1.019x | 20.9% | 0.988x | 18.0% | 1.0156x |
+| raytrace | 0.991x | 30.3% | 0.983x | 26.1% | 1.0041x |
+| navier_stokes | 1.019x | 24.3% | 0.987x | 28.2% | 1.0161x |
+| splay | 1.006x | 21.6% | 0.999x | 23.5% | 1.0035x |
+| **geomean** |  |  |  |  | **1.0021x** |
 
-The order-neutral macro geometric mean is **0.9795x**, about **2.05%**
-faster, and no workload crosses the 2% regression gate. Separate 60+60
-targeted runs measured Crypto **0.9710x** and the zero-hit `arith_loop`
-control **0.9895x**. Sixty-pair confirmations of the two layout watchpoints
-measured DeltaBlue **0.9881x** and Splay **1.0095x**.
+The order-neutral macro result is retention evidence rather than a resolved
+effect size: the geomean is **1.0021x** and no point-estimate regression
+exceeds 2%, but several spreads exceed 20%, so the shared x86 VM does not
+statistically establish that bound. Targeted slow-path controls likewise show
+no point-estimate regression above 2%:
+
+| control | pairs/order | forward C/B | spread | reverse B/C | spread | neutral C/B |
+|---|---:|---:|---:|---:|---:|---:|
+| `bit_and_double` | 60 | 0.990x | 29.1% | 1.010x | 45.0% | 0.9900x |
+| `bit_and_object` | 100 | 0.997x | 49.4% | 1.001x | 42.5% | 0.9980x |
+
+Twenty-pair arm64 confirmation on `Darwin 25.6.0` measured **0.9964x**
+across the same six macros. Its per-workload neutral ratios were Richards
+**0.9920x**, DeltaBlue **1.0055x**, Crypto **0.9766x**, RayTrace **1.0116x**,
+Navier-Stokes **0.9881x**, and Splay **1.0050x**; the largest regression was
+1.16% by point estimate. The x86 A/A calibration itself measured **0.988x**
+with 45.3% spread, so the high-spread VM rows above are deliberately reported
+as noisy point estimates, not claims of precise speedup or a proven threshold.
 
 The small final shape matters. A V8-Ignition-style accumulator-immediate
 opcode family was prototyped (Ignition ships `BitwiseAndSmi`,
 `BitwiseOrSmi`, `BitwiseXorSmi`, and the three Smi shifts
-[in its bytecode set](https://github.com/v8/v8/blob/d405ed7c7b8141bb435ed5cf651163fa32e0d11a/src/interpreter/bytecodes.h#L225-L268)),
-but Cynic's appended handler regressed a zero-hit `arith_loop` control by
-**4.01%** and was rejected. Splitting `LdaSmi16` into a direct cross-handler
-edge triggered a whole-function LLVM phase change, grew `runFrames` by
-7,120 bytes, and regressed Navier-Stokes by **4.12%**. The first compact
-in-arm hybrid stayed at +96 bytes but regressed DeltaBlue by **3.00%**;
-retaining the normal decode path as the hinted fallthrough produced the
-gated result above. These rejected rungs are why wall-time and native-layout
-checks, not dispatch-count reduction alone, decide retention.
+[in its bytecode set](https://github.com/v8/v8/blob/d405ed7c7b8141bb435ed5cf651163fa32e0d11a/src/interpreter/bytecodes.h#L225-L268)).
+The best direct-transfer superinstruction kept object coercion neutral but
+regressed Navier-Stokes by **6.3%**; sharing the handler removed the cloned
+tail but regressed the object control by **5.2%** and Navier-Stokes by
+**3.2%**. A compact primitive-Number successor path cost only 93 native bytes
+but regressed the object control by **7.9%**. All were rejected. The retained
+bytecode-preserving path is larger, but it is the only reviewed shape that
+keeps one coercion operation. No retained point estimate regresses by more
+than 2%; the shared-host x86 result remains statistically inconclusive.
 
-Validation on the locked final snapshot covered both threaded widths, the
-deliberately ordinary Smi8 path, Int32 and Double operands, one-shot object
-coercion, a caught coercion throw, logical telemetry, and allocation-pressure
-GC. The complete ReleaseSafe unit suite passed **3,184 tests** with **464
-intentional skips**. Exact-main and candidate `bitwise-and` test262 pass
-lists were identical at **29 pass / 1 known fail**, including under
-`gc-threshold=1`. The required non-cached full sweep retained **48,653 pass /
-1,324 fail**, plus ShadowRealm **63 / 1**, with no pass-count change.
+Validation on the locked final snapshot covers both threaded widths, the
+deliberately ordinary Smi8 path, Int32 and Double operands, general-LHS
+evaluation order, one-shot object coercion, a caught coercion throw, logical
+telemetry, `Symbol.toPrimitive` and Symbol error paths, allocation-pressure
+GC, and the benchmark driver's true even median. Exact-main and candidate
+`bitwise-and` test262 pass lists remain
+identical at **36 pass / 1 known fail**, including under `gc-threshold=1`.
+The required non-cached full sweep retained **48,653 pass / 1,324 fail**, plus
+ShadowRealm **63 / 1**, with no pass-count change.
 
 ### 2026-07-30 — target-specific computed-receiver register reuse, host `Darwin 25.6.0 arm64`
 

--- a/bench/micros/bit_and_double.js
+++ b/bench/micros/bit_and_double.js
@@ -1,0 +1,13 @@
+// Double-heavy binary bitwise AND loop. The RHS emits LdaSmi16 -> BitAnd,
+// while adding 0.5 after every result keeps the next LHS outside Int32.
+// This pins one failed Int32 probe plus the shared ToNumeric / ToInt32
+// fallback on every iteration.
+'use strict';
+function run() {
+    let value = 0.5;
+    for (let i = 0; i < 5_000_000; i++) {
+        value = (value & 32767) + 0.5;
+    }
+    return value;
+}
+print(run());

--- a/bench/micros/bit_and_object.js
+++ b/bench/micros/bit_and_object.js
@@ -1,0 +1,14 @@
+// Object-coercion binary bitwise AND loop. The RHS emits
+// LdaSmi16 -> BitAnd; successor threading must enter the shared
+// ToNumeric/valueOf path exactly once on every iteration.
+'use strict';
+const operand = {
+    valueOf() {
+        return 32769;
+    },
+};
+let masked = 0;
+for (let i = 0; i < 1_000_000; i++) {
+    masked = operand & 32767;
+}
+print(masked);

--- a/build.zig
+++ b/build.zig
@@ -200,9 +200,19 @@ pub fn build(b: *std.Build) void {
     const exe_tests = b.addTest(.{ .root_module = exe_mod, .filters = test_filters });
     const run_exe_tests = b.addRunArtifact(exe_tests);
 
+    const bench_tests_mod = b.createModule(.{
+        .root_source_file = b.path("tools/bench.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    bench_tests_mod.addImport("cynic", lib_mod);
+    const bench_tests = b.addTest(.{ .root_module = bench_tests_mod, .filters = test_filters });
+    const run_bench_tests = b.addRunArtifact(bench_tests);
+
     const test_step = b.step("test", "Run all unit tests");
     test_step.dependOn(&run_lib_tests.step);
     test_step.dependOn(&run_exe_tests.step);
+    test_step.dependOn(&run_bench_tests.step);
 
     // `zig build test-fuzz` runs the Fuzzilli REPRL host unit tests
     // (the REPRL protocol encoder + the coverage-hook arithmetic).
@@ -565,9 +575,17 @@ pub fn build(b: *std.Build) void {
     exe_mod_test_safe.addImport("cynic", lib_mod_test_safe);
     const safe_lib_tests = b.addTest(.{ .root_module = lib_mod_test_safe, .filters = test_filters });
     const safe_exe_tests = b.addTest(.{ .root_module = exe_mod_test_safe, .filters = test_filters });
+    const safe_bench_tests_mod = b.createModule(.{
+        .root_source_file = b.path("tools/bench.zig"),
+        .target = target,
+        .optimize = .ReleaseSafe,
+    });
+    safe_bench_tests_mod.addImport("cynic", lib_mod_test_safe);
+    const safe_bench_tests = b.addTest(.{ .root_module = safe_bench_tests_mod, .filters = test_filters });
     const test_fast_step = b.step("test-fast", "Run all unit tests built ReleaseSafe — finishes in ~3 min vs the Debug `test` step's 10+; keeps safety checks, GC verifiers, leak detection");
     test_fast_step.dependOn(&b.addRunArtifact(safe_lib_tests).step);
     test_fast_step.dependOn(&b.addRunArtifact(safe_exe_tests).step);
+    test_fast_step.dependOn(&b.addRunArtifact(safe_bench_tests).step);
     test_fast_step.dependOn(&run_t262_tests.step);
 
     // A second harness binary, built ReleaseSafe and installed under

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1072,15 +1072,15 @@ sampling by `/profile`.
   JIT tiers are unchanged, and logical stats remain exactly comparable.
   Crypto records **4,647,283** new direct transfers (**5.177%** of its
   logical instructions): 4,646,882 Int32 hits and 401 transfers into the
-  shared slow path. The native delta is 894 bytes in `runFrames` for the
-  pinned-Zig Linux x86_64 ReleaseFast build. Post-review true-median 40+40
-  x86_64 A/B measured a **1.0021x** neutral interpreter macro geomean; no
-  point-estimate regression exceeded 2%, but shared-VM variance was too high
-  to establish that bound statistically. The 20+20 arm64 point
-  estimate was **0.9964x**. Dedicated Double and object slow-path controls had
-  **0.9900x** and **0.9980x** point estimates. Rejected
-  superinstruction variants regressed Navier-Stokes or object coercion by
-  3.2-7.9%. See `bench-results.md`.
+  shared slow path. The pre-composition isolation grew `runFrames` by 894
+  bytes and measured a **1.0021x** neutral interpreter macro geomean; its
+  20+20 arm64 point estimate was **0.9964x**. After compact `Shr` landed, an
+  exact `c0b3c866` / `93d6b48a` composed-artifact rerun measured an 853-byte
+  `runFrames` delta, **1.0087x** Lantern macro geomean, and **1.019x** /
+  **1.037x** Double / object controls with 35% / 22% spread. No row crossed
+  the runner's noise-adjusted regression threshold. Rejected superinstruction
+  variants regressed Navier-Stokes or object coercion by 3.2-7.9%. See
+  `bench-results.md`.
 - **Compact Smi `Shr` successor threading (2026-07-31).** Crypto telemetry
   found **4,646,114** `LdaSmi8 -> Shr` transitions, **5.175%** of all logical
   instructions; **4,645,838** (**99.994%**) had an Int32 left operand. The

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1066,14 +1066,21 @@ sampling by `/profile`.
   merged Smi-load handler now recognizes full-width / i16 integer masks
   followed by `BitAnd` and executes the shared Int32 operation before the
   next indirect dispatch. `LdaSmi8` is excluded to protect Splay's two
-  million nonmatching compact loads; non-Int32 left operands leave `ip` on
-  the ordinary `BitAnd` coercion / BigInt / throw path. Bytecode and both JIT
-  tiers are unchanged, and logical stats remain exactly comparable. Crypto
-  records **4,646,882** new direct transfers (**5.176%** of its logical
-  instructions), while the final native delta is 96 bytes. A pinned x86_64
-  40+40 forward/reverse A/B measured an order-neutral **0.9795x**
-  interpreter macro geometric mean, with no workload regression above 2%;
-  targeted Crypto measured **0.9710x**. See `bench-results.md`.
+  million nonmatching compact loads. Non-Int32 left operands consume the
+  successor and enter the shared `bitwiseBinary` coercion / BigInt / throw
+  operation once, avoiding a repeated probe and dispatch. Bytecode and both
+  JIT tiers are unchanged, and logical stats remain exactly comparable.
+  Crypto records **4,647,283** new direct transfers (**5.177%** of its
+  logical instructions): 4,646,882 Int32 hits and 401 transfers into the
+  shared slow path. The native delta is 894 bytes in `runFrames` for the
+  pinned-Zig Linux x86_64 ReleaseFast build. Post-review true-median 40+40
+  x86_64 A/B measured a **1.0021x** neutral interpreter macro geomean; no
+  point-estimate regression exceeded 2%, but shared-VM variance was too high
+  to establish that bound statistically. The 20+20 arm64 point
+  estimate was **0.9964x**. Dedicated Double and object slow-path controls had
+  **0.9900x** and **0.9980x** point estimates. Rejected
+  superinstruction variants regressed Navier-Stokes or object coercion by
+  3.2-7.9%. See `bench-results.md`.
 - **Compact Smi `Shr` successor threading (2026-07-31).** Crypto telemetry
   found **4,646,114** `LdaSmi8 -> Shr` transitions, **5.175%** of all logical
   instructions; **4,645,838** (**99.994%**) had an Int32 left operand. The

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -96,6 +96,8 @@ Run one fixture with `zig build bench -- --filter=<name>`; combine it with
 | Fixture | Iters | Stresses |
 |---|---:|---|
 | `arith_loop` | 5,000,000 | Bytecode dispatch density on `Op.add` / `Op.lt` / `Op.jmp` — int32 fast-path + the threaded-dispatch loop with no property access. Smi-overflow paths are NOT exercised (every step stays int32-clean via `\| 0`). |
+| `bit_and_double` | 5,000,000 | Double-heavy `LdaSmi16 -> BitAnd` execution. Adding `0.5` after every result keeps the next left operand outside Int32, pinning one failed Int32 probe followed by the shared §13.15.3 ToNumeric and §6.1.6.1.16 NumberBitwiseOp / ToInt32 path on every iteration. |
+| `bit_and_object` | 1,000,000 | Coercible-object `LdaSmi16 -> BitAnd` execution. A stable `valueOf` operand pins the successor's shared §13.15.3 ToNumeric and §6.1.6.1.16 NumberBitwiseOp / ToInt32 path on every iteration and catches repeated coercion or fallback-probe regressions. |
 | `mul_loop` | 3,000,000 | Numeric `Op.mul` dispatch with an Int32/Double raw-operand pair and a Double result. Pins Lantern's one-byte per-site operand profile plus the fused Number multiplication path; the changing multiplicand prevents constant folding. |
 | `div_loop` | 3,000,000 | Numeric `Op.div` dispatch with Int32 raw operands and a Double result. Pins Lantern's one-byte per-site operand profile plus the fused Number division path; the changing numerator prevents constant folding. |
 | `mod_loop` | 3,000,000 | Numeric `Op.mod` dispatch with two Int32 operands. Pins Lantern's direct truncating Number-remainder path; the changing dividend prevents constant folding, while an accumulated checksum keeps every result observable. |

--- a/src/runtime/lantern/interpreter.zig
+++ b/src/runtime/lantern/interpreter.zig
@@ -1562,10 +1562,12 @@ pub fn runFrames(
             // macro corpus. Thread the pure completions here while preserving
             // the ordinary bytecode for both JIT tiers.
             //
-            // For arithmetic successors, a non-Int32 LHS (a Double,
-            // coercible object, or BigInt) leaves `ip` on the successor so
-            // its existing slow path remains the sole conversion / re-entry /
-            // exception implementation. The Star completion is an
+            // If the LHS is not an Int32 (a Double, coercible object, or
+            // BigInt), compact Shr leaves `ip` on the successor so its
+            // existing handler remains the sole conversion / re-entry /
+            // exception implementation. Wider BitAnd consumes the successor
+            // and enters that same `bitwiseBinary` operation directly,
+            // avoiding a repeated probe and dispatch. Star is an
             // unconditional frame-register store.
             if (op_tag == .lda_smi8) {
                 if (ip + 1 < code.len and code[ip] == @intFromEnum(Op.shr)) {
@@ -1600,6 +1602,20 @@ pub fn runFrames(
                     ip += 2;
                     if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.bit_and);
                     acc = res;
+                } else {
+                    ip += 2;
+                    if (comptime bytecode_stats.enabled) bytecode_stats.observeDirectActive(.bit_and);
+                    if (try bitwiseBinary(realm, .bit_and, registers[r], acc)) |res| {
+                        acc = res;
+                    } else {
+                        const ex = realm.pending_exception orelse try makeTypeError(realm, "ToPrimitive failed");
+                        realm.pending_exception = null;
+                        f.ip = ip;
+                        f.accumulator = acc;
+                        committed = true;
+                        if (!try unwindThrow(allocator, realm, frames, ex)) return .{ .thrown = ex };
+                        continue :dispatch try reEnterDispatch(frames, &f, &local_chunk, &code, &registers, &ip, &acc, &committed);
+                    }
                 }
             }
             continue :dispatch try decodeNext(code, &ip, &committed);

--- a/src/runtime/lantern/tests.zig
+++ b/src/runtime/lantern/tests.zig
@@ -1932,12 +1932,58 @@ test "smi8 bit-and direct threading: compact masks stay on ordinary dispatch" {
     try testing.expectEqual(@as(u64, 0), stats.direct_transfers);
 }
 
+test "smi bit-and direct threading: Double transfers to shared slow path" {
+    if (comptime !bytecode_stats.enabled) return error.SkipZigTest;
+
+    var stats: bytecode_stats.DynamicStats = .{};
+    const activation = bytecode_stats.activate(&stats);
+    defer activation.deinit();
+
+    try expectScriptInt(
+        \\function f(x) { return x & 32767; }
+        \\f(32769.9);
+    , 1);
+
+    try testing.expectEqual(@as(u64, 1), stats.pairCount(.lda_smi16, .bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.opcodeCount(.bit_and));
+    try testing.expectEqual(@as(u64, 1), stats.direct_transfers);
+}
+
+test "smi bit-and direct threading: general LHS precedes one coercion" {
+    try expectScriptStringWithBuiltins(
+        \\let effects = "";
+        \\function lhs() {
+        \\  effects = effects + "l";
+        \\  return { valueOf() { effects = effects + "v"; return 32769; } };
+        \\}
+        \\const result = lhs() & 32767;
+        \\effects + ":" + result;
+    , "lv:1");
+}
+
+test "smi bit-and direct threading: Symbol coercion uses shared slow path" {
+    try expectScriptStringWithBuiltins(
+        \\let calls = 0;
+        \\function mask(x) { return x & 32767; }
+        \\const value = {
+        \\  [Symbol.toPrimitive]() { calls = calls + 1; return 32769; }
+        \\};
+        \\const masked = mask(value);
+        \\let symbolError = "none";
+        \\try {
+        \\  mask(Symbol("x"));
+        \\} catch (e) {
+        \\  symbolError = e.constructor.name;
+        \\}
+        \\masked + ":" + calls + ":" + symbolError;
+    , "1:1:TypeError");
+}
+
 test "smi bit-and direct threading: slow coercion and caught throw stay exact" {
     // The integer calls take the two inline width paths. The Double and
-    // object calls decline them with `ip` still on BitAnd, then enter the
-    // ordinary handler. Pin successful JS re-entry and exception unwinding
-    // so the optimization cannot accidentally skip or repeat ToNumeric
-    // effects.
+    // object calls decline them, then enter the shared `bitwiseBinary` slow
+    // operation directly. Pin successful JS re-entry and exception unwinding
+    // so the optimization cannot accidentally skip or repeat ToNumeric effects.
     try expectScriptStringWithBuiltins(
         \\let calls = 0;
         \\function mask(x) { return x & 32767; }

--- a/tools/bench.zig
+++ b/tools/bench.zig
@@ -88,6 +88,8 @@ const Bench = struct {
 
 const BENCHES = [_]Bench{
     .{ .name = "arith_loop", .path = "bench/micros/arith_loop.js" },
+    .{ .name = "bit_and_double", .path = "bench/micros/bit_and_double.js" },
+    .{ .name = "bit_and_object", .path = "bench/micros/bit_and_object.js" },
     .{ .name = "mul_loop", .path = "bench/micros/mul_loop.js" },
     .{ .name = "div_loop", .path = "bench/micros/div_loop.js" },
     .{ .name = "mod_loop", .path = "bench/micros/mod_loop.js" },
@@ -377,6 +379,30 @@ fn medianOfSortedF64(sorted: []const f64) f64 {
     return (sorted[sorted.len / 2 - 1] + sorted[sorted.len / 2]) / 2.0;
 }
 
+const RatioSummary = struct {
+    median: f64,
+    spread_pct: f64,
+};
+
+fn summarizeSortedRatios(sorted: []const f64) RatioSummary {
+    const median = medianOfSortedF64(sorted);
+    return .{
+        .median = median,
+        .spread_pct = if (median > 0)
+            (sorted[sorted.len - 1] - sorted[0]) / median * 100.0
+        else
+            0.0,
+    };
+}
+
+test "A/B ratio summary averages the middle pair for an even sample count" {
+    const ratios = [_]f64{ 0.80, 0.90, 1.10, 1.20 };
+    const summary = summarizeSortedRatios(&ratios);
+
+    try std.testing.expectApproxEqAbs(@as(f64, 1.00), summary.median, 0.000_001);
+    try std.testing.expectApproxEqAbs(@as(f64, 40.00), summary.spread_pct, 0.000_001);
+}
+
 fn nearestRankF64(sorted: []const f64, percentile: u8) f64 {
     var rank = (@as(usize, percentile) * sorted.len + 99) / 100;
     rank = std.math.clamp(rank, 1, sorted.len);
@@ -441,9 +467,8 @@ fn runInterleavedAb(
         const base_ms = usToMs(medianUsOf(base));
         const head_ms = usToMs(medianUsOf(head));
         std.mem.sort(f64, ratios, {}, std.sort.asc(f64));
-        const ratio_med = ratios[ratios.len / 2];
-        const r_spread = if (ratio_med > 0) (ratios[ratios.len - 1] - ratios[0]) / ratio_med * 100.0 else 0.0;
-        const row = try std.fmt.bufPrint(&buf, "{s:<16} {d:>10.2} {d:>10.2} {d:>8.3}x {d:>8.1}\n", .{ b.name, base_ms, head_ms, ratio_med, r_spread });
+        const ratio_summary = summarizeSortedRatios(ratios);
+        const row = try std.fmt.bufPrint(&buf, "{s:<16} {d:>10.2} {d:>10.2} {d:>8.3}x {d:>8.1}\n", .{ b.name, base_ms, head_ms, ratio_summary.median, ratio_summary.spread_pct });
         try std.Io.File.stdout().writeStreamingAll(io, row);
     }
 }


### PR DESCRIPTION
Follow-up to #90, which merged before review completed.

## Summary
- consume non-Int32 wider-Smi `BitAnd` successors into the shared `bitwiseBinary` operation exactly once while preserving main's `LdaSmi8 -> Shr` threading
- make direct-transfer telemetry and the stats-enabled CI witnesses match actual dispatch bypasses, including Double, object, Symbol, GC, and unwind paths
- fix the benchmark runner's even-sample median and add dedicated Double/object controls
- replace overclaimed historical evidence with qualified measurements and an exact composed-artifact x86 A/B

## Verification
- `zig build test-fast --summary all -Dbytecode-stats=true "-Dtest-filter=direct threading"` (45/45 selected tests)
- `zig build test-fast --summary all` (3,388 pass, 267 intentional skips; 11/11 steps)
- `zig fmt --check src/runtime/lantern/interpreter.zig src/runtime/lantern/tests.zig tools/bench.zig build.zig`
- test262 allocation-pressure parity: `bitwise-and` 36/1 and signed `right-shift` 36/1
- remote job `cynic-1785809628-46276`: exact `c0b3c866` vs `93d6b48a`, 20 interleaved pairs across both tiers and all micros/macros; no noise-adjusted regression flag
- final correctness and performance subagent reviews: no actionable findings