### PR TITLE
Fix interleaved A/B median

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -652,6 +652,23 @@ pub fn build(b: *std.Build) void {
     const bench_step = b.step("bench", "Run the micro-bench suite (p50 + spread + outliers; --runs=N for tail percentiles)");
     bench_step.dependOn(&run_bench.step);
 
+    // Keep the benchmark driver's statistics helpers under the ordinary
+    // unit-test gates without making focused tool tests build the Debug
+    // engine. ReleaseSafe retains the checks relevant to this pure logic.
+    const bench_tests_mod = b.createModule(.{
+        .root_source_file = b.path("tools/bench.zig"),
+        .target = target,
+        .optimize = .ReleaseSafe,
+        .link_libc = true,
+    });
+    bench_tests_mod.addImport("cynic", lib_mod_test_safe);
+    const bench_tests = b.addTest(.{ .root_module = bench_tests_mod, .filters = test_filters });
+    const run_bench_tests = b.addRunArtifact(bench_tests);
+    const test_bench_step = b.step("test-bench", "Run benchmark-driver unit tests");
+    test_bench_step.dependOn(&run_bench_tests.step);
+    test_step.dependOn(&run_bench_tests.step);
+    test_fast_step.dependOn(&run_bench_tests.step);
+
     // (The `bench-regex` Perlex-vs-libregexp matcher benchmark — the
     // decision gate for retiring the vendored fallback — was removed
     // with libregexp itself; there is no second engine to compare

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -92,6 +92,8 @@ the fixture drops below ~50 ms on the lead engine.
 
 Run one fixture with `zig build bench -- --filter=<name>`; combine it with
 `--runs=<N>`, `--no-jit`, or `--ab-baseline=<binary>` for a focused gate.
+Interleaved A/B reports use the true median of the per-pair ratios, averaging
+the two middle ratios when the run count is even.
 
 | Fixture | Iters | Stresses |
 |---|---:|---|

--- a/tools/bench.zig
+++ b/tools/bench.zig
@@ -377,6 +377,39 @@ fn medianOfSortedF64(sorted: []const f64) f64 {
     return (sorted[sorted.len / 2 - 1] + sorted[sorted.len / 2]) / 2.0;
 }
 
+const PairedRatioSummary = struct {
+    median: f64,
+    spread_pct: f64,
+};
+
+fn summarizePairedRatios(ratios: []f64) PairedRatioSummary {
+    std.debug.assert(ratios.len > 0);
+    std.mem.sort(f64, ratios, {}, std.sort.asc(f64));
+    const median = medianOfSortedF64(ratios);
+    return .{
+        .median = median,
+        .spread_pct = if (median > 0)
+            (ratios[ratios.len - 1] - ratios[0]) / median * 100.0
+        else
+            0.0,
+    };
+}
+
+test "interleaved A/B ratio uses a true even-sample median" {
+    var ratios = [_]f64{ 1.06, 0.98, 1.02, 1.00 };
+    const summary = summarizePairedRatios(&ratios);
+    try std.testing.expectApproxEqAbs(
+        @as(f64, 1.01),
+        summary.median,
+        1e-12,
+    );
+    try std.testing.expectApproxEqAbs(
+        @as(f64, (1.06 - 0.98) / 1.01 * 100.0),
+        summary.spread_pct,
+        1e-12,
+    );
+}
+
 fn nearestRankF64(sorted: []const f64, percentile: u8) f64 {
     var rank = (@as(usize, percentile) * sorted.len + 99) / 100;
     rank = std.math.clamp(rank, 1, sorted.len);
@@ -386,9 +419,10 @@ fn nearestRankF64(sorted: []const f64, percentile: u8) f64 {
 /// Interleaved A/B (`--ab-baseline=<binary>`). For each fixture, alternate
 /// HEAD and baseline runs back-to-back so each pair sees the same
 /// instantaneous host speed, then take the median of the per-iteration
-/// ratios (head_i / base_i). Drift between the two halves cancels, so the
-/// ratio is trustworthy even on a noisy shared host — far better than
-/// running all of HEAD then all of baseline. `ratio < 1` = HEAD faster.
+/// ratios (head_i / base_i), averaging the two middle ratios for even N.
+/// Drift between the two halves cancels, so the ratio is trustworthy even
+/// on a noisy shared host — far better than running all of HEAD then all of
+/// baseline. `ratio < 1` = HEAD faster.
 /// `spread%` is (max-min)/median of the per-iteration ratios: low = the
 /// ratio is solid, high = genuinely unstable (re-run / suspect).
 fn runInterleavedAb(
@@ -440,10 +474,8 @@ fn runInterleavedAb(
 
         const base_ms = usToMs(medianUsOf(base));
         const head_ms = usToMs(medianUsOf(head));
-        std.mem.sort(f64, ratios, {}, std.sort.asc(f64));
-        const ratio_med = ratios[ratios.len / 2];
-        const r_spread = if (ratio_med > 0) (ratios[ratios.len - 1] - ratios[0]) / ratio_med * 100.0 else 0.0;
-        const row = try std.fmt.bufPrint(&buf, "{s:<16} {d:>10.2} {d:>10.2} {d:>8.3}x {d:>8.1}\n", .{ b.name, base_ms, head_ms, ratio_med, r_spread });
+        const ratio_summary = summarizePairedRatios(ratios);
+        const row = try std.fmt.bufPrint(&buf, "{s:<16} {d:>10.2} {d:>10.2} {d:>8.3}x {d:>8.1}\n", .{ b.name, base_ms, head_ms, ratio_summary.median, ratio_summary.spread_pct });
         try std.Io.File.stdout().writeStreamingAll(io, row);
     }
 }


### PR DESCRIPTION
## Summary

- Compute the true median of interleaved A/B per-pair ratios by averaging the two middle values for even run counts.
- Keep median and spread calculation in one tested production summary path.
- Add a focused test-bench step to the ordinary unit-test gates and document the behavior.

## Root cause

The A/B runner sorted ratio samples but selected the upper-middle value for even counts. Odd-count measurements, including PR #93 retained 41-pair samples, are unchanged.

## Validation

- Regression test observed failing before the production fix.
- zig build test-bench
- Zig formatting and git diff checks
- Two-run arith_loop A/B smoke test
- Independent statistical and build reviews; the sole test-strength finding was fixed and re-reviewed as resolved.