### PR TITLE
Add x86_64 support to Bistromath T1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,7 +440,7 @@ jobs:
             --filter=language/expressions --top-rss=10
 
   test262-jit-differential:
-    name: test262 JIT differential
+    name: test262 JIT differential (AArch64)
     # docs/jit.md §10.2 — the heart of Bistromath verification: a
     # full sweep with every eligible chunk force-compiled (`--jit`
     # runs each realm at tier-up threshold 1) must produce the
@@ -451,11 +451,10 @@ jobs:
     # actual fixture sets, not just the counts, so compensating
     # flips can't hide.
     #
-    # macos-latest, not ubuntu: GitHub's macOS runners are Apple
-    # Silicon, and Bistromath emits aarch64 only today (docs/jit.md
-    # §14 keeps x86_64 a mechanical follow-up). On x86_64 the tier
-    # is comptime-off and the diff would compare the interpreter
-    # with itself.
+    # The macOS lane qualifies Bistromath's AArch64 backend. A separate
+    # native Ubuntu lane below runs the same fail-closed comparison for
+    # x86_64; keeping the jobs separate lets this one also qualify the
+    # AArch64-only Ohaimark tier.
     #
     # GATING since the 2026-06-11 default-on decision (docs/jit.md
     # §10.5): the tier ships on by default, so a pass-set
@@ -489,12 +488,13 @@ jobs:
       - name: Set up Zig
         uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
         with:
-          cache-key: jit-differential
+          cache-key: jit-differential-aarch64
 
       - name: Differential sweep (interpreter vs force-compiled)
         timeout-minutes: 50
         run: |
           set -euo pipefail
+          test "$(uname -m)" = arm64
           # The force-compile (`--jit`) sweep must produce the EXACT
           # pass-set of the interpreter sweep (docs/jit.md §10.2). Two
           # real fixture classes block in a way the cooperative
@@ -518,7 +518,7 @@ jobs:
           # the harness, doesn't block) stays in the comparison.
           EXCLUDES=(--exclude=built-ins/Atomics/wait/ --exclude=built-ins/Atomics/notify/ --exclude=built-ins/TypedArray/prototype/copyWithin/coerced)
           zig build test262 -- --quiet --threads=0 "${EXCLUDES[@]}" --pass-list-out=/tmp/pass-interp.txt
-          zig build test262 -- --quiet --threads=0 --jit "${EXCLUDES[@]}" --pass-list-out=/tmp/pass-jit.txt
+          zig build test262 -- --quiet --threads=0 --jit --require-bistromath-entry "${EXCLUDES[@]}" --pass-list-out=/tmp/pass-jit.txt
           # Both files exist and are non-empty only if both sweeps
           # completed — otherwise fail before the diff.
           test -s /tmp/pass-interp.txt
@@ -540,6 +540,44 @@ jobs:
           diff -u /tmp/pass-interp.txt /tmp/pass-ohaimark.txt
           echo "Ohaimark pass-set identical: $(wc -l < /tmp/pass-ohaimark.txt) fixtures"
 
+  test262-jit-differential-x86-64:
+    name: test262 JIT differential (x86_64)
+    # Native x86_64 qualification for Bistromath. Pass-set equality alone can
+    # self-compare if dispatch accidentally stays in Lantern, so the forced
+    # sweep also requires a positive counter at the actual generated-entry
+    # boundary. Any incomplete worker invalidates the pass-list artifact.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: build-and-test
+    steps:
+      - name: Audit egress (advisory)
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          submodules: recursive
+
+      - name: Set up Zig
+        uses: xyzzylabs/setup-zig@09d85d9dbb73308882e7a26e61a8f706eed40df1  # v1.0.2
+        with:
+          cache-key: jit-differential-x86-64
+
+      - name: Differential sweep (interpreter vs force-compiled x86_64)
+        timeout-minutes: 50
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = x86_64
+          EXCLUDES=(--exclude=built-ins/Atomics/wait/ --exclude=built-ins/Atomics/notify/ --exclude=built-ins/TypedArray/prototype/copyWithin/coerced)
+          zig build test262 -- --quiet --threads=0 --timeout=120 "${EXCLUDES[@]}" --pass-list-out=/tmp/pass-interp-x86-64.txt
+          zig build test262 -- --quiet --threads=0 --timeout=120 --jit --require-bistromath-entry "${EXCLUDES[@]}" --pass-list-out=/tmp/pass-jit-x86-64.txt
+          test -s /tmp/pass-interp-x86-64.txt
+          test -s /tmp/pass-jit-x86-64.txt
+          diff -u /tmp/pass-interp-x86-64.txt /tmp/pass-jit-x86-64.txt
+          echo "x86_64 Bistromath pass-sets identical: $(wc -l < /tmp/pass-interp-x86-64.txt) fixtures"
+
   test262-gc-stress-jit:
     name: test262 GC stress + ${{ matrix.tier.label }} / ${{ matrix.bucket }} (advisory)
     # The docs/jit.md §12 step-3d net: ReleaseSafe arms
@@ -548,9 +586,10 @@ jobs:
     # so a compiled property write whose barrier mirror drifted
     # from the interpreter's (the §9 rule) trips the verifier with
     # the offending (container, field, target) instead of slipping
-    # through as a rare flake. macos-latest because Bistromath is
-    # aarch64-only (see test262-jit-differential above). Buckets
-    # are the property-write-heavy surfaces; advisory like its
+    # through as a rare flake. This mixed T1/T2 matrix stays on macOS
+    # because Ohaimark is AArch64-only; native x86_64 Bistromath is gated
+    # by the differential job above and Ubuntu's full ReleaseSafe unit run.
+    # Buckets are the property-write-heavy surfaces; advisory like its
     # sibling gc-stress job. T2 rows also print Ohaimark rollout telemetry.
     runs-on: macos-latest
     timeout-minutes: 25

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,9 +430,11 @@ sequence), `--no-harness` (disable the `sta.js` +
 `--jit` (run every realm with Bistromath enabled and the tier-up
 threshold forced to 1 — the docs/jit.md §10 differential gate: a
 full sweep with this flag must produce the exact pass-set of one
-without it; aarch64 hosts only, a comptime no-op elsewhere. CI
-runs the comparison as the gating `test262-jit-differential`
-job. The harness flag is independent of the `cynic` CLI, where
+without it; AArch64 and x86_64 hosts on macOS/Linux, a comptime
+no-op elsewhere. Pair differential runs with
+`--require-bistromath-entry` so they fail unless generated T1 code
+actually executes. CI gates both native architectures. The harness
+flag is independent of the `cynic` CLI, where
 the tier is on by default at natural thresholds and `--no-jit`
 opts out),
 `--ohaimark` (force the default-on Ohaimark tier before Bistromath and

--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ RegExp engine), Sarcasm (the from-scratch WebAssembly engine —
 Unicode tables, and
 the hardened-by-default realm-boot pipeline. The runtime is filling
 in §19-§28 one bucket at a time. Bistromath (the baseline JIT)
-runs by default (`--no-jit` opts out) since the step-3 exit
-([`docs/jit.md`](docs/jit.md)); Ohaimark's typed-feedback snapshot,
+runs by default on AArch64 and x86_64 hosts on macOS and Linux
+(`--no-jit` opts out); other targets stay in Lantern
+([`docs/jit.md`](docs/jit.md)). Ohaimark's AArch64-only typed-feedback
+snapshot,
 block-argument SSA, specialization and representation planners, and verified
 logical deopt plus direct-entry/stable-home physical metadata and a
 graph/Lantern differential evaluator, deterministic register/spill allocation,
@@ -79,7 +81,12 @@ rollout bench) until its own differential and performance gates pass. The final
 fixture of `1.041x`, and 0.8 KiB installed code, passing both rollout ceilings.
 Baseline and forced-T2 test262 sweeps produced the exact same 48,517-pass set;
 focused ReleaseSafe GC-pressure runs and bounded crash/value-differential fuzz
-campaigns found no verifier failure, host crash, or differential. See
+campaigns found no verifier failure, host crash, or differential. Bistromath's
+x86_64 qualification ran the full interpreter and forced-T1 sweeps on macOS
+under Rosetta: both passed 48,517 fixtures, their pass-set diff was empty, and
+the fail-closed `--require-bistromath-entry` witness counted 2,455,587 generated
+entries. `x86_64-linux-musl` and `aarch64-linux-musl` cross-builds and focused
+ReleaseSafe suites on both ISAs passed as well. See
 [`docs/ROADMAP.md`](docs/ROADMAP.md) for the thematic breakdown.
 
 ### Conformance
@@ -207,6 +214,7 @@ your local `zig version` reports an older dev tag, bump it.
 - `--threads=<n>` — worker count (`0` = auto, `1` = sequential, `>1` = pool).
 - `--only-failing` — skip-as-pass any path in `.test262-pass-cache.txt`. After a full sweep populates the cache, the next iteration runs only the ~7 k failing/skipped fixtures — ≤ 30 s vs ≤ 100 s. Don't use for score rows; use it for per-fix verification.
 - `--jit` / `--ohaimark` — force Bistromath alone, or default-on Ohaimark before Bistromath, at threshold 1 for independent pass-set differential runs.
+- `--require-bistromath-entry` — with `--jit`, fail unless the sweep actually crosses generated T1 code. The differential gate uses this so an unsupported or disconnected backend cannot pass by comparing Lantern with itself.
 - `--ohaimark-stats` — with `--ohaimark`, print aggregate T2 compile attempts, publications/refusals, compile time, installed bytes, generated entries, completions, guard exits, refusal-stage counts, and the top unsupported bytecodes. Remains parallel-safe.
 
 Top-level CLI (not a test262 harness flag): `--ohaimark-osr` enables

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -38,7 +38,7 @@ that will be settled with an ADR when the time comes.
         │  hot
         ▼
    ┌──────────────────┐
-   │ Bistromath (T1)  │  ◄── default-on (M5)
+   │ Bistromath (T1)  │  ◄── default-on, AArch64 + x86_64 (M5)
    └────┬─────────────┘
         │  hotter
         ▼
@@ -241,8 +241,9 @@ selects narrow immediate / IC forms, relaxes relative branches to
 i8/i16/i32, and remaps source, handler, and dense-switch side tables.
 Load, store, and computed property sites use separate typed IC arrays
 so their layouts and index spaces stay small. Bytecode is the source
-of truth for IR — Bistromath (default-on since 2026-06; `--no-jit`
-opts out) and Ohaimark (default-on at natural thresholds;
+of truth for IR — Bistromath (AArch64 + x86_64 on macOS/Linux,
+default-on since 2026-06; `--no-jit` opts out; other targets interpret)
+and Ohaimark (AArch64-only, default-on at natural thresholds;
 `--no-ohaimark` isolates T1, while `--no-jit` disables both). Ohaimark's
 feedback/SSA/specialization/representation/deopt-home front end, differential
 evaluator, checked-int32/Number/property-IC AArch64 subset,

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1139,6 +1139,18 @@ sampling by `/profile`.
   the hardened `hasOwnProperty` path **304.6 → 152.8 ms p50 (-49.8%)**.
   Full main test262 reference and `--jit` sweeps match at
   **48,653 / 49,977 (97.35%)**; the SES suite remains **36 / 36**.
+- **Bistromath x86_64 qualification (2026-08-08).** The shared one-pass T1
+  compiler now selects AArch64 or x86_64 through a thin register/ABI adapter,
+  with SysV helper calls, rel32 control flow, exact Lantern tier-down state,
+  exception unwinding, and GC-root preservation covered by native tests. Full
+  interpreter and forced-Bistromath test262 sweeps on macOS under Rosetta each
+  passed **48,517** fixtures with an empty pass-set diff; the forced sweep
+  crossed **2,455,587** generated entries under the fail-closed
+  `--require-bistromath-entry` witness. `x86_64-linux-musl` and
+  `aarch64-linux-musl` cross-builds and focused ReleaseSafe suites on both ISAs
+  passed. Bistromath is therefore supported on AArch64 and x86_64 hosts on
+  macOS and Linux; Ohaimark remains AArch64-only and other targets stay in
+  Lantern.
 - **Ohaimark optimizer front end (2026-07-16).** The T2 ADR is now
   concrete: typed ICs snapshot into immutable same-index arrays without
   copying GC-managed callee/prototype/snapshot pointers; finalized bytecode
@@ -1943,7 +1955,8 @@ and the per-builtin checklist; this section tracks status.
 
 ## Future work (post-strict-only-runtime)
 
-- **Bistromath** — baseline JIT (T1). Direct opcode-to-native,
+- **Bistromath** — baseline JIT (T1). Direct opcode-to-native on AArch64 and
+  x86_64 hosts on macOS and Linux,
   inline caches for property access. Modeled on JSC Baseline /
   V8 Sparkplug. **Shipped** (M5, 2026-06) and on by default —
   `--no-jit` opts out; coverage, gates, and measured wins are

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -1,7 +1,9 @@
 # JIT tiers — Bistromath (T1), Ohaimark (T2), Spasm (wasm T1), and the shared substrate
 
-Status: **Bistromath and Ohaimark ship on by default** (`--no-ohaimark`
-isolates T1; `--no-jit` selects Lantern). Ohaimark's feedback/SSA,
+Status: **Bistromath ships on AArch64 and x86_64 hosts on macOS and Linux;
+Ohaimark remains AArch64-only.** Both ship on by default where supported
+(`--no-ohaimark` isolates T1; `--no-jit` selects Lantern), while targets
+without qualified native codegen stay in Lantern. Ohaimark's feedback/SSA,
 specialization, representation/deopt plans, allocation, AArch64 codegen,
 live-cell property guards, exact Lantern recovery, backedge safepoints, and
 transactional executable ownership have landed. Its helper-free ABI now adds
@@ -11,7 +13,12 @@ graduation 30-pair T2/T1 run measured `0.997x` geometric mean, `1.041x` worst,
 and 0.8 KiB installed code. Baseline and forced-T2 test262 pass lists match at
 48,517 paths; focused ReleaseSafe GC-pressure runs and bounded crash/value
 differential fuzz campaigns found no verifier failure, host crash, or
-differential. CI now gates both T1 and T2 pass-set equality. Loop-header OSR
+differential. CI now gates both T1 and T2 pass-set equality. Bistromath's
+x86_64 qualification ran full interpreter and forced-T1 test262 sweeps on
+macOS under Rosetta: both passed 48,517 fixtures, the pass-set diff was empty,
+and `--require-bistromath-entry` counted 2,455,587 generated entries.
+`x86_64-linux-musl` and `aarch64-linux-musl` cross-builds and focused
+ReleaseSafe suites on both ISAs also passed. Loop-header OSR
 into Ohaimark is implemented behind a realm-local **default-off** gate
 (`Realm.ohaimark_osr_enabled` / CLI `--ohaimark-osr`); it does not graduate to
 default-on until its own differential and natural-threshold gates pass (see
@@ -40,14 +47,14 @@ Pinned here:
   Spasm, the wasm baseline — and the exact reuse boundary (§7);
 - the JS↔wasm call-boundary fast path — per-signature thunks in the
   shared code region, IC-integrated dispatch on both sides (§7.1);
-- executable-memory mechanics for macOS/arm64 + Linux (§8);
+- executable-memory mechanics for macOS and Linux on AArch64 and x86_64 (§8);
 - the verification gate: differential test262 at force-compile, plus
   gc-stress (§10).
 
 Deferred, each with an owner section: Ohaimark runtime deoptimization/codegen
 ([ohaimark.md](ohaimark.md) — §5), per-realm code-cache scoping (the ADR
-[multi-realm.md](multi-realm.md) already reserves — §14), x86_64
-port timing (§8), background compilation (§14).
+[multi-realm.md](multi-realm.md) already reserves — §14), additional
+codegen targets (§8), and background compilation (§14).
 
 ## 1. Why a JIT, and why now
 
@@ -210,8 +217,8 @@ including §15.10 PTC re-entries; back-edges +1) and the tier state
 ## 4. Bistromath — the T1 baseline JIT
 
 One sentence: a single forward pass over Lantern bytecode emitting
-machine code per opcode — inline fast paths for Smi arithmetic and
-IC hits, helper calls for everything else — into a function whose
+AArch64 or x86_64 machine code per opcode — inline fast paths for Smi
+arithmetic and IC hits, helper calls for everything else — into a function whose
 execution state *is* a Lantern `CallFrame`, so the interpreter, the
 GC, OSR, and the watchdog cannot tell (and don't care) which tier is
 driving.
@@ -283,7 +290,8 @@ helper-call slow path, or a bare helper call:
 - **Smi arithmetic/compare** (`add`, `sub`, `lt`, `loop_inc_lt`, …):
   inline both-int32 tag check + op + overflow check; overflow or
   non-int32 falls into the existing `arith.zig` helper. The
-  NaN-boxed tag tests are 2–3 instructions on arm64.
+  NaN-boxed tag tests compile to a short ISA-local sequence on both
+  targets.
 - **Register moves, constants** (`ldar`, `star`, `lda_smi`,
   `lda_constant`, `lda_undefined`, …): inline loads/stores against
   the register file — these opcodes exist only to feed the
@@ -612,7 +620,7 @@ same line.
 | Layer | Shared? | Notes |
 |---|---|---|
 | Per-ISA assembler/encoder (`asm_aarch64`, `asm_x86_64`) | **yes** | one encoder, grown opcode-by-opcode on demand |
-| MacroAssembler facade (labels, branches, veneers, ABI moves) | **yes** | the SM model; style: target-independent call sites, per-ISA bodies |
+| MacroAssembler facade (labels, branches, veneers, ABI moves) | **yes** | target-independent call sites with per-ISA bodies; Bistromath's thin adapter maps its logical register vocabulary onto AArch64 and x86_64 |
 | Executable-memory allocator (W^X, MAP_JIT, icache flush, free) | **yes** | one reservation per Engine (§8) |
 | Entry/exit thunks + driver loop infrastructure | **yes** (machinery) | instances differ per tier — JS thunks sync `CallFrame`, wasm thunks marshal cells; the per-signature JS↔wasm boundary thunks are first-class citizens here (§7.1) |
 | Safepoint/interrupt convention (`host_interrupt`, budgets) | **yes** | same atomic, same back-edge discipline |
@@ -631,9 +639,11 @@ src/runtime/jit/            shared substrate (new)
   code_alloc.zig            reserve/commit, W^X toggling, icache flush,
                             per-code free; one region per Engine
   asm_aarch64.zig           encoder
-  asm_x86_64.zig            encoder (second target, §8)
-  masm.zig                  facade + ABI helpers + veneer/branch fixups
+  asm_x86_64.zig            encoder
+  masm.zig                  AArch64 facade used by Ohaimark/Spasm
 src/runtime/bistromath/     T1 JS baseline (per AGENTS.md repo map)
+  bistromath.zig            target-neutral one-pass compiler
+  masm.zig                  AArch64/x86_64 register + ABI adapter
 src/runtime/ohaimark/       T2 (M6; ADR first)
 src/runtime/wasm/spasm.zig  Spasm — the wasm T1 baseline (§6)
 ```
@@ -659,10 +669,13 @@ through the host-function bridge ([wasm-engine.md](wasm-engine.md)
 noise against dispatch overhead. The moment either side compiles,
 the boundary gets the same treatment as everything else:
 
-- **Same code region, near calls both directions.** Compiled JS,
-  compiled wasm, and every boundary thunk live in the one §8
-  reservation, inside arm64 `BL` range — a warm crossing never
-  takes an indirect hop through engine plumbing.
+- **Same code region, near calls both directions.** On AArch64,
+  compiled JS, compiled wasm, and every boundary thunk live in the
+  one §8 reservation, inside `BL` (±128 MiB) range — a warm crossing
+  never takes an indirect hop through engine plumbing. x86_64
+  Bistromath already uses the corresponding `rel32` (±2 GiB) scheme;
+  Spasm and the boundary thunks remain future x86_64 work and will
+  share that reservation when they gain an x86_64 backend.
 - **Per-signature thunks, compiled once, cached by canonical
   function type** (the same type identity `call_indirect` checks).
   The JS→wasm *entry thunk* unboxes arguments straight from the
@@ -708,7 +721,10 @@ The ritual, validated against JSC/V8 practice and Apple's
 porting-JIT guide; all of it lives in `code_alloc.zig` so no tier
 ever touches a syscall:
 
-- **macOS arm64 (primary target):** `mmap(PROT_READ|WRITE|EXEC,
+- **Supported hosts:** the executable allocator supports macOS and Linux on
+  AArch64 and x86_64. Bistromath is qualified on both ISAs; Ohaimark remains
+  AArch64-only, and targets without a qualified emitter interpret in Lantern.
+- **macOS AArch64:** `mmap(PROT_READ|WRITE|EXEC,
   MAP_PRIVATE|ANONYMOUS|MAP_JIT)` — Zig's `std.c.MAP` for darwin
   already carries the `JIT` bit. Writes happen inside a
   `pthread_jit_write_protect_np(0)` … `(1)` window (per-thread,
@@ -720,18 +736,21 @@ ever touches a syscall:
   entitlement; the `com.apple.security.cs.allow-jit` entitlement
   becomes relevant only if Cynic ever ships hardened-runtime signed
   builds (recorded, not actioned).
+- **macOS x86_64:** the ordinary page-protection path flips the reserved
+  region RW↔RX with `mprotect`; coherent instruction/data caches need no
+  explicit invalidation.
 - **Linux:** start with the simple, measured thing — `mprotect`
   flipping RW↔RX around writes (SpiderMonkey measured <1% Octane
   cost for full W^X). x86_64 needs no icache maintenance; aarch64
   Linux gets compiler_rt's real `__clear_cache`.
-- **W^X always, RWX never** — including on Intel macs where the
-  toggle is a no-op; the allocator API makes writable-and-executable
+- **W^X always, RWX never** — including on Intel Macs, which use the
+  page-protection path; the allocator API makes writable-and-executable
   states mutually exclusive by construction, because retrofitting
   W^X into a JIT that assumed RWX is the documented painful path.
-- **Branch reach:** arm64 `B/BL` spans ±128 MiB. v1 reserves a
-  single region well under that (64 MiB default, flag-tunable) so
-  every intra-cache call is a near branch; veneer support in `masm`
-  is the day-two answer if a workload outgrows it.
+- **Branch reach:** AArch64 `B/BL` spans ±128 MiB and x86_64 `rel32`
+  spans ±2 GiB. v1 reserves a single region well under both (64 MiB
+  default, flag-tunable), so every intra-cache call is a near branch;
+  veneer support in `masm` is the day-two answer if a workload outgrows it.
 - **Code lifetime:** `CodeAllocator.installOwned` returns an
   `InstalledCode` handle containing the exact executable slice and allocator.
   `Chunk.JitState` owns Bistromath's main code + continuation blob and
@@ -799,7 +818,10 @@ The tier ships dark, proves equivalence, then flips on:
    vs off — the same bar every IC commit already meets
    ([inline-caches.md](inline-caches.md) "Verification"). Lantern is
    the executable spec; Bistromath is correct exactly when the
-   sweep can't tell them apart.
+   sweep can't tell them apart. The forced-T1 sweep also passes
+   `--require-bistromath-entry`, which exits 2 unless at least one generated
+   entry actually executes; equal pass sets cannot pass by comparing Lantern
+   with itself.
    Ohaimark repeats this gate independently with test262 `--ohaimark`, which
    forces T2 before T1 without changing the established T1-only `--jit` pass
    set. CI reruns that exact comparison as a gating step and adds
@@ -1049,6 +1071,17 @@ useful:
    `comm`, never counts: counts let compensating flips hide), a
    `--jit` lane in the gc-stress matrix, bench at the §11
    targets — then the default-on conversation.
+
+   3h. **x86_64 qualification (2026-08-08).** The one-pass compiler now
+       targets AArch64 and x86_64 through `bistromath/masm.zig`; the x86_64
+       side owns its SysV entry/helper ABI, register mapping, and rel32
+       branches without changing Lantern-frame identity or tier-down state.
+       Full interpreter and forced-T1 test262 sweeps on macOS under Rosetta
+       both passed 48,517 fixtures with an empty pass-set diff. The forced
+       sweep executed 2,455,587 generated entries, counted by the fail-closed
+       `--require-bistromath-entry` witness. `x86_64-linux-musl` and
+       `aarch64-linux-musl` cross-builds plus focused ReleaseSafe suites on
+       both ISAs also passed.
 4. **Spasm** — `wasm/spasm.zig` on the same substrate (§6) plus
    the §7.1 per-signature boundary thunks, gated by the wasm
    spec-testsuite at 100% with tiering forced, scored against the
@@ -1313,10 +1346,6 @@ useful:
   engine compiles its optimizing tier off-thread; Cynic realms are
   single-threaded today, which is the complication to design
   around).
-- **x86_64 timing** — the masm facade keeps the second encoder a
-  mechanical port; land it when CI hardware or an embedder demands
-  it, not before the differential gate exists to validate it
-  cheaply.
 - **Polymorphic ICs** — stay deferred per
   [inline-caches.md](inline-caches.md) until Ohaimark consumes
   feedback; T1 neither needs nor wants them.

--- a/src/main.zig
+++ b/src/main.zig
@@ -460,7 +460,8 @@ pub const ParsedFlags = struct {
     /// byte-identical through every increment, gc-stress and bench
     /// gates green). `--no-jit` is the permanent escape hatch;
     /// `--jit` is still accepted as an explicit no-op. Sets
-    /// `realm.jit_enabled`; a comptime no-op off aarch64.
+    /// `realm.jit_enabled`; a comptime no-op outside AArch64/x86_64
+    /// macOS/Linux hosts, where Lantern remains the complete engine.
     jit: bool = true,
     /// Ohaimark (docs/ohaimark.md) — ON by default after its performance,
     /// differential, GC-pressure, and fuzz gates passed. `--no-ohaimark`

--- a/src/root.zig
+++ b/src/root.zig
@@ -161,9 +161,12 @@ test {
     _ = @import("runtime/wasm/tests.zig");
     _ = @import("runtime/jit/code_alloc.zig");
     _ = @import("runtime/jit/asm_aarch64.zig");
+    _ = @import("runtime/jit/asm_x86_64_test.zig");
     _ = @import("runtime/jit/masm.zig");
+    _ = @import("runtime/jit/masm_safety_test.zig");
     _ = @import("runtime/jit/layout.zig");
     _ = @import("runtime/bistromath/bistromath.zig");
+    _ = @import("runtime/bistromath/x86_64_test.zig");
     _ = @import("runtime/ohaimark/ohaimark.zig");
     _ = @import("runtime/ohaimark/tests.zig");
     _ = @import("runtime/ohaimark/allocation_test.zig");

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -33,6 +33,7 @@ pub const Heap = heap.Heap;
 pub const HandleScope = heap.HandleScope;
 
 pub const BistromathStats = @import("runtime/bistromath/stats.zig").Stats;
+pub const BistromathEntryCounter = @import("runtime/bistromath/stats.zig").SharedEntryCounter;
 pub const OhaimarkStats = @import("runtime/ohaimark/stats.zig").Stats;
 
 pub const realm = @import("runtime/realm.zig");

--- a/src/runtime.zig
+++ b/src/runtime.zig
@@ -32,6 +32,7 @@ pub const heap = @import("runtime/heap.zig");
 pub const Heap = heap.Heap;
 pub const HandleScope = heap.HandleScope;
 
+pub const BistromathStats = @import("runtime/bistromath/stats.zig").Stats;
 pub const OhaimarkStats = @import("runtime/ohaimark/stats.zig").Stats;
 
 pub const realm = @import("runtime/realm.zig");

--- a/src/runtime/bistromath/bistromath.zig
+++ b/src/runtime/bistromath/bistromath.zig
@@ -30,7 +30,6 @@
 //! type speculation are Ohaimark's (§5).
 
 const std = @import("std");
-const builtin = @import("builtin");
 
 const chunk_mod = @import("../../bytecode/chunk.zig");
 const Chunk = chunk_mod.Chunk;
@@ -43,19 +42,18 @@ const interpreter = @import("../lantern/interpreter.zig");
 const CallFrame = interpreter.CallFrame;
 const RunError = interpreter.RunError;
 const code_alloc = @import("../jit/code_alloc.zig");
-const masm_mod = @import("../jit/masm.zig");
+const masm_mod = @import("masm.zig");
 const Masm = masm_mod.Masm;
-const a64 = @import("../jit/asm_aarch64.zig");
+const isa = masm_mod;
 const layout = @import("../jit/layout.zig");
 const JSObject = @import("../object.zig").JSObject;
 const heap_mod = @import("../heap.zig");
 const ohaimark_policy = @import("../ohaimark/policy.zig");
 
-/// Bistromath needs both an executable-memory target and an
-/// emitter for the host ISA. x86_64 hosts run the engine fine but
-/// stay interpreter-only until the second encoder lands
-/// (docs/jit.md §14).
-pub const supported = code_alloc.supported and builtin.cpu.arch == .aarch64;
+/// Bistromath needs both an executable-memory target and a qualified emitter
+/// for the host ISA. The compiler itself remains shared across the two native
+/// backends; only `bistromath/masm.zig` owns their ABI/code-encoding details.
+pub const supported = code_alloc.supported and masm_mod.supported_isa;
 
 /// What compiled code reports back to the dispatcher.
 pub const EntryResult = enum(u32) {
@@ -284,7 +282,9 @@ fn driveTop(
     var stub = entry;
     while (true) {
         const fr = &frames.items[frames.items.len - 1];
-        switch (@as(EntryResult, @enumFromInt(stub(realm, fr, fr.registers.ptr)))) {
+        realm.heap.bistromath_stats.recordEntry();
+        const raw_result = stub(realm, fr, fr.registers.ptr);
+        switch (@as(EntryResult, @enumFromInt(raw_result))) {
             .done => {
                 // §10.2.2 ConstructResult for construct frames.
                 var ret = fr.accumulator;
@@ -370,7 +370,7 @@ fn compile(realm: *Realm, chunk: *const Chunk, js: *Chunk.JitState) void {
     var c = Compiler.init(realm.heap.allocator, chunk);
     defer c.deinit();
     c.run() catch return;
-    var code = ca.installOwned(c.m.code.items) catch return;
+    var code = ca.installOwned(c.m.bytes()) catch return;
     defer code.deinit();
     // The OSR table rides in the code region (same allocator as the
     // code). If its install fails the chunk still
@@ -430,21 +430,29 @@ pub fn tryOsrEnterTop(
     };
 }
 
-const CompileError = error{ OutOfMemory, UnsupportedOp };
+const CompileError = error{
+    OutOfMemory,
+    UnsupportedOp,
+    UnsupportedInstruction,
+    LabelAlreadyBound,
+    InvalidLabel,
+    BranchOutOfRange,
+    UnresolvedLabel,
+};
 
 // Pinned registers inside compiled code (docs/jit.md §4.2). x19-x24
 // are callee-saved per AAPCS64 and restored in the epilogue;
 // x9-x13 are scratch.
-const realm_reg: a64.Reg = .x19;
-const frame_reg: a64.Reg = .x20;
-const regs_reg: a64.Reg = .x21;
-const acc_reg: a64.Reg = .x22;
+const realm_reg: isa.Reg = .x19;
+const frame_reg: isa.Reg = .x20;
+const regs_reg: isa.Reg = .x21;
+const acc_reg: isa.Reg = .x22;
 /// Pinned `Value.fromInt32(0).bits` — the int32 tag in the high
 /// half-word. `eor` against it + `lsr #48` is the tag test.
-const int32_tag_reg: a64.Reg = .x23;
+const int32_tag_reg: isa.Reg = .x23;
 /// Pinned `Value.false_.bits` — the bool tag for compare results
 /// and `jmp_if_*` truthiness.
-const bool_tag_reg: a64.Reg = .x24;
+const bool_tag_reg: isa.Reg = .x24;
 
 // Struct offsets come from the layout contract (docs/jit.md §12
 // step 3a) — never derived locally.
@@ -488,7 +496,10 @@ fn ohaimarkOsrYieldProbe(
     target_bc: u64,
 ) callconv(.c) u32 {
     if (!r.ohaimark_osr_enabled or !r.ohaimark_enabled or !r.jit_enabled) return 0;
-    if (comptime !supported) return 0;
+    // Never yield a Bistromath activation to an Ohaimark backend that cannot
+    // install native code on this target. Keep this tied to T2's cycle-free
+    // policy constant so a future backend addition cannot leave a stale gate.
+    if (comptime !ohaimark_policy.supported) return 0;
     const state = frame.chunk.jit_state orelse return 0;
     if (state.ohaimark_osr_strikes >= ohaimark_policy.osr_strike_limit) return 0;
     if (target_bc > std.math.maxInt(u32)) return 0;
@@ -888,6 +899,30 @@ const Compiler = struct {
         try self.prologue();
         try self.body();
         try self.tail();
+        try self.validateLabels();
+    }
+
+    /// A missing bind must be a normal compile refusal. Installing a rel32
+    /// placeholder would silently turn an intended jump into fallthrough.
+    fn validateLabels(self: *const Compiler) CompileError!void {
+        for (self.labels.items) |*label| if (!Masm.labelResolved(label))
+            return error.UnresolvedLabel;
+        for (self.tds.items) |*stub| if (!Masm.labelResolved(&stub.label))
+            return error.UnresolvedLabel;
+        for (self.threws.items) |*stub| if (!Masm.labelResolved(&stub.label))
+            return error.UnresolvedLabel;
+        for (self.resume_points.items) |*point| if (!Masm.labelResolved(&point.label))
+            return error.UnresolvedLabel;
+        const fixed = [_]*const Masm.Label{
+            &self.body_start,
+            &self.done_label,
+            &self.frame_pushed_label,
+            &self.tier_down_label,
+            &self.threw_label,
+            &self.oom_label,
+        };
+        for (fixed) |label| if (!Masm.labelResolved(label))
+            return error.UnresolvedLabel;
     }
 
     /// Pass 1 — reject unsupported opcodes before any emission and
@@ -935,26 +970,23 @@ const Compiler = struct {
 
     fn prologue(self: *Compiler) CompileError!void {
         const m = &self.m;
-        try m.emit(a64.stpPreIdxSp(.fp, .lr, -16));
-        try m.emit(a64.stpPreIdxSp(.x19, .x20, -16));
-        try m.emit(a64.stpPreIdxSp(.x21, .x22, -16));
-        try m.emit(a64.stpPreIdxSp(.x23, .x24, -16));
-        try m.emit(a64.movReg(realm_reg, .x0));
-        try m.emit(a64.movReg(frame_reg, .x1));
-        try m.emit(a64.movReg(regs_reg, .x2));
-        try m.emit(a64.ldrImm(acc_reg, frame_reg, acc_off));
+        try m.enterFrame();
+        try m.moveEntryArg(realm_reg, 0);
+        try m.moveEntryArg(frame_reg, 1);
+        try m.moveEntryArg(regs_reg, 2);
+        try m.emit(isa.ldrImm(acc_reg, frame_reg, acc_off));
         try m.movImm64(int32_tag_reg, int32_tag_bits);
         try m.movImm64(bool_tag_reg, bool_tag_bits);
     }
 
     fn body(self: *Compiler) CompileError!void {
         const m = &self.m;
-        m.bind(&self.body_start);
+        try m.bind(&self.body_start);
         const code = self.chunk.code;
         var i: usize = 0;
         while (i < code.len) {
             const bc: u32 = @intCast(i);
-            if (self.target_labels.get(bc)) |idx| m.bind(&self.labels.items[idx]);
+            if (self.target_labels.get(bc)) |idx| try m.bind(&self.labels.items[idx]);
             const op: Op = @enumFromInt(code[i]);
             const after = i + 1 + Op.operandSize(op);
             switch (op) {
@@ -978,20 +1010,20 @@ const Compiler = struct {
                     const k = readU16(code, i + 1);
                     try m.movImm64(acc_reg, self.chunk.constants[k].bits);
                 },
-                .ldar => try m.emit(a64.ldrImm(acc_reg, regs_reg, regSlot(code[i + 1]))),
-                .star => try m.emit(a64.strImm(acc_reg, regs_reg, regSlot(code[i + 1]))),
+                .ldar => try m.emit(isa.ldrImm(acc_reg, regs_reg, regSlot(code[i + 1]))),
+                .star => try m.emit(isa.strImm(acc_reg, regs_reg, regSlot(code[i + 1]))),
                 // Compact forms — index/constant baked into the opcode.
                 .lda_zero => try m.movImm64(acc_reg, Value.fromInt32(0).bits),
                 .lda_one => try m.movImm64(acc_reg, Value.fromInt32(1).bits),
-                .ldar_0, .ldar_1, .ldar_2, .ldar_3 => try m.emit(a64.ldrImm(acc_reg, regs_reg, regSlot(@intFromEnum(op) - @intFromEnum(Op.ldar_0)))),
-                .star_0, .star_1, .star_2, .star_3 => try m.emit(a64.strImm(acc_reg, regs_reg, regSlot(@intFromEnum(op) - @intFromEnum(Op.star_0)))),
+                .ldar_0, .ldar_1, .ldar_2, .ldar_3 => try m.emit(isa.ldrImm(acc_reg, regs_reg, regSlot(@intFromEnum(op) - @intFromEnum(Op.ldar_0)))),
+                .star_0, .star_1, .star_2, .star_3 => try m.emit(isa.strImm(acc_reg, regs_reg, regSlot(@intFromEnum(op) - @intFromEnum(Op.star_0)))),
                 .mov => {
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
-                    try m.emit(a64.strImm(.x9, regs_reg, regSlot(code[i + 2])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.strImm(.x9, regs_reg, regSlot(code[i + 2])));
                 },
                 .star_ldar => {
-                    try m.emit(a64.strImm(acc_reg, regs_reg, regSlot(code[i + 1])));
-                    try m.emit(a64.ldrImm(acc_reg, regs_reg, regSlot(code[i + 2])));
+                    try m.emit(isa.strImm(acc_reg, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(acc_reg, regs_reg, regSlot(code[i + 2])));
                 },
                 .inc_reg, .dec_reg => {
                     // §13.4 fast path. The bytecode's general semantics are
@@ -1001,30 +1033,30 @@ const Compiler = struct {
                     // the observable slow path exactly once.
                     const td = try self.tdFor(bc);
                     const r = code[i + 1];
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r)));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r)));
                     try self.checkInt32(.x9, td);
                     if (op == .inc_reg) {
-                        try m.emit(a64.addsImmW(.x11, .x9, 1));
+                        try m.emit(isa.addsImmW(.x11, .x9, 1));
                     } else {
                         try m.movImm64(.x10, 1);
-                        try m.emit(a64.subsRegW(.x11, .x9, .x10));
+                        try m.emit(isa.subsRegW(.x11, .x9, .x10));
                     }
                     try m.jumpCond(.vs, td);
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
-                    try m.emit(a64.strImm(acc_reg, regs_reg, regSlot(r)));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.strImm(acc_reg, regs_reg, regSlot(r)));
                 },
 
                 .add, .sub => {
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
                     try m.emit(if (op == .add)
-                        a64.addsRegW(.x11, .x9, acc_reg)
+                        isa.addsRegW(.x11, .x9, acc_reg)
                     else
-                        a64.subsRegW(.x11, .x9, acc_reg));
+                        isa.subsRegW(.x11, .x9, acc_reg));
                     try m.jumpCond(.vs, td);
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .add_to_int32 => {
                     // `acc = ToInt32(reg + acc)`. Like `.add` but the
@@ -1033,23 +1065,23 @@ const Compiler = struct {
                     // low word IS the answer. Both operands must be
                     // int32 (else deopt); the tagged retag follows.
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
-                    try m.emit(a64.addsRegW(.x11, .x9, acc_reg));
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.addsRegW(.x11, .x9, acc_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .mul => {
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
                     // 64-bit product of the 32-bit payloads; the
                     // result is i32-representable iff it sign-
                     // extends to itself.
-                    try m.emit(a64.smull(.x11, .x9, acc_reg));
-                    try m.emit(a64.sxtw(.x12, .x11));
-                    try m.emit(a64.cmpReg(.x12, .x11));
+                    try m.emit(isa.smull(.x11, .x9, acc_reg));
+                    try m.emit(isa.sxtw(.x12, .x11));
+                    try m.emit(isa.cmpReg(.x12, .x11));
                     try m.jumpCond(.ne, td);
                     // §6.1.6.1.4: int32 cannot encode -0. A zero product
                     // with one negative operand resumes in Lantern, whose
@@ -1059,9 +1091,9 @@ const Compiler = struct {
                     try m.jumpCbnz(.x11, &nonzero);
                     try m.jumpTbnz(.x9, 31, td);
                     try m.jumpTbnz(acc_reg, 31, td);
-                    m.bind(&nonzero);
-                    try m.emit(a64.movRegW(.x11, .x11));
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.bind(&nonzero);
+                    try m.emit(isa.movRegW(.x11, .x11));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .add_smi, .add_smi8, .add_smi16 => {
                     const td = try self.tdFor(bc);
@@ -1070,12 +1102,12 @@ const Compiler = struct {
                         .add_smi16 => readI16(code, i + 2),
                         else => readI32(code, i + 2),
                     };
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try m.movImm64(.x10, @as(u32, @bitCast(imm)));
-                    try m.emit(a64.addsRegW(.x11, .x9, .x10));
+                    try m.emit(isa.addsRegW(.x11, .x9, .x10));
                     try m.jumpCond(.vs, td);
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .to_int32 => {
                     // §7.1.6 fast path: an int32 is its own ToInt32.
@@ -1084,33 +1116,33 @@ const Compiler = struct {
                 },
                 .bit_and, .bit_or, .bit_xor => {
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
                     try m.emit(switch (op) {
-                        .bit_and => a64.andRegW(.x11, .x9, acc_reg),
-                        .bit_or => a64.orrRegW(.x11, .x9, acc_reg),
-                        else => a64.eorRegW(.x11, .x9, acc_reg),
+                        .bit_and => isa.andRegW(.x11, .x9, acc_reg),
+                        .bit_or => isa.orrRegW(.x11, .x9, acc_reg),
+                        else => isa.eorRegW(.x11, .x9, acc_reg),
                     });
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
 
                 .lt, .gt, .le, .ge, .eq, .neq, .strict_eq, .strict_neq => {
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
                     // acc = reg CMP acc, on the int32 payloads.
-                    try m.emit(a64.cmpRegW(.x9, acc_reg));
-                    try m.emit(a64.csetW(.x11, switch (op) {
-                        .lt => a64.Cond.lt,
+                    try m.emit(isa.cmpRegW(.x9, acc_reg));
+                    try m.emit(isa.csetW(.x11, switch (op) {
+                        .lt => isa.Cond.lt,
                         .gt => .gt,
                         .le => .le,
                         .ge => .ge,
                         .eq, .strict_eq => .eq,
                         else => .ne,
                     }));
-                    try m.emit(a64.orrReg(acc_reg, .x11, bool_tag_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, bool_tag_reg));
                 },
 
                 .make_environment => {
@@ -1152,8 +1184,8 @@ const Compiler = struct {
                     const threw = try self.threwFor(bc);
                     // Root the live accumulator through the frame —
                     // the callee may allocate and GC (§4.2).
-                    try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_callee)));
+                    try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_callee)));
                     try self.emitCallDispatch(.x9, null, r_callee + 1, argc, ic_call, @intCast(after), td, threw);
                     try self.bindResume(@intCast(after));
                 },
@@ -1168,8 +1200,8 @@ const Compiler = struct {
                     const ic_call: u16 = if (op == .call_method8) code[i + 4] else readU16(code, i + 4);
                     const td = try self.tdFor(bc);
                     const threw = try self.threwFor(bc);
-                    try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_callee)));
+                    try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_callee)));
                     try self.emitCallDispatch(.x9, r_recv, r_callee + 1, argc, ic_call, @intCast(after), td, threw);
                     try self.bindResume(@intCast(after));
                 },
@@ -1192,8 +1224,8 @@ const Compiler = struct {
                     // acc_reg, so acc_reg must stay the pre-op value
                     // until the call commits (x14 carries the
                     // callee instead).
-                    try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-                    try m.emit(a64.ldrImm(.x14, regs_reg, regSlot(r_recv)));
+                    try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.ldrImm(.x14, regs_reg, regSlot(r_recv)));
                     try self.emitPropertyIcLoad(.x14, .x14, ic_load, td);
                     try self.emitCallDispatch(.x14, r_recv, r_recv + 1, argc, ic_call, @intCast(after), td, threw);
                     try self.bindResume(@intCast(after));
@@ -1232,30 +1264,30 @@ const Compiler = struct {
                         // before the callee pointer is computed. A
                         // trip re-runs this tail_call in Lantern.
                         try self.backEdgeSafePoint(bc);
-                        try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_callee)));
+                        try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_callee)));
                         // Function-kind heap pointer (kind bits 0).
                         try m.movImm64(.x13, layout.value_bits.tag_object_shifted);
-                        try m.emit(a64.eorReg(.x13, .x9, .x13));
-                        try m.emit(a64.lsrImm(.x12, .x13, 48));
+                        try m.emit(isa.eorReg(.x13, .x9, .x13));
+                        try m.emit(isa.lsrImm(.x12, .x13, 48));
                         try m.jumpCbnz(.x12, td);
-                        try m.emit(a64.lslImm(.x12, .x13, 62));
-                        try m.emit(a64.lsrImm(.x12, .x12, 62));
+                        try m.emit(isa.lslImm(.x12, .x13, 62));
+                        try m.emit(isa.lsrImm(.x12, .x12, 62));
                         try m.jumpCbnz(.x12, td);
-                        try m.emit(a64.lsrImm(.x10, .x13, 2));
-                        try m.emit(a64.lslImm(.x10, .x10, 2));
+                        try m.emit(isa.lsrImm(.x10, .x13, 2));
+                        try m.emit(isa.lslImm(.x10, .x10, 2));
                         // Same chunk, not an arrow.
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.chunk));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.chunk));
                         try m.movImm64(.x12, @intFromPtr(self.chunk));
-                        try m.emit(a64.cmpReg(.x11, .x12));
+                        try m.emit(isa.cmpReg(.x11, .x12));
                         try m.jumpCond(.ne, td);
-                        try m.emit(a64.ldrbImm(.x11, .x10, layout.function.is_arrow));
+                        try m.emit(isa.ldrbImm(.x11, .x10, layout.function.is_arrow));
                         try m.jumpCbnz(.x11, td);
                         // Args window down to r0..argc-1 (dest is
                         // always below source — forward copy safe).
                         var k: u8 = 0;
                         while (k < argc) : (k += 1) {
-                            try m.emit(a64.ldrImm(.x11, regs_reg, regSlot(r_callee + 1 + k)));
-                            try m.emit(a64.strImm(.x11, regs_reg, regSlot(k)));
+                            try m.emit(isa.ldrImm(.x11, regs_reg, regSlot(r_callee + 1 + k)));
+                            try m.emit(isa.strImm(.x11, regs_reg, regSlot(k)));
                         }
                         // Frame rebuild from the callee's capture
                         // set — the interpreter's reframe store set,
@@ -1264,21 +1296,21 @@ const Compiler = struct {
                         // wrap flags) and argc (only the arguments
                         // machinery reads it, which register-safe
                         // bodies cannot contain).
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.captured_env));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.env));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.captured_env));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.env));
                         try m.movImm64(.x12, Value.undefined_.bits);
-                        try m.emit(a64.strImm(.x12, frame_reg, layout.frame.this_value));
-                        try m.emit(a64.strImm(.x12, frame_reg, layout.frame.new_target));
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.home_object));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.home_object));
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.home_function));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.home_function));
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.super_called_cell));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.super_called_cell));
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.owning_module));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.owning_module));
-                        try m.emit(a64.ldrImm(.x11, .x10, layout.function.realm));
-                        try m.emit(a64.strImm(.x11, frame_reg, layout.frame.running_realm));
+                        try m.emit(isa.strImm(.x12, frame_reg, layout.frame.this_value));
+                        try m.emit(isa.strImm(.x12, frame_reg, layout.frame.new_target));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.home_object));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.home_object));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.home_function));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.home_function));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.super_called_cell));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.super_called_cell));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.owning_module));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.owning_module));
+                        try m.emit(isa.ldrImm(.x11, .x10, layout.function.realm));
+                        try m.emit(isa.strImm(.x11, frame_reg, layout.frame.running_realm));
                         // A fresh activation's accumulator.
                         try m.movImm64(acc_reg, Value.undefined_.bits);
                         try m.jump(&self.body_start);
@@ -1297,31 +1329,31 @@ const Compiler = struct {
                     // down.
                     const td = try self.tdFor(bc);
                     try self.checkInt32(acc_reg, td);
-                    try m.emit(a64.movRegW(.x11, acc_reg));
+                    try m.emit(isa.movRegW(.x11, acc_reg));
                     try m.jumpCbz(.x11, td);
-                    try m.emit(a64.movz(.x13, 0, 0));
-                    try m.emit(a64.subsRegW(.x11, .x13, .x11));
+                    try m.emit(isa.movz(.x13, 0, 0));
+                    try m.emit(isa.subsRegW(.x11, .x13, .x11));
                     try m.jumpCond(.vs, td);
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .bit_not => {
                     // §13.5.6 — ~int32 stays int32 always.
                     const td = try self.tdFor(bc);
                     try self.checkInt32(acc_reg, td);
-                    try m.emit(a64.movn(.x13, 0, 0));
-                    try m.emit(a64.eorRegW(.x11, acc_reg, .x13));
-                    try m.emit(a64.orrReg(acc_reg, .x11, int32_tag_reg));
+                    try m.emit(isa.movn(.x13, 0, 0));
+                    try m.emit(isa.eorRegW(.x11, acc_reg, .x13));
+                    try m.emit(isa.orrReg(acc_reg, .x11, int32_tag_reg));
                 },
                 .logical_not => {
                     // §13.5.7 on an already-Boolean acc — payload
                     // bit 0 flips and the tag bits are untouched, so
                     // no retag. Non-bool acc tiers down to ToBoolean.
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.eorReg(.x13, acc_reg, bool_tag_reg));
-                    try m.emit(a64.cmpImm(.x13, 1, false));
+                    try m.emit(isa.eorReg(.x13, acc_reg, bool_tag_reg));
+                    try m.emit(isa.cmpImm(.x13, 1, false));
                     try m.jumpCond(.hi, td);
-                    try m.emit(a64.movz(.x13, 1, 0));
-                    try m.emit(a64.eorReg(acc_reg, acc_reg, .x13));
+                    try m.emit(isa.movz(.x13, 1, 0));
+                    try m.emit(isa.eorReg(acc_reg, acc_reg, .x13));
                 },
                 .lda_env => {
                     // Fixed-depth chain walk (the compiler
@@ -1331,18 +1363,18 @@ const Compiler = struct {
                     const depth = code[i + 1];
                     const slot = code[i + 2];
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.env));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.env));
                     try m.jumpCbz(.x9, td);
                     var d = depth;
                     while (d > 0) : (d -= 1) {
-                        try m.emit(a64.ldrImm(.x9, .x9, layout.env.parent));
+                        try m.emit(isa.ldrImm(.x9, .x9, layout.env.parent));
                         try m.jumpCbz(.x9, td);
                     }
-                    try m.emit(a64.ldrImm(.x11, .x9, layout.env.slots_len));
-                    try m.emit(a64.cmpImm(.x11, slot, false));
+                    try m.emit(isa.ldrImm(.x11, .x9, layout.env.slots_len));
+                    try m.emit(isa.cmpImm(.x11, slot, false));
                     try m.jumpCond(.ls, td);
-                    try m.emit(a64.ldrImm(.x10, .x9, layout.env.slots));
-                    try m.emit(a64.ldrImm(acc_reg, .x10, @as(u15, slot) * 8));
+                    try m.emit(isa.ldrImm(.x10, .x9, layout.env.slots));
+                    try m.emit(isa.ldrImm(acc_reg, .x10, @as(u15, slot) * 8));
                 },
                 .sta_env => {
                     // Same walk; the store runs the interpreter's
@@ -1351,20 +1383,20 @@ const Compiler = struct {
                     const depth = code[i + 1];
                     const slot = code[i + 2];
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.env));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.env));
                     try m.jumpCbz(.x9, td);
                     var d = depth;
                     while (d > 0) : (d -= 1) {
-                        try m.emit(a64.ldrImm(.x9, .x9, layout.env.parent));
+                        try m.emit(isa.ldrImm(.x9, .x9, layout.env.parent));
                         try m.jumpCbz(.x9, td);
                     }
-                    try m.emit(a64.ldrImm(.x11, .x9, layout.env.slots_len));
-                    try m.emit(a64.cmpImm(.x11, slot, false));
+                    try m.emit(isa.ldrImm(.x11, .x9, layout.env.slots_len));
+                    try m.emit(isa.cmpImm(.x11, slot, false));
                     try m.jumpCond(.ls, td);
-                    try m.emit(a64.movReg(.x0, realm_reg));
-                    try m.emit(a64.movReg(.x1, .x9));
+                    try m.emit(isa.movReg(.x0, realm_reg));
+                    try m.emit(isa.movReg(.x1, .x9));
                     try m.movImm64(.x2, slot);
-                    try m.emit(a64.movReg(.x3, acc_reg));
+                    try m.emit(isa.movReg(.x3, acc_reg));
                     try m.callAbs(.x16, @intFromPtr(&envStoreBarrier));
                 },
                 .lda_global_slot => {
@@ -1376,10 +1408,10 @@ const Compiler = struct {
                     const abs_idx: usize = @as(usize, self.chunk.global_lexical_base) + readU32(code, i + 1);
                     var have_gr = Masm.Label{};
                     defer have_gr.fixups.deinit(m.gpa);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.running_realm));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.running_realm));
                     try m.jumpCbnz(.x9, &have_gr);
-                    try m.emit(a64.movReg(.x9, realm_reg));
-                    m.bind(&have_gr);
+                    try m.emit(isa.movReg(.x9, realm_reg));
+                    try m.bind(&have_gr);
                     try self.loadFieldU64(.x10, .x9, layout.realm.globals_decl_slots_ptr);
                     try self.loadFieldU64(acc_reg, .x10, abs_idx * 8);
                 },
@@ -1389,10 +1421,10 @@ const Compiler = struct {
                     const abs_idx: usize = @as(usize, self.chunk.global_lexical_base) + readU32(code, i + 1);
                     var have_gr = Masm.Label{};
                     defer have_gr.fixups.deinit(m.gpa);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.running_realm));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.running_realm));
                     try m.jumpCbnz(.x9, &have_gr);
-                    try m.emit(a64.movReg(.x9, realm_reg));
-                    m.bind(&have_gr);
+                    try m.emit(isa.movReg(.x9, realm_reg));
+                    try m.bind(&have_gr);
                     try self.loadFieldU64(.x10, .x9, layout.realm.globals_decl_slots_ptr);
                     try self.storeFieldU64(acc_reg, .x10, abs_idx * 8);
                 },
@@ -1407,17 +1439,17 @@ const Compiler = struct {
                     const td = try self.tdFor(bc);
                     var have_gr = Masm.Label{};
                     defer have_gr.fixups.deinit(m.gpa);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.running_realm));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.running_realm));
                     try m.jumpCbnz(.x9, &have_gr);
-                    try m.emit(a64.movReg(.x9, realm_reg));
-                    m.bind(&have_gr);
+                    try m.emit(isa.movReg(.x9, realm_reg));
+                    try m.bind(&have_gr);
                     try self.loadFieldU64(.x10, .x9, layout.realm.globals_decl_slots_ptr);
                     try self.loadFieldU64(.x11, .x10, abs_idx * 8);
                     try m.movImm64(.x12, Value.hole_.bits);
-                    try m.emit(a64.cmpReg(.x11, .x12));
+                    try m.emit(isa.cmpReg(.x11, .x12));
                     try m.jumpCond(.eq, td);
                     try self.loadFieldU64(.x12, .x9, layout.realm.globals_decl_const_flags_ptr);
-                    try m.emit(a64.ldrbImm(.x13, .x12, @intCast(abs_idx)));
+                    try m.emit(isa.ldrbImm(.x13, .x12, @intCast(abs_idx)));
                     try m.jumpCbnz(.x13, td);
                     try self.storeFieldU64(acc_reg, .x10, abs_idx * 8);
                 },
@@ -1432,9 +1464,9 @@ const Compiler = struct {
                     // presence and read the (always-initialised)
                     // `this_value` otherwise.
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.super_called_cell));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.super_called_cell));
                     try m.jumpCbnz(.x9, td);
-                    try m.emit(a64.ldrImm(acc_reg, frame_reg, layout.frame.this_value));
+                    try m.emit(isa.ldrImm(acc_reg, frame_reg, layout.frame.this_value));
                 },
                 .lda_property, .lda_property8 => {
                     const td = try self.tdFor(bc);
@@ -1456,7 +1488,7 @@ const Compiler = struct {
                     const r_at = i + if (narrow) @as(usize, 2) else 3;
                     const r_obj = code[r_at];
                     const ic_idx: u16 = if (narrow) code[r_at + 1] else readU16(code, r_at + 1);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_obj)));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_obj)));
                     try self.emitPropertyIcLoad(.x9, acc_reg, ic_idx, td);
                 },
                 .sta_property, .sta_property8 => {
@@ -1470,19 +1502,19 @@ const Compiler = struct {
                     const r_at = i + if (narrow) @as(usize, 2) else 3;
                     const r_obj = code[r_at];
                     const ic_idx: u16 = if (narrow) code[r_at + 1] else readU16(code, r_at + 1);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_obj)));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_obj)));
                     try self.emitPlainObject(.x9, .x9, td);
                     try self.emitStoreCellAddr(.x10, ic_idx);
-                    try m.emit(a64.ldrImm(.x11, .x10, layout.store_ic_cell.shape));
+                    try m.emit(isa.ldrImm(.x11, .x10, layout.store_ic_cell.shape));
                     try m.jumpCbz(.x11, td);
-                    try m.emit(a64.ldrImm(.x12, .x9, layout.object.shape));
-                    try m.emit(a64.cmpReg(.x11, .x12));
+                    try m.emit(isa.ldrImm(.x12, .x9, layout.object.shape));
+                    try m.emit(isa.cmpReg(.x11, .x12));
                     try m.jumpCond(.ne, td);
-                    try m.emit(a64.ldrImmW(.x11, .x10, layout.store_ic_cell.slot));
+                    try m.emit(isa.ldrImmW(.x11, .x10, layout.store_ic_cell.slot));
                     try self.emitSlotWrite(acc_reg, .x9, .x11);
-                    try m.emit(a64.movReg(.x0, realm_reg));
-                    try m.emit(a64.movReg(.x1, .x9));
-                    try m.emit(a64.movReg(.x2, acc_reg));
+                    try m.emit(isa.movReg(.x0, realm_reg));
+                    try m.emit(isa.movReg(.x1, .x9));
+                    try m.emit(isa.movReg(.x2, acc_reg));
                     try m.callAbs(.x16, @intFromPtr(&storeBarrier));
                 },
                 .lda_global, .lda_global_or_undef, .lda_global8, .lda_global_or_undef8 => {
@@ -1498,25 +1530,25 @@ const Compiler = struct {
                     const ic_idx: u16 = if (narrow) code[i + 2] else readU16(code, i + 3);
                     var have_gr = Masm.Label{};
                     defer have_gr.fixups.deinit(m.gpa);
-                    try m.emit(a64.ldrImm(.x9, frame_reg, layout.frame.running_realm));
+                    try m.emit(isa.ldrImm(.x9, frame_reg, layout.frame.running_realm));
                     try m.jumpCbnz(.x9, &have_gr);
-                    try m.emit(a64.movReg(.x9, realm_reg));
-                    m.bind(&have_gr);
+                    try m.emit(isa.movReg(.x9, realm_reg));
+                    try m.bind(&have_gr);
                     try self.emitCellAddr(.x10, ic_idx);
                     try self.loadFieldU64(.x12, .x9, layout.realm.globals_target);
                     try m.jumpCbz(.x12, td);
-                    try m.emit(a64.ldrImm(.x11, .x10, layout.load_ic_cell.shape));
+                    try m.emit(isa.ldrImm(.x11, .x10, layout.load_ic_cell.shape));
                     try m.jumpCbz(.x11, td);
-                    try m.emit(a64.ldrImm(.x13, .x12, layout.object.shape));
-                    try m.emit(a64.cmpReg(.x11, .x13));
+                    try m.emit(isa.ldrImm(.x13, .x12, layout.object.shape));
+                    try m.emit(isa.cmpReg(.x11, .x13));
                     try m.jumpCond(.ne, td);
-                    try m.emit(a64.ldrImm(.x11, .x10, layout.load_ic_cell.proto));
+                    try m.emit(isa.ldrImm(.x11, .x10, layout.load_ic_cell.proto));
                     try m.jumpCbnz(.x11, td);
                     try self.loadFieldU64(.x13, .x9, layout.realm.globals_decl_revision);
-                    try m.emit(a64.ldrImm(.x9, .x10, layout.load_ic_cell.proto_rev));
-                    try m.emit(a64.cmpReg(.x13, .x9));
+                    try m.emit(isa.ldrImm(.x9, .x10, layout.load_ic_cell.proto_rev));
+                    try m.emit(isa.cmpReg(.x13, .x9));
                     try m.jumpCond(.ne, td);
-                    try m.emit(a64.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
+                    try m.emit(isa.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
                     try self.emitSlotRead(acc_reg, .x12, .x11);
                 },
 
@@ -1524,7 +1556,7 @@ const Compiler = struct {
                     const td = try self.tdFor(bc);
                     const table_index = readU16(code, i + 2);
                     const table = self.chunk.switch_tables[table_index];
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     // Lantern handles integer-valued doubles and every
                     // non-int32 default miss. The baseline's hot path stays a
                     // tag check plus native comparisons with no JS re-entry.
@@ -1533,7 +1565,7 @@ const Compiler = struct {
                         if (target == table.default_target) continue;
                         const case_value: i32 = @intCast(@as(i64, table.min) + @as(i64, @intCast(slot)));
                         try m.movImm64(.x10, @as(u32, @bitCast(case_value)));
-                        try m.emit(a64.cmpRegW(.x9, .x10));
+                        try m.emit(isa.cmpRegW(.x9, .x10));
                         try m.jumpCond(.eq, try self.labelForExisting(target));
                     }
                     try m.jump(try self.labelForExisting(table.default_target));
@@ -1560,8 +1592,8 @@ const Compiler = struct {
                     // Bool-tagged accumulators only; anything else
                     // (numbers, strings, objects in a condition)
                     // tiers down to ToBoolean in Lantern.
-                    try m.emit(a64.eorReg(.x11, acc_reg, bool_tag_reg));
-                    try m.emit(a64.lsrImm(.x11, .x11, 48));
+                    try m.emit(isa.eorReg(.x11, acc_reg, bool_tag_reg));
+                    try m.emit(isa.lsrImm(.x11, .x11, 48));
                     try m.jumpCbnz(.x11, td);
                     var skip = Masm.Label{};
                     defer skip.fixups.deinit(m.gpa);
@@ -1574,7 +1606,7 @@ const Compiler = struct {
                     }
                     if (off < 0) try self.backEdgeSafePoint(target);
                     try m.jump(try self.labelForExisting(target));
-                    m.bind(&skip);
+                    try m.bind(&skip);
                 },
                 .loop_inc_lt, .loop_inc_lt8, .loop_inc_lt32 => {
                     const td = try self.tdFor(bc);
@@ -1583,21 +1615,21 @@ const Compiler = struct {
                     const info = op.branchInfo().?;
                     const off = info.displacement(code, i);
                     const target = info.target(code, i);
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_counter)));
-                    try m.emit(a64.ldrImm(.x10, regs_reg, regSlot(r_bound)));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_counter)));
+                    try m.emit(isa.ldrImm(.x10, regs_reg, regSlot(r_bound)));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(.x10, td);
-                    try m.emit(a64.addsImmW(.x11, .x9, 1));
+                    try m.emit(isa.addsImmW(.x11, .x9, 1));
                     try m.jumpCond(.vs, td);
-                    try m.emit(a64.orrReg(.x12, .x11, int32_tag_reg));
-                    try m.emit(a64.strImm(.x12, regs_reg, regSlot(r_counter)));
-                    try m.emit(a64.cmpRegW(.x11, .x10));
+                    try m.emit(isa.orrReg(.x12, .x11, int32_tag_reg));
+                    try m.emit(isa.strImm(.x12, regs_reg, regSlot(r_counter)));
+                    try m.emit(isa.cmpRegW(.x11, .x10));
                     var skip = Masm.Label{};
                     defer skip.fixups.deinit(m.gpa);
                     try m.jumpCond(.ge, &skip);
                     if (off < 0) try self.backEdgeSafePoint(target);
                     try m.jump(try self.labelForExisting(target));
-                    m.bind(&skip);
+                    try m.bind(&skip);
                 },
                 .jmp_if_strict_eq,
                 .jmp_if_strict_eq8,
@@ -1630,10 +1662,10 @@ const Compiler = struct {
                     const info = op.branchInfo().?;
                     const target = info.target(code, i);
                     const canonical = info.canonical;
-                    try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
+                    try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(code[i + 1])));
                     try self.checkInt32(.x9, td);
                     try self.checkInt32(acc_reg, td);
-                    try m.emit(a64.cmpRegW(.x9, acc_reg));
+                    try m.emit(isa.cmpRegW(.x9, acc_reg));
                     var skip = Masm.Label{};
                     defer skip.fixups.deinit(m.gpa);
                     // Skip the branch when it should NOT be taken. For the
@@ -1641,7 +1673,7 @@ const Compiler = struct {
                     // `jmp_if_not_*` (jump-on-false) ops it is "comparison
                     // holds" — int32 has no NaN, so the signed condition is
                     // exact here.
-                    const skip_cond: a64.Cond = switch (canonical) {
+                    const skip_cond: isa.Cond = switch (canonical) {
                         .jmp_if_strict_eq => .ne,
                         .jmp_if_strict_neq => .eq,
                         .jmp_if_not_lt => .lt,
@@ -1651,7 +1683,7 @@ const Compiler = struct {
                     };
                     try m.jumpCond(skip_cond, &skip);
                     try m.jump(try self.labelForExisting(target));
-                    m.bind(&skip);
+                    try m.bind(&skip);
                 },
 
                 .throw_if_hole => {
@@ -1660,7 +1692,7 @@ const Compiler = struct {
                     // ReferenceError with its proper message.
                     const td = try self.tdFor(bc);
                     try m.movImm64(.x9, Value.hole_.bits);
-                    try m.emit(a64.cmpReg(acc_reg, .x9));
+                    try m.emit(isa.cmpReg(acc_reg, .x9));
                     try m.jumpCond(.eq, td);
                 },
 
@@ -1674,13 +1706,13 @@ const Compiler = struct {
                     // hole) tiers down to re-run the full op in Lantern.
                     const r_obj = code[i + 1];
                     const td = try self.tdFor(bc);
-                    try m.emit(a64.ldrImm(.x0, regs_reg, regSlot(r_obj)));
-                    try m.emit(a64.movReg(.x1, acc_reg));
-                    try m.emit(a64.addImm(.x2, frame_reg, acc_off, false));
+                    try m.emit(isa.ldrImm(.x0, regs_reg, regSlot(r_obj)));
+                    try m.emit(isa.movReg(.x1, acc_reg));
+                    try m.emit(isa.addImm(.x2, frame_reg, acc_off, false));
                     try m.callAbs(.x16, @intFromPtr(&denseGetShim));
-                    try m.emit(a64.movRegW(.x0, .x0));
+                    try m.emit(isa.movRegW(.x0, .x0));
                     try m.jumpCbz(.x0, td);
-                    try m.emit(a64.ldrImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.ldrImm(acc_reg, frame_reg, acc_off));
                 },
                 .make_array_n => {
                     // docs/ctor-array-build-gap.md L2 — helper-mediated
@@ -1692,16 +1724,16 @@ const Compiler = struct {
                     // register file (regs_reg == f.registers).
                     const r_base = code[i + 1];
                     const n = code[i + 2];
-                    try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-                    try m.emit(a64.movReg(.x0, realm_reg));
-                    try m.emit(a64.movReg(.x1, regs_reg));
+                    try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.movReg(.x0, realm_reg));
+                    try m.emit(isa.movReg(.x1, regs_reg));
                     try m.movImm64(.x2, r_base);
                     try m.movImm64(.x3, n);
-                    try m.emit(a64.addImm(.x4, frame_reg, acc_off, false));
+                    try m.emit(isa.addImm(.x4, frame_reg, acc_off, false));
                     try m.callAbs(.x16, @intFromPtr(&makeArrayShim));
-                    try m.emit(a64.movRegW(.x0, .x0));
+                    try m.emit(isa.movRegW(.x0, .x0));
                     try m.jumpCbnz(.x0, &self.oom_label);
-                    try m.emit(a64.ldrImm(acc_reg, frame_reg, acc_off));
+                    try m.emit(isa.ldrImm(acc_reg, frame_reg, acc_off));
                 },
 
                 .return_ => try m.jump(&self.done_label),
@@ -1723,47 +1755,44 @@ const Compiler = struct {
     fn tail(self: *Compiler) CompileError!void {
         const m = &self.m;
         for (self.tds.items) |*t| {
-            m.bind(&t.label);
+            try m.bind(&t.label);
             try m.movImm64(.x9, t.resume_off);
             try m.jump(&self.tier_down_label);
         }
         for (self.threws.items) |*t| {
-            m.bind(&t.label);
+            try m.bind(&t.label);
             try m.movImm64(.x9, t.resume_off);
             try m.jump(&self.threw_label);
         }
-        m.bind(&self.done_label);
-        try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-        try m.emit(a64.movz(.x0, 1, 0)); // EntryResult.done
+        try m.bind(&self.done_label);
+        try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+        try m.emit(isa.movz(.x0, 1, 0)); // EntryResult.done
         var epilogue = Masm.Label{};
         defer epilogue.fixups.deinit(m.gpa);
         try m.jump(&epilogue);
         // x9 = the faulting call op's offset; the accumulator was
         // synced before the call, so only ip needs the store.
-        m.bind(&self.threw_label);
-        try m.emit(a64.strImm(.x9, frame_reg, ip_off));
-        try m.emit(a64.movz(.x0, 2, 0)); // EntryResult.threw
+        try m.bind(&self.threw_label);
+        try m.emit(isa.strImm(.x9, frame_reg, ip_off));
+        try m.emit(isa.movz(.x0, 2, 0)); // EntryResult.threw
         try m.jump(&epilogue);
-        m.bind(&self.oom_label);
-        try m.emit(a64.movz(.x0, 3, 0)); // EntryResult.host_oom
+        try m.bind(&self.oom_label);
+        try m.emit(isa.movz(.x0, 3, 0)); // EntryResult.host_oom
         try m.jump(&epilogue);
         // In-line frame-reentry (docs/jit.md §4.5): the call/construct
         // site already stamped the resume ip and flushed acc to the
         // frame, and pushed the callee — just report `frame_pushed`.
-        m.bind(&self.frame_pushed_label);
-        try m.emit(a64.movz(.x0, @intFromEnum(EntryResult.frame_pushed), 0));
+        try m.bind(&self.frame_pushed_label);
+        try m.emit(isa.movz(.x0, @intFromEnum(EntryResult.frame_pushed), 0));
         try m.jump(&epilogue);
         // x9 = bytecode offset to resume at.
-        m.bind(&self.tier_down_label);
-        try m.emit(a64.strImm(.x9, frame_reg, ip_off));
-        try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-        try m.emit(a64.movz(.x0, 0, 0)); // EntryResult.resume_interp
-        m.bind(&epilogue);
-        try m.emit(a64.ldpPostIdxSp(.x23, .x24, 16));
-        try m.emit(a64.ldpPostIdxSp(.x21, .x22, 16));
-        try m.emit(a64.ldpPostIdxSp(.x19, .x20, 16));
-        try m.emit(a64.ldpPostIdxSp(.fp, .lr, 16));
-        try m.emit(a64.ret());
+        try m.bind(&self.tier_down_label);
+        try m.emit(isa.strImm(.x9, frame_reg, ip_off));
+        try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+        try m.emit(isa.movz(.x0, 0, 0)); // EntryResult.resume_interp
+        try m.bind(&epilogue);
+        try m.leaveFrame();
+        try m.emit(isa.ret());
         // OSR entry stubs (docs/jit.md §12 3f): one per loop
         // header — the same prologue, then a jump into the body at
         // the header. The dispatcher enters here from a Lantern
@@ -1786,7 +1815,7 @@ const Compiler = struct {
         for (self.resume_points.items) |*r| {
             try self.osr_entries.append(m.gpa, .{
                 .bc = r.bc,
-                .code_off = @intCast(m.code.items.len),
+                .code_off = try continuationOffset(m.offset()),
             });
             try self.prologue();
             try m.jump(&r.label);
@@ -1796,7 +1825,7 @@ const Compiler = struct {
     fn emitTargetReentry(self: *Compiler, bc: u32) CompileError!void {
         try self.osr_entries.append(self.m.gpa, .{
             .bc = bc,
-            .code_off = @intCast(self.m.code.items.len),
+            .code_off = try continuationOffset(self.m.offset()),
         });
         try self.prologue();
         const idx = self.target_labels.get(bc) orelse return error.UnsupportedOp;
@@ -1820,34 +1849,38 @@ const Compiler = struct {
         const td = try self.tdFor(target);
         try self.loadRealmU64(.x9, step_budget_off);
         try m.jumpCbz(.x9, td);
-        try m.emit(a64.subImm(.x9, .x9, 1, false));
+        try m.emit(isa.subImm(.x9, .x9, 1, false));
         try self.storeRealmU64(.x9, step_budget_off);
         try self.loadRealmU8(.x10, interrupt_off);
         try m.jumpCbnz(.x10, td);
 
-        var osr_skip: Masm.Label = .{};
-        defer osr_skip.deinit(m.gpa);
-        try self.loadRealmU8(.x9, layout.realm.ohaimark_osr_enabled);
-        try m.jumpCbz(.x9, &osr_skip);
-        // Flush the pinned accumulator before the helper; tier-down
-        // reloads from the frame, and a concurrent GC sees it rooted.
-        try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
-        try m.emit(a64.movReg(.x0, realm_reg));
-        try m.emit(a64.movReg(.x1, frame_reg));
-        try m.movImm64(.x2, target);
-        try m.callAbs(.x16, @intFromPtr(&ohaimarkOsrYieldProbe));
-        try m.jumpCbnz(.x0, td);
-        // Helper returns 0: keep the flushed acc in the register.
-        try m.emit(a64.ldrImm(acc_reg, frame_reg, acc_off));
-        m.bind(&osr_skip);
+        if (comptime ohaimark_policy.supported) {
+            var osr_skip: Masm.Label = .{};
+            defer osr_skip.deinit(m.gpa);
+            try self.loadRealmU8(.x9, layout.realm.ohaimark_osr_enabled);
+            try m.jumpCbz(.x9, &osr_skip);
+            // Flush the pinned accumulator before the helper; tier-down
+            // reloads from the frame, and a concurrent GC sees it rooted.
+            try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
+            try m.emit(isa.movReg(.x0, realm_reg));
+            try m.emit(isa.movReg(.x1, frame_reg));
+            try m.movImm64(.x2, target);
+            try m.callAbs(.x16, @intFromPtr(&ohaimarkOsrYieldProbe));
+            // C only promises the low u32 return register on both ABIs.
+            try m.emit(isa.movRegW(.x0, .x0));
+            try m.jumpCbnz(.x0, td);
+            // Helper returns 0: keep the flushed acc in the register.
+            try m.emit(isa.ldrImm(acc_reg, frame_reg, acc_off));
+            try m.bind(&osr_skip);
+        }
     }
 
     /// `eor` against the pinned tag, shift the payload away, and
     /// tier down unless the high half-word matched int32.
-    fn checkInt32(self: *Compiler, src: a64.Reg, td: *Masm.Label) CompileError!void {
+    fn checkInt32(self: *Compiler, src: isa.Reg, td: *Masm.Label) CompileError!void {
         const m = &self.m;
-        try m.emit(a64.eorReg(.x13, src, int32_tag_reg));
-        try m.emit(a64.lsrImm(.x13, .x13, 48));
+        try m.emit(isa.eorReg(.x13, src, int32_tag_reg));
+        try m.emit(isa.lsrImm(.x13, .x13, 48));
         try m.jumpCbnz(.x13, td);
     }
 
@@ -1858,50 +1891,50 @@ const Compiler = struct {
 
     /// 64-bit field load from `base + off`; the big-offset path
     /// stages through `dst`, so no scratch is clobbered.
-    fn loadFieldU64(self: *Compiler, dst: a64.Reg, base: a64.Reg, off: usize) CompileError!void {
+    fn loadFieldU64(self: *Compiler, dst: isa.Reg, base: isa.Reg, off: usize) CompileError!void {
         const m = &self.m;
         if (off <= 32760) {
-            try m.emit(a64.ldrImm(dst, base, @intCast(off)));
+            try m.emit(isa.ldrImm(dst, base, @intCast(off)));
         } else {
-            try m.emit(a64.addImm(dst, base, @intCast(off >> 12), true));
-            try m.emit(a64.ldrImm(dst, dst, @intCast(off & 0xFFF)));
+            try m.emit(isa.addImm(dst, base, try fieldPageImmediate(off), true));
+            try m.emit(isa.ldrImm(dst, dst, @intCast(off & 0xFFF)));
         }
     }
 
-    fn loadRealmU64(self: *Compiler, dst: a64.Reg, off: usize) CompileError!void {
+    fn loadRealmU64(self: *Compiler, dst: isa.Reg, off: usize) CompileError!void {
         try self.loadFieldU64(dst, realm_reg, off);
     }
 
     /// Clobbers x13 on the big-offset path (the source register
     /// must be preserved, unlike `loadFieldU64`'s dst-staging).
-    fn storeFieldU64(self: *Compiler, src: a64.Reg, base: a64.Reg, off: usize) CompileError!void {
+    fn storeFieldU64(self: *Compiler, src: isa.Reg, base: isa.Reg, off: usize) CompileError!void {
         const m = &self.m;
         if (off <= 32760) {
-            try m.emit(a64.strImm(src, base, @intCast(off)));
+            try m.emit(isa.strImm(src, base, @intCast(off)));
         } else {
-            try m.emit(a64.addImm(.x13, base, @intCast(off >> 12), true));
-            try m.emit(a64.strImm(src, .x13, @intCast(off & 0xFFF)));
+            try m.emit(isa.addImm(.x13, base, try fieldPageImmediate(off), true));
+            try m.emit(isa.strImm(src, .x13, @intCast(off & 0xFFF)));
         }
     }
 
     /// Clobbers x13 on the big-offset path.
-    fn storeRealmU64(self: *Compiler, src: a64.Reg, off: usize) CompileError!void {
+    fn storeRealmU64(self: *Compiler, src: isa.Reg, off: usize) CompileError!void {
         const m = &self.m;
         if (off <= 32760) {
-            try m.emit(a64.strImm(src, realm_reg, @intCast(off)));
+            try m.emit(isa.strImm(src, realm_reg, @intCast(off)));
         } else {
-            try m.emit(a64.addImm(.x13, realm_reg, @intCast(off >> 12), true));
-            try m.emit(a64.strImm(src, .x13, @intCast(off & 0xFFF)));
+            try m.emit(isa.addImm(.x13, realm_reg, try fieldPageImmediate(off), true));
+            try m.emit(isa.strImm(src, .x13, @intCast(off & 0xFFF)));
         }
     }
 
-    fn loadRealmU8(self: *Compiler, dst: a64.Reg, off: usize) CompileError!void {
+    fn loadRealmU8(self: *Compiler, dst: isa.Reg, off: usize) CompileError!void {
         const m = &self.m;
         if (off <= 4095) {
-            try m.emit(a64.ldrbImm(dst, realm_reg, @intCast(off)));
+            try m.emit(isa.ldrbImm(dst, realm_reg, @intCast(off)));
         } else {
-            try m.emit(a64.addImm(dst, realm_reg, @intCast(off >> 12), true));
-            try m.emit(a64.ldrbImm(dst, dst, @intCast(off & 0xFFF)));
+            try m.emit(isa.addImm(dst, realm_reg, try fieldPageImmediate(off), true));
+            try m.emit(isa.ldrbImm(dst, dst, @intCast(off & 0xFFF)));
         }
     }
 
@@ -1910,19 +1943,19 @@ const Compiler = struct {
     /// functions, symbols, and BigInts share the tag and tier
     /// down. On success `dst` holds the object pointer (kind bits
     /// cleared). `src` survives; x12/x13 are clobbered.
-    fn emitPlainObject(self: *Compiler, src: a64.Reg, dst: a64.Reg, td: *Masm.Label) CompileError!void {
+    fn emitPlainObject(self: *Compiler, src: isa.Reg, dst: isa.Reg, td: *Masm.Label) CompileError!void {
         const m = &self.m;
         try m.movImm64(.x13, layout.value_bits.tag_object_shifted);
-        try m.emit(a64.eorReg(.x13, src, .x13));
-        try m.emit(a64.lsrImm(.x12, .x13, 48));
+        try m.emit(isa.eorReg(.x13, src, .x13));
+        try m.emit(isa.lsrImm(.x12, .x13, 48));
         try m.jumpCbnz(.x12, td);
         // Kind bits live in the pointer's alignment slack (low 2).
-        try m.emit(a64.lslImm(.x12, .x13, 62));
-        try m.emit(a64.lsrImm(.x12, .x12, 62));
-        try m.emit(a64.cmpImm(.x12, @intCast(layout.value_bits.kind_object), false));
+        try m.emit(isa.lslImm(.x12, .x13, 62));
+        try m.emit(isa.lsrImm(.x12, .x12, 62));
+        try m.emit(isa.cmpImm(.x12, @intCast(layout.value_bits.kind_object), false));
         try m.jumpCond(.ne, td);
-        try m.emit(a64.lsrImm(dst, .x13, 2));
-        try m.emit(a64.lslImm(dst, dst, 2));
+        try m.emit(isa.lsrImm(dst, .x13, 2));
+        try m.emit(isa.lslImm(dst, dst, 2));
     }
 
     /// `JSObject.slotAt` in machine code: inline slot when
@@ -1930,48 +1963,48 @@ const Compiler = struct {
     /// layout-contract slice witness covers the latter). `obj` and
     /// `slot` survive; x12/x13 are clobbered; `dst` may be the
     /// accumulator.
-    fn emitSlotRead(self: *Compiler, dst: a64.Reg, obj: a64.Reg, slot: a64.Reg) CompileError!void {
+    fn emitSlotRead(self: *Compiler, dst: isa.Reg, obj: isa.Reg, slot: isa.Reg) CompileError!void {
         const m = &self.m;
         var ovf = Masm.Label{};
         defer ovf.fixups.deinit(m.gpa);
         var done = Masm.Label{};
         defer done.fixups.deinit(m.gpa);
-        try m.emit(a64.cmpImm(slot, @intCast(layout.object.inline_slot_cap), false));
+        try m.emit(isa.cmpImm(slot, @intCast(layout.object.inline_slot_cap), false));
         try m.jumpCond(.cs, &ovf);
-        try m.emit(a64.lslImm(.x13, slot, 3));
-        try m.emit(a64.addReg(.x13, .x13, obj));
-        try m.emit(a64.ldrImm(dst, .x13, layout.object.inline_slots));
+        try m.emit(isa.lslImm(.x13, slot, 3));
+        try m.emit(isa.addReg(.x13, .x13, obj));
+        try m.emit(isa.ldrImm(dst, .x13, layout.object.inline_slots));
         try m.jump(&done);
-        m.bind(&ovf);
-        try m.emit(a64.ldrImm(.x12, obj, layout.object.overflow_items_ptr));
-        try m.emit(a64.subImm(.x13, slot, @intCast(layout.object.inline_slot_cap), false));
-        try m.emit(a64.lslImm(.x13, .x13, 3));
-        try m.emit(a64.addReg(.x13, .x13, .x12));
-        try m.emit(a64.ldrImm(dst, .x13, 0));
-        m.bind(&done);
+        try m.bind(&ovf);
+        try m.emit(isa.ldrImm(.x12, obj, layout.object.overflow_items_ptr));
+        try m.emit(isa.subImm(.x13, slot, @intCast(layout.object.inline_slot_cap), false));
+        try m.emit(isa.lslImm(.x13, .x13, 3));
+        try m.emit(isa.addReg(.x13, .x13, .x12));
+        try m.emit(isa.ldrImm(dst, .x13, 0));
+        try m.bind(&done);
     }
 
     /// `JSObject.setSlot` in machine code — the mirror of
     /// `emitSlotRead` with stores.
-    fn emitSlotWrite(self: *Compiler, src: a64.Reg, obj: a64.Reg, slot: a64.Reg) CompileError!void {
+    fn emitSlotWrite(self: *Compiler, src: isa.Reg, obj: isa.Reg, slot: isa.Reg) CompileError!void {
         const m = &self.m;
         var ovf = Masm.Label{};
         defer ovf.fixups.deinit(m.gpa);
         var done = Masm.Label{};
         defer done.fixups.deinit(m.gpa);
-        try m.emit(a64.cmpImm(slot, @intCast(layout.object.inline_slot_cap), false));
+        try m.emit(isa.cmpImm(slot, @intCast(layout.object.inline_slot_cap), false));
         try m.jumpCond(.cs, &ovf);
-        try m.emit(a64.lslImm(.x13, slot, 3));
-        try m.emit(a64.addReg(.x13, .x13, obj));
-        try m.emit(a64.strImm(src, .x13, layout.object.inline_slots));
+        try m.emit(isa.lslImm(.x13, slot, 3));
+        try m.emit(isa.addReg(.x13, .x13, obj));
+        try m.emit(isa.strImm(src, .x13, layout.object.inline_slots));
         try m.jump(&done);
-        m.bind(&ovf);
-        try m.emit(a64.ldrImm(.x12, obj, layout.object.overflow_items_ptr));
-        try m.emit(a64.subImm(.x13, slot, @intCast(layout.object.inline_slot_cap), false));
-        try m.emit(a64.lslImm(.x13, .x13, 3));
-        try m.emit(a64.addReg(.x13, .x13, .x12));
-        try m.emit(a64.strImm(src, .x13, 0));
-        m.bind(&done);
+        try m.bind(&ovf);
+        try m.emit(isa.ldrImm(.x12, obj, layout.object.overflow_items_ptr));
+        try m.emit(isa.subImm(.x13, slot, @intCast(layout.object.inline_slot_cap), false));
+        try m.emit(isa.lslImm(.x13, .x13, 3));
+        try m.emit(isa.addReg(.x13, .x13, .x12));
+        try m.emit(isa.strImm(src, .x13, 0));
+        try m.bind(&done);
     }
 
     /// The named-property IC read — mirrors the interpreter's three
@@ -1983,55 +2016,55 @@ const Compiler = struct {
     /// (written last; may equal `src_val`). Clobbers x9-x13.
     fn emitPropertyIcLoad(
         self: *Compiler,
-        src_val: a64.Reg,
-        dst: a64.Reg,
+        src_val: isa.Reg,
+        dst: isa.Reg,
         ic_idx: u16,
         td: *Masm.Label,
     ) CompileError!void {
         const m = &self.m;
         try self.emitPlainObject(src_val, .x9, td);
         try self.emitCellAddr(.x10, ic_idx);
-        try m.emit(a64.ldrImm(.x11, .x10, layout.load_ic_cell.shape));
+        try m.emit(isa.ldrImm(.x11, .x10, layout.load_ic_cell.shape));
         try m.jumpCbz(.x11, td);
-        try m.emit(a64.ldrImm(.x12, .x9, layout.object.shape));
-        try m.emit(a64.cmpReg(.x11, .x12));
+        try m.emit(isa.ldrImm(.x12, .x9, layout.object.shape));
+        try m.emit(isa.cmpReg(.x11, .x12));
         try m.jumpCond(.ne, td);
         var proto_path = Masm.Label{};
         defer proto_path.fixups.deinit(m.gpa);
         var next = Masm.Label{};
         defer next.fixups.deinit(m.gpa);
-        try m.emit(a64.ldrImm(.x11, .x10, layout.load_ic_cell.proto));
+        try m.emit(isa.ldrImm(.x11, .x10, layout.load_ic_cell.proto));
         try m.jumpCbnz(.x11, &proto_path);
         // Own-data hit: dst = recv.slots[cell.slot].
-        try m.emit(a64.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
+        try m.emit(isa.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
         try self.emitSlotRead(dst, .x9, .x11);
         try m.jump(&next);
         // Proto-load hit: identity of the cached proto, the proto's
         // own shape, AND the realm-wide §10.1.1-mutation counter,
         // exactly per the interpreter's predicate.
-        m.bind(&proto_path);
-        try m.emit(a64.ldrImm(.x12, .x9, layout.object.prototype));
-        try m.emit(a64.cmpReg(.x12, .x11));
+        try m.bind(&proto_path);
+        try m.emit(isa.ldrImm(.x12, .x9, layout.object.prototype));
+        try m.emit(isa.cmpReg(.x12, .x11));
         try m.jumpCond(.ne, td);
-        try m.emit(a64.ldrImm(.x9, .x10, layout.load_ic_cell.proto_shape));
-        try m.emit(a64.ldrImm(.x13, .x12, layout.object.shape));
-        try m.emit(a64.cmpReg(.x9, .x13));
+        try m.emit(isa.ldrImm(.x9, .x10, layout.load_ic_cell.proto_shape));
+        try m.emit(isa.ldrImm(.x13, .x12, layout.object.shape));
+        try m.emit(isa.cmpReg(.x9, .x13));
         try m.jumpCond(.ne, td);
         try self.loadRealmU64(.x9, layout.realm.proto_revision_counter);
-        try m.emit(a64.ldrImm(.x13, .x10, layout.load_ic_cell.proto_rev));
-        try m.emit(a64.cmpReg(.x9, .x13));
+        try m.emit(isa.ldrImm(.x13, .x10, layout.load_ic_cell.proto_rev));
+        try m.emit(isa.cmpReg(.x9, .x13));
         try m.jumpCond(.ne, td);
         var synthetic = Masm.Label{};
         defer synthetic.fixups.deinit(m.gpa);
-        try m.emit(a64.ldrbImm(.x11, .x10, layout.load_ic_cell.kind));
-        try m.emit(a64.cmpImm(.x11, layout.load_ic_cell.kind_synthetic_accessor, false));
+        try m.emit(isa.ldrbImm(.x11, .x10, layout.load_ic_cell.kind));
+        try m.emit(isa.cmpImm(.x11, layout.load_ic_cell.kind_synthetic_accessor, false));
         try m.jumpCond(.eq, &synthetic);
-        try m.emit(a64.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
+        try m.emit(isa.ldrImmW(.x11, .x10, layout.load_ic_cell.slot));
         try self.emitSlotRead(dst, .x12, .x11);
         try m.jump(&next);
-        m.bind(&synthetic);
-        try m.emit(a64.ldrImm(dst, .x10, layout.load_ic_cell.synthetic_value));
-        m.bind(&next);
+        try m.bind(&synthetic);
+        try m.emit(isa.ldrImm(dst, .x10, layout.load_ic_cell.synthetic_value));
+        try m.bind(&next);
     }
 
     /// The shared helperCall result dispatch: zero-extend the u32
@@ -2040,22 +2073,22 @@ const Compiler = struct {
     /// frame on success.
     fn emitCallStatus(self: *Compiler, threw: *Masm.Label) CompileError!void {
         const m = &self.m;
-        try m.emit(a64.movRegW(.x0, .x0));
+        try m.emit(isa.movRegW(.x0, .x0));
         var ok = Masm.Label{};
         defer ok.fixups.deinit(m.gpa);
         try m.jumpCbz(.x0, &ok);
-        try m.emit(a64.cmpImm(.x0, @intFromEnum(HelperCallStatus.threw), false));
+        try m.emit(isa.cmpImm(.x0, @intFromEnum(HelperCallStatus.threw), false));
         try m.jumpCond(.eq, threw);
         try m.jump(&self.oom_label);
-        m.bind(&ok);
-        try m.emit(a64.ldrImm(acc_reg, frame_reg, acc_off));
+        try m.bind(&ok);
+        try m.emit(isa.ldrImm(acc_reg, frame_reg, acc_off));
     }
 
     /// Bake the address of this site's IC cell into `dst`. Cells
     /// are chunk-owned mutable side-state; the chunk outlives the
     /// code, and compiled code only loads through the pointer, so
     /// the GC weak-clear protocol is untouched (docs/jit.md §4.4).
-    fn emitCellAddr(self: *Compiler, dst: a64.Reg, ic_idx: u16) CompileError!void {
+    fn emitCellAddr(self: *Compiler, dst: isa.Reg, ic_idx: u16) CompileError!void {
         if (ic_idx >= self.chunk.inline_load_caches.len) return error.UnsupportedOp;
         const addr: u64 = @intFromPtr(&self.chunk.inline_load_caches[ic_idx]);
         try self.m.movImm64(dst, addr);
@@ -2064,14 +2097,14 @@ const Compiler = struct {
     /// Like `emitCellAddr` for a named-store IC. Load and store sites have
     /// independent index spaces and layouts; crossing them silently tiers a
     /// valid compiled store down (or reads the wrong cell).
-    fn emitStoreCellAddr(self: *Compiler, dst: a64.Reg, ic_idx: u16) CompileError!void {
+    fn emitStoreCellAddr(self: *Compiler, dst: isa.Reg, ic_idx: u16) CompileError!void {
         if (ic_idx >= self.chunk.inline_store_caches.len) return error.UnsupportedOp;
         const addr: u64 = @intFromPtr(&self.chunk.inline_store_caches[ic_idx]);
         try self.m.movImm64(dst, addr);
     }
 
     /// Like `emitCellAddr` for the call-IC table.
-    fn emitCallCellAddr(self: *Compiler, dst: a64.Reg, ic_idx: u16) CompileError!void {
+    fn emitCallCellAddr(self: *Compiler, dst: isa.Reg, ic_idx: u16) CompileError!void {
         if (ic_idx >= self.chunk.inline_call_caches.len) return error.UnsupportedOp;
         const addr: u64 = @intFromPtr(&self.chunk.inline_call_caches[ic_idx]);
         try self.m.movImm64(dst, addr);
@@ -2093,7 +2126,7 @@ const Compiler = struct {
     /// Clobbers x9-x13 and the argument registers.
     fn emitCallDispatch(
         self: *Compiler,
-        callee_val: a64.Reg,
+        callee_val: isa.Reg,
         this_from: ?u8,
         args_base: u8,
         argc: u8,
@@ -2107,19 +2140,19 @@ const Compiler = struct {
         defer generic.fixups.deinit(m.gpa);
         // Function-kind heap pointer? (kind bits 0) — else generic.
         try m.movImm64(.x13, layout.value_bits.tag_object_shifted);
-        try m.emit(a64.eorReg(.x13, callee_val, .x13));
-        try m.emit(a64.lsrImm(.x12, .x13, 48));
+        try m.emit(isa.eorReg(.x13, callee_val, .x13));
+        try m.emit(isa.lsrImm(.x12, .x13, 48));
         try m.jumpCbnz(.x12, &generic);
-        try m.emit(a64.lslImm(.x12, .x13, 62));
-        try m.emit(a64.lsrImm(.x12, .x12, 62));
+        try m.emit(isa.lslImm(.x12, .x13, 62));
+        try m.emit(isa.lsrImm(.x12, .x12, 62));
         try m.jumpCbnz(.x12, &generic);
-        try m.emit(a64.lsrImm(.x10, .x13, 2));
-        try m.emit(a64.lslImm(.x10, .x10, 2));
+        try m.emit(isa.lsrImm(.x10, .x13, 2));
+        try m.emit(isa.lslImm(.x10, .x10, 2));
         // Cell compare.
         try self.emitCallCellAddr(.x11, ic_call);
-        try m.emit(a64.ldrImm(.x12, .x11, layout.call_ic_cell.callee));
+        try m.emit(isa.ldrImm(.x12, .x11, layout.call_ic_cell.callee));
         try m.jumpCbz(.x12, &generic);
-        try m.emit(a64.cmpReg(.x10, .x12));
+        try m.emit(isa.cmpReg(.x10, .x12));
         try m.jumpCond(.ne, &generic);
         // Hit: in-line push. Stamp the resume ip (the op after the
         // call) so the driver's `resumeCodeOffset(frame.ip)` finds the
@@ -2128,39 +2161,39 @@ const Compiler = struct {
         // frame pointer may dangle after the shim's `frames.append`
         // realloc, so we must not touch `frame_reg` after the call.
         try m.movImm64(.x9, after_bc);
-        try m.emit(a64.strImm(.x9, frame_reg, ip_off));
-        try m.emit(a64.movReg(.x0, realm_reg));
-        try m.emit(a64.movReg(.x1, .x10)); // callee fn ptr
+        try m.emit(isa.strImm(.x9, frame_reg, ip_off));
+        try m.emit(isa.movReg(.x0, realm_reg));
+        try m.emit(isa.movReg(.x1, .x10)); // callee fn ptr
         if (this_from) |r_this| {
-            try m.emit(a64.ldrImm(.x2, regs_reg, regSlot(r_this)));
+            try m.emit(isa.ldrImm(.x2, regs_reg, regSlot(r_this)));
         } else {
             try m.movImm64(.x2, Value.undefined_.bits);
         }
-        try m.emit(a64.addImm(.x3, regs_reg, @intCast(@as(u32, regSlot(args_base))), false));
+        try m.emit(isa.addImm(.x3, regs_reg, @intCast(@as(u32, regSlot(args_base))), false));
         try m.movImm64(.x4, argc);
         try m.callAbs(.x16, @intFromPtr(&pushCallFrameShim));
         // PushStatus: 0 pushed → frame_pushed; 1 tier_down → re-run the
         // op in Lantern; 2 host_oom.
-        try m.emit(a64.movRegW(.x0, .x0));
+        try m.emit(isa.movRegW(.x0, .x0));
         try m.jumpCbz(.x0, &self.frame_pushed_label);
-        try m.emit(a64.cmpImm(.x0, @intFromEnum(PushStatus.tier_down), false));
+        try m.emit(isa.cmpImm(.x0, @intFromEnum(PushStatus.tier_down), false));
         try m.jumpCond(.eq, td);
         try m.jump(&self.oom_label);
         // Miss: generic dispatch on the raw Value (nested path; handles
         // every exotic callee kind). Falls through to the resume label
         // (next op) with the result in acc.
-        m.bind(&generic);
-        try m.emit(a64.movReg(.x2, callee_val));
-        try m.emit(a64.movReg(.x0, realm_reg));
-        try m.emit(a64.movReg(.x1, frame_reg));
+        try m.bind(&generic);
+        try m.emit(isa.movReg(.x2, callee_val));
+        try m.emit(isa.movReg(.x0, realm_reg));
+        try m.emit(isa.movReg(.x1, frame_reg));
         if (this_from) |r_this| {
-            try m.emit(a64.ldrImm(.x3, regs_reg, regSlot(r_this)));
+            try m.emit(isa.ldrImm(.x3, regs_reg, regSlot(r_this)));
         } else {
             try m.movImm64(.x3, Value.undefined_.bits);
         }
-        try m.emit(a64.addImm(.x4, regs_reg, @intCast(@as(u32, regSlot(args_base))), false));
+        try m.emit(isa.addImm(.x4, regs_reg, @intCast(@as(u32, regSlot(args_base))), false));
         try m.movImm64(.x5, argc);
-        try m.emit(a64.addImm(.x6, frame_reg, acc_off, false));
+        try m.emit(isa.addImm(.x6, frame_reg, acc_off, false));
         try m.callAbs(.x16, @intFromPtr(&helperCall));
         try self.emitCallStatus(threw);
     }
@@ -2187,43 +2220,43 @@ const Compiler = struct {
     ) CompileError!void {
         const m = &self.m;
         const td = try self.tdFor(bc);
-        try m.emit(a64.ldrImm(.x9, regs_reg, regSlot(r_callee)));
+        try m.emit(isa.ldrImm(.x9, regs_reg, regSlot(r_callee)));
         // Function-kind heap pointer? (kind bits 0) — else tier down.
         try m.movImm64(.x13, layout.value_bits.tag_object_shifted);
-        try m.emit(a64.eorReg(.x13, .x9, .x13));
-        try m.emit(a64.lsrImm(.x12, .x13, 48));
+        try m.emit(isa.eorReg(.x13, .x9, .x13));
+        try m.emit(isa.lsrImm(.x12, .x13, 48));
         try m.jumpCbnz(.x12, td);
-        try m.emit(a64.lslImm(.x12, .x13, 62));
-        try m.emit(a64.lsrImm(.x12, .x12, 62));
+        try m.emit(isa.lslImm(.x12, .x13, 62));
+        try m.emit(isa.lsrImm(.x12, .x12, 62));
         try m.jumpCbnz(.x12, td);
-        try m.emit(a64.lsrImm(.x10, .x13, 2));
-        try m.emit(a64.lslImm(.x10, .x10, 2)); // x10 = callee fn ptr
+        try m.emit(isa.lsrImm(.x10, .x13, 2));
+        try m.emit(isa.lslImm(.x10, .x10, 2)); // x10 = callee fn ptr
         // Cell compare: callee match.
         try self.emitCallCellAddr(.x11, ic_call);
-        try m.emit(a64.ldrImm(.x12, .x11, layout.call_ic_cell.callee));
+        try m.emit(isa.ldrImm(.x12, .x11, layout.call_ic_cell.callee));
         try m.jumpCbz(.x12, td);
-        try m.emit(a64.cmpReg(.x10, .x12));
+        try m.emit(isa.cmpReg(.x10, .x12));
         try m.jumpCond(.ne, td);
         // §10.1.14 guard: `callee_fn.prototype` == `cell.proto`.
-        try m.emit(a64.ldrImm(.x12, .x10, layout.function.prototype));
-        try m.emit(a64.ldrImm(.x13, .x11, layout.call_ic_cell.proto));
-        try m.emit(a64.cmpReg(.x12, .x13));
+        try m.emit(isa.ldrImm(.x12, .x10, layout.function.prototype));
+        try m.emit(isa.ldrImm(.x13, .x11, layout.call_ic_cell.proto));
+        try m.emit(isa.cmpReg(.x12, .x13));
         try m.jumpCond(.ne, td);
         // Hit: stamp resume ip, flush acc (the shim allocates/GCs —
         // §4.2), and push the construct frame. `frame_reg` may dangle
         // after the append realloc, so touch it only before the call.
-        try m.emit(a64.strImm(acc_reg, frame_reg, acc_off));
+        try m.emit(isa.strImm(acc_reg, frame_reg, acc_off));
         try m.movImm64(.x9, after_bc);
-        try m.emit(a64.strImm(.x9, frame_reg, ip_off));
-        try m.emit(a64.movReg(.x0, realm_reg));
-        try m.emit(a64.movReg(.x1, .x11)); // cell ptr
-        try m.emit(a64.movReg(.x2, .x10)); // callee fn ptr
-        try m.emit(a64.addImm(.x3, regs_reg, @intCast(@as(u32, regSlot(r_callee + 1))), false));
+        try m.emit(isa.strImm(.x9, frame_reg, ip_off));
+        try m.emit(isa.movReg(.x0, realm_reg));
+        try m.emit(isa.movReg(.x1, .x11)); // cell ptr
+        try m.emit(isa.movReg(.x2, .x10)); // callee fn ptr
+        try m.emit(isa.addImm(.x3, regs_reg, @intCast(@as(u32, regSlot(r_callee + 1))), false));
         try m.movImm64(.x4, argc);
         try m.callAbs(.x16, @intFromPtr(&pushConstructFrameShim));
-        try m.emit(a64.movRegW(.x0, .x0));
+        try m.emit(isa.movRegW(.x0, .x0));
         try m.jumpCbz(.x0, &self.frame_pushed_label);
-        try m.emit(a64.cmpImm(.x0, @intFromEnum(PushStatus.tier_down), false));
+        try m.emit(isa.cmpImm(.x0, @intFromEnum(PushStatus.tier_down), false));
         try m.jumpCond(.eq, td);
         try m.jump(&self.oom_label);
     }
@@ -2234,12 +2267,26 @@ const Compiler = struct {
     /// push path, or by fall-through on the generic-call miss path).
     fn bindResume(self: *Compiler, after_bc: u32) CompileError!void {
         try self.resume_points.append(self.m.gpa, .{ .bc = after_bc, .label = .{} });
-        self.m.bind(&self.resume_points.items[self.resume_points.items.len - 1].label);
+        try self.m.bind(&self.resume_points.items[self.resume_points.items.len - 1].label);
     }
 };
 
 fn regSlot(r: u8) u15 {
     return @as(u15, r) * 8;
+}
+
+/// Split a byte offset into the high immediate used by the shared
+/// page-plus-low-offset field sequence. Refuse values the A64-shaped logical
+/// operation cannot encode; never let a user-sized global slot reach a cast
+/// trap on either backend.
+fn fieldPageImmediate(off: usize) CompileError!u12 {
+    return std.math.cast(u12, off >> 12) orelse error.UnsupportedOp;
+}
+
+/// Continuation metadata stores native code offsets as u32. A pathological
+/// chunk must refuse compilation if its emitted code exceeds that contract.
+fn continuationOffset(off: usize) CompileError!u32 {
+    return std.math.cast(u32, off) orelse error.UnsupportedOp;
 }
 
 fn targetOf(after_operand: usize, off: i16) u32 {
@@ -3845,5 +3892,21 @@ test "jit bistromath: in-line construct returns the constructed object (§10.2.2
     try testing.expectEqual(
         Chunk.JitState.Tier.compiled,
         templateNamed(&chunk, "step").jit_state.?.bistromath.code.tier,
+    );
+}
+
+test "jit bistromath: oversized field and continuation offsets refuse without trapping" {
+    try testing.expectEqual(
+        @as(u12, std.math.maxInt(u12)),
+        try fieldPageImmediate(0x00ff_ffff),
+    );
+    try testing.expectError(error.UnsupportedOp, fieldPageImmediate(0x0100_0000));
+    try testing.expectEqual(
+        std.math.maxInt(u32),
+        try continuationOffset(std.math.maxInt(u32)),
+    );
+    try testing.expectError(
+        error.UnsupportedOp,
+        continuationOffset(@as(usize, std.math.maxInt(u32)) + 1),
     );
 }

--- a/src/runtime/bistromath/masm.zig
+++ b/src/runtime/bistromath/masm.zig
@@ -1,0 +1,686 @@
+//! Bistromath-local MacroAssembler facade.
+//!
+//! The bytecode compiler stays one pass and target-neutral.  This adapter owns
+//! the only details that differ between its supported hosts: physical register
+//! assignment, two- versus three-address integer operations, condition codes,
+//! entry/call ABI, and prologue/epilogue layout.  The raw encoders and W^X code
+//! allocator remain shared under `runtime/jit/`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+const a64 = @import("../jit/asm_aarch64.zig");
+const a64_masm = @import("../jit/masm.zig");
+const x64 = @import("../jit/asm_x86_64.zig");
+
+const use_x64 = builtin.cpu.arch == .x86_64;
+const BackendMasm = if (use_x64) x64.Masm else a64_masm.Masm;
+
+pub const supported_isa = switch (builtin.cpu.arch) {
+    .aarch64, .x86_64 => true,
+    else => false,
+};
+
+/// Logical registers used by the shared Bistromath emitter.  The names retain
+/// the original A64 spelling so the bytecode/compiler correspondence stays
+/// reviewable; `xreg` below assigns their x86_64 physical homes.
+pub const Reg = enum {
+    x0,
+    x1,
+    x2,
+    x3,
+    x4,
+    x5,
+    x6,
+    x9,
+    x10,
+    x11,
+    x12,
+    x13,
+    x14,
+    x16,
+    x19,
+    x20,
+    x21,
+    x22,
+    x23,
+    x24,
+};
+
+/// A64 condition names form the target-neutral vocabulary used by the
+/// compiler.  `xCond` maps their flag meaning to x86 condition codes.
+pub const Cond = enum {
+    eq,
+    ne,
+    cs,
+    cc,
+    mi,
+    pl,
+    vs,
+    vc,
+    hi,
+    ls,
+    ge,
+    lt,
+    gt,
+    le,
+    al,
+    nv,
+};
+
+pub const Error = error{
+    OutOfMemory,
+    LabelAlreadyBound,
+    InvalidLabel,
+    BranchOutOfRange,
+    UnsupportedInstruction,
+};
+
+const Binary = struct { rd: Reg, rn: Reg, rm: Reg };
+const Unary = struct { rd: Reg, rn: Reg };
+
+pub const Instruction = union(enum) {
+    movz: struct { rd: Reg, imm16: u16, hw: u2 },
+    movn: struct { rd: Reg, imm16: u16, hw: u2 },
+    mov_reg: Unary,
+    mov_reg_w: Unary,
+    add_reg: Binary,
+    add_imm: struct { rd: Reg, rn: Reg, imm12: u12, lsl12: bool },
+    sub_imm: struct { rd: Reg, rn: Reg, imm12: u12, lsl12: bool },
+    cmp_imm: struct { rn: Reg, imm12: u12, lsl12: bool },
+    adds_reg_w: Binary,
+    subs_reg_w: Binary,
+    cmp_reg: struct { rn: Reg, rm: Reg },
+    cmp_reg_w: struct { rn: Reg, rm: Reg },
+    adds_imm_w: struct { rd: Reg, rn: Reg, imm12: u12 },
+    cset_w: struct { rd: Reg, cond: Cond },
+    smull: Binary,
+    sxtw: Unary,
+    and_reg_w: Binary,
+    orr_reg_w: Binary,
+    eor_reg_w: Binary,
+    orr_reg: Binary,
+    eor_reg: Binary,
+    lsl_imm: struct { rd: Reg, rn: Reg, shift: u6 },
+    lsr_imm: struct { rd: Reg, rn: Reg, shift: u6 },
+    ldr_imm: struct { rt: Reg, rn: Reg, byte_off: u15 },
+    str_imm: struct { rt: Reg, rn: Reg, byte_off: u15 },
+    ldr_imm_w: struct { rt: Reg, rn: Reg, byte_off: u14 },
+    ldrb_imm: struct { rt: Reg, rn: Reg, imm12: u12 },
+    ret,
+};
+
+pub fn movz(rd: Reg, imm16: u16, hw: u2) Instruction {
+    return .{ .movz = .{ .rd = rd, .imm16 = imm16, .hw = hw } };
+}
+
+pub fn movn(rd: Reg, imm16: u16, hw: u2) Instruction {
+    return .{ .movn = .{ .rd = rd, .imm16 = imm16, .hw = hw } };
+}
+
+pub fn movReg(rd: Reg, rm: Reg) Instruction {
+    return .{ .mov_reg = .{ .rd = rd, .rn = rm } };
+}
+
+pub fn movRegW(rd: Reg, rm: Reg) Instruction {
+    return .{ .mov_reg_w = .{ .rd = rd, .rn = rm } };
+}
+
+pub fn addReg(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .add_reg = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn addImm(rd: Reg, rn: Reg, imm12: u12, lsl12: bool) Instruction {
+    return .{ .add_imm = .{ .rd = rd, .rn = rn, .imm12 = imm12, .lsl12 = lsl12 } };
+}
+
+pub fn subImm(rd: Reg, rn: Reg, imm12: u12, lsl12: bool) Instruction {
+    return .{ .sub_imm = .{ .rd = rd, .rn = rn, .imm12 = imm12, .lsl12 = lsl12 } };
+}
+
+pub fn cmpImm(rn: Reg, imm12: u12, lsl12: bool) Instruction {
+    return .{ .cmp_imm = .{ .rn = rn, .imm12 = imm12, .lsl12 = lsl12 } };
+}
+
+pub fn addsRegW(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .adds_reg_w = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn subsRegW(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .subs_reg_w = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn cmpReg(rn: Reg, rm: Reg) Instruction {
+    return .{ .cmp_reg = .{ .rn = rn, .rm = rm } };
+}
+
+pub fn cmpRegW(rn: Reg, rm: Reg) Instruction {
+    return .{ .cmp_reg_w = .{ .rn = rn, .rm = rm } };
+}
+
+pub fn addsImmW(rd: Reg, rn: Reg, imm12: u12) Instruction {
+    return .{ .adds_imm_w = .{ .rd = rd, .rn = rn, .imm12 = imm12 } };
+}
+
+pub fn csetW(rd: Reg, cond: Cond) Instruction {
+    return .{ .cset_w = .{ .rd = rd, .cond = cond } };
+}
+
+pub fn smull(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .smull = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn sxtw(rd: Reg, rn: Reg) Instruction {
+    return .{ .sxtw = .{ .rd = rd, .rn = rn } };
+}
+
+pub fn andRegW(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .and_reg_w = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn orrRegW(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .orr_reg_w = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn eorRegW(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .eor_reg_w = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn orrReg(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .orr_reg = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn eorReg(rd: Reg, rn: Reg, rm: Reg) Instruction {
+    return .{ .eor_reg = .{ .rd = rd, .rn = rn, .rm = rm } };
+}
+
+pub fn lslImm(rd: Reg, rn: Reg, shift: u6) Instruction {
+    return .{ .lsl_imm = .{ .rd = rd, .rn = rn, .shift = shift } };
+}
+
+pub fn lsrImm(rd: Reg, rn: Reg, shift: u6) Instruction {
+    return .{ .lsr_imm = .{ .rd = rd, .rn = rn, .shift = shift } };
+}
+
+pub fn ldrImm(rt: Reg, rn: Reg, byte_off: u15) Instruction {
+    return .{ .ldr_imm = .{ .rt = rt, .rn = rn, .byte_off = byte_off } };
+}
+
+pub fn strImm(rt: Reg, rn: Reg, byte_off: u15) Instruction {
+    return .{ .str_imm = .{ .rt = rt, .rn = rn, .byte_off = byte_off } };
+}
+
+pub fn ldrImmW(rt: Reg, rn: Reg, byte_off: u14) Instruction {
+    return .{ .ldr_imm_w = .{ .rt = rt, .rn = rn, .byte_off = byte_off } };
+}
+
+pub fn ldrbImm(rt: Reg, rn: Reg, imm12: u12) Instruction {
+    return .{ .ldrb_imm = .{ .rt = rt, .rn = rn, .imm12 = imm12 } };
+}
+
+pub fn ret() Instruction {
+    return .ret;
+}
+
+pub const Masm = struct {
+    gpa: std.mem.Allocator,
+    backend: BackendMasm,
+
+    pub const Label = BackendMasm.Label;
+
+    pub fn init(gpa: std.mem.Allocator) Masm {
+        return .{ .gpa = gpa, .backend = BackendMasm.init(gpa) };
+    }
+
+    pub fn deinit(self: *Masm) void {
+        self.backend.deinit();
+        self.* = undefined;
+    }
+
+    pub fn bytes(self: *const Masm) []const u8 {
+        return self.backend.code.items;
+    }
+
+    pub fn offset(self: *const Masm) usize {
+        return self.backend.code.items.len;
+    }
+
+    /// Save Bistromath's pinned state and establish the platform call
+    /// alignment.  x86 reserves `[rsp+0]` permanently for SysV argument 7.
+    pub fn enterFrame(self: *Masm) Error!void {
+        if (comptime use_x64) {
+            try self.backend.subRegImm32(.rsp, 56);
+            try self.backend.store64Disp32(.rsp, 8, .r12);
+            try self.backend.store64Disp32(.rsp, 16, .r13);
+            try self.backend.store64Disp32(.rsp, 24, .r14);
+            try self.backend.store64Disp32(.rsp, 32, .r15);
+            try self.backend.store64Disp32(.rsp, 40, .rbx);
+            try self.backend.store64Disp32(.rsp, 48, .rbp);
+        } else {
+            try self.backend.emit(a64.stpPreIdxSp(.fp, .lr, -16));
+            try self.backend.emit(a64.stpPreIdxSp(.x19, .x20, -16));
+            try self.backend.emit(a64.stpPreIdxSp(.x21, .x22, -16));
+            try self.backend.emit(a64.stpPreIdxSp(.x23, .x24, -16));
+        }
+    }
+
+    pub fn leaveFrame(self: *Masm) Error!void {
+        if (comptime use_x64) {
+            try self.backend.load64Disp32(.r12, .rsp, 8);
+            try self.backend.load64Disp32(.r13, .rsp, 16);
+            try self.backend.load64Disp32(.r14, .rsp, 24);
+            try self.backend.load64Disp32(.r15, .rsp, 32);
+            try self.backend.load64Disp32(.rbx, .rsp, 40);
+            try self.backend.load64Disp32(.rbp, .rsp, 48);
+            try self.backend.addRegImm32(.rsp, 56);
+        } else {
+            try self.backend.emit(a64.ldpPostIdxSp(.x23, .x24, 16));
+            try self.backend.emit(a64.ldpPostIdxSp(.x21, .x22, 16));
+            try self.backend.emit(a64.ldpPostIdxSp(.x19, .x20, 16));
+            try self.backend.emit(a64.ldpPostIdxSp(.fp, .lr, 16));
+        }
+    }
+
+    /// Move one C entry argument into a logical pinned register.  x0 is the
+    /// A64 argument/return register but x86 separates rdi input from rax
+    /// output, so entry moves must be explicit at this boundary.
+    pub fn moveEntryArg(self: *Masm, destination: Reg, argument: u2) Error!void {
+        if (comptime use_x64) {
+            const source: x64.Reg = switch (argument) {
+                0 => .rdi,
+                1 => .rsi,
+                2 => .rdx,
+                else => return error.UnsupportedInstruction,
+            };
+            try self.backend.movReg64(xreg(destination), source);
+        } else {
+            const source: a64.Reg = switch (argument) {
+                0 => .x0,
+                1 => .x1,
+                2 => .x2,
+                else => return error.UnsupportedInstruction,
+            };
+            try self.backend.emit(a64.movReg(areg(destination), source));
+        }
+    }
+
+    pub fn emit(self: *Masm, instruction: Instruction) Error!void {
+        if (comptime use_x64) {
+            try self.emitX64(instruction);
+        } else {
+            try self.emitA64(instruction);
+        }
+    }
+
+    pub fn movImm64(self: *Masm, destination: Reg, value: u64) Error!void {
+        if (comptime use_x64) {
+            try self.backend.movImm64(xreg(destination), value);
+        } else {
+            try self.backend.movImm64(areg(destination), value);
+        }
+    }
+
+    pub fn bind(self: *Masm, label: *Label) Error!void {
+        try self.backend.bind(label);
+    }
+
+    pub fn jump(self: *Masm, label: *Label) Error!void {
+        try self.backend.jump(label);
+    }
+
+    pub fn jumpCond(self: *Masm, condition: Cond, label: *Label) Error!void {
+        if (comptime use_x64) {
+            try self.backend.jumpCond(xCond(condition), label);
+        } else {
+            try self.backend.jumpCond(aCond(condition), label);
+        }
+    }
+
+    pub fn jumpCbz(self: *Masm, register: Reg, label: *Label) Error!void {
+        if (comptime use_x64) {
+            const physical = xreg(register);
+            try self.backend.testReg64(physical, physical);
+            try self.backend.jumpCond(.equal, label);
+        } else {
+            try self.backend.jumpCbz(areg(register), label);
+        }
+    }
+
+    pub fn jumpCbnz(self: *Masm, register: Reg, label: *Label) Error!void {
+        if (comptime use_x64) {
+            const physical = xreg(register);
+            try self.backend.testReg64(physical, physical);
+            try self.backend.jumpCond(.not_equal, label);
+        } else {
+            try self.backend.jumpCbnz(areg(register), label);
+        }
+    }
+
+    pub fn jumpTbz(self: *Masm, register: Reg, bit: u6, label: *Label) Error!void {
+        if (comptime use_x64) {
+            if (bit >= 32) return error.UnsupportedInstruction;
+            try self.backend.testReg32Imm32(xreg(register), @as(u32, 1) << @intCast(bit));
+            try self.backend.jumpCond(.equal, label);
+        } else {
+            try self.backend.jumpTbz(areg(register), bit, label);
+        }
+    }
+
+    pub fn jumpTbnz(self: *Masm, register: Reg, bit: u6, label: *Label) Error!void {
+        if (comptime use_x64) {
+            if (bit >= 32) return error.UnsupportedInstruction;
+            try self.backend.testReg32Imm32(xreg(register), @as(u32, 1) << @intCast(bit));
+            try self.backend.jumpCond(.not_equal, label);
+        } else {
+            try self.backend.jumpTbnz(areg(register), bit, label);
+        }
+    }
+
+    /// Absolute C call.  The shared compiler stages logical x0..x6; x86
+    /// moves x0 from rax to SysV rdi and writes x6 to the reserved stack slot.
+    pub fn callAbs(self: *Masm, scratch: Reg, target: usize) Error!void {
+        if (comptime use_x64) {
+            const target_reg = xreg(scratch);
+            try self.backend.store64Disp32(.rsp, 0, xreg(.x6));
+            try self.backend.movReg64(.rdi, xreg(.x0));
+            try self.backend.movImm64(target_reg, @intCast(target));
+            try self.backend.callReg(target_reg);
+        } else {
+            try self.backend.callAbs(areg(scratch), target);
+        }
+    }
+
+    pub fn labelResolved(label: *const Label) bool {
+        return label.bound != null and label.fixups.items.len == 0;
+    }
+
+    fn emitA64(self: *Masm, instruction: Instruction) Error!void {
+        const word: u32 = switch (instruction) {
+            .movz => |v| a64.movz(areg(v.rd), v.imm16, v.hw),
+            .movn => |v| a64.movn(areg(v.rd), v.imm16, v.hw),
+            .mov_reg => |v| a64.movReg(areg(v.rd), areg(v.rn)),
+            .mov_reg_w => |v| a64.movRegW(areg(v.rd), areg(v.rn)),
+            .add_reg => |v| a64.addReg(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .add_imm => |v| a64.addImm(areg(v.rd), areg(v.rn), v.imm12, v.lsl12),
+            .sub_imm => |v| a64.subImm(areg(v.rd), areg(v.rn), v.imm12, v.lsl12),
+            .cmp_imm => |v| a64.cmpImm(areg(v.rn), v.imm12, v.lsl12),
+            .adds_reg_w => |v| a64.addsRegW(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .subs_reg_w => |v| a64.subsRegW(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .cmp_reg => |v| a64.cmpReg(areg(v.rn), areg(v.rm)),
+            .cmp_reg_w => |v| a64.cmpRegW(areg(v.rn), areg(v.rm)),
+            .adds_imm_w => |v| a64.addsImmW(areg(v.rd), areg(v.rn), v.imm12),
+            .cset_w => |v| a64.csetW(areg(v.rd), aCond(v.cond)),
+            .smull => |v| a64.smull(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .sxtw => |v| a64.sxtw(areg(v.rd), areg(v.rn)),
+            .and_reg_w => |v| a64.andRegW(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .orr_reg_w => |v| a64.orrRegW(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .eor_reg_w => |v| a64.eorRegW(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .orr_reg => |v| a64.orrReg(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .eor_reg => |v| a64.eorReg(areg(v.rd), areg(v.rn), areg(v.rm)),
+            .lsl_imm => |v| a64.lslImm(areg(v.rd), areg(v.rn), v.shift),
+            .lsr_imm => |v| a64.lsrImm(areg(v.rd), areg(v.rn), v.shift),
+            .ldr_imm => |v| a64.ldrImm(areg(v.rt), areg(v.rn), v.byte_off),
+            .str_imm => |v| a64.strImm(areg(v.rt), areg(v.rn), v.byte_off),
+            .ldr_imm_w => |v| a64.ldrImmW(areg(v.rt), areg(v.rn), v.byte_off),
+            .ldrb_imm => |v| a64.ldrbImm(areg(v.rt), areg(v.rn), v.imm12),
+            .ret => a64.ret(),
+        };
+        try self.backend.emit(word);
+    }
+
+    fn emitX64(self: *Masm, instruction: Instruction) Error!void {
+        switch (instruction) {
+            .movz => |v| try self.backend.movImm64(
+                xreg(v.rd),
+                @as(u64, v.imm16) << (@as(u6, v.hw) * 16),
+            ),
+            .movn => |v| try self.backend.movImm64(
+                xreg(v.rd),
+                ~(@as(u64, v.imm16) << (@as(u6, v.hw) * 16)),
+            ),
+            .mov_reg => |v| try self.backend.movReg64(xreg(v.rd), xreg(v.rn)),
+            .mov_reg_w => |v| try self.backend.movReg32(xreg(v.rd), xreg(v.rn)),
+            .add_reg => |v| try self.emitCommutative64(v, .add),
+            .add_imm => |v| {
+                const rd = xreg(v.rd);
+                const rn = xreg(v.rn);
+                if (rd != rn) try self.backend.movReg64(rd, rn);
+                const amount: u32 = @as(u32, v.imm12) << (if (v.lsl12) 12 else 0);
+                try self.backend.addRegImm32(rd, amount);
+            },
+            .sub_imm => |v| {
+                const rd = xreg(v.rd);
+                const rn = xreg(v.rn);
+                if (rd != rn) try self.backend.movReg64(rd, rn);
+                const amount: u32 = @as(u32, v.imm12) << (if (v.lsl12) 12 else 0);
+                try self.backend.subRegImm32(rd, amount);
+            },
+            .cmp_imm => |v| {
+                const amount: u32 = @as(u32, v.imm12) << (if (v.lsl12) 12 else 0);
+                try self.backend.cmpRegImm32(xreg(v.rn), amount);
+            },
+            .adds_reg_w => |v| try self.emitCommutative32(v, .add),
+            .subs_reg_w => |v| try self.emitSub32(v),
+            .cmp_reg => |v| try self.backend.cmpReg64(xreg(v.rn), xreg(v.rm)),
+            .cmp_reg_w => |v| try self.backend.cmpReg32(xreg(v.rn), xreg(v.rm)),
+            .adds_imm_w => |v| {
+                const rd = xreg(v.rd);
+                const rn = xreg(v.rn);
+                if (rd != rn) try self.backend.movReg32(rd, rn);
+                try self.backend.addReg32Imm32(rd, v.imm12);
+            },
+            .cset_w => |v| try self.backend.setCond32(xreg(v.rd), xCond(v.cond)),
+            .smull => |v| {
+                const rd = xreg(v.rd);
+                const rm = xreg(v.rm);
+                if (rd == .rax or rd == rm) return error.UnsupportedInstruction;
+                // x0/rax is call-clobbered and never carries bytecode state.
+                // It is the private second operand for the full signed product.
+                try self.backend.signExtendReg32To64(rd, xreg(v.rn));
+                try self.backend.signExtendReg32To64(.rax, rm);
+                try self.backend.imulReg64(rd, .rax);
+            },
+            .sxtw => |v| try self.backend.signExtendReg32To64(xreg(v.rd), xreg(v.rn)),
+            .and_reg_w => |v| try self.emitCommutative32(v, .and_),
+            .orr_reg_w => |v| try self.emitCommutative32(v, .or_),
+            .eor_reg_w => |v| try self.emitCommutative32(v, .xor_),
+            .orr_reg => |v| try self.emitCommutative64(v, .or_),
+            .eor_reg => |v| try self.emitCommutative64(v, .xor_),
+            .lsl_imm => |v| {
+                const rd = xreg(v.rd);
+                const rn = xreg(v.rn);
+                if (rd != rn) try self.backend.movReg64(rd, rn);
+                try self.backend.shlImm8(rd, v.shift);
+            },
+            .lsr_imm => |v| {
+                const rd = xreg(v.rd);
+                const rn = xreg(v.rn);
+                if (rd != rn) try self.backend.movReg64(rd, rn);
+                try self.backend.shrImm8(rd, v.shift);
+            },
+            .ldr_imm => |v| try self.backend.load64Disp32(
+                xreg(v.rt),
+                xreg(v.rn),
+                v.byte_off,
+            ),
+            .str_imm => |v| try self.backend.store64Disp32(
+                xreg(v.rn),
+                v.byte_off,
+                xreg(v.rt),
+            ),
+            .ldr_imm_w => |v| try self.backend.load32Disp32(
+                xreg(v.rt),
+                xreg(v.rn),
+                v.byte_off,
+            ),
+            .ldrb_imm => |v| try self.backend.load8Disp32(
+                xreg(v.rt),
+                xreg(v.rn),
+                v.imm12,
+            ),
+            .ret => try self.backend.ret(),
+        }
+    }
+
+    const BinaryOp = enum { add, and_, or_, xor_ };
+
+    fn emitCommutative64(self: *Masm, value: Binary, operation: BinaryOp) Error!void {
+        const rd = xreg(value.rd);
+        const rn = xreg(value.rn);
+        const rm = xreg(value.rm);
+        if (rd == rn) {
+            try self.apply64(operation, rd, rm);
+        } else if (rd == rm) {
+            try self.apply64(operation, rd, rn);
+        } else {
+            try self.backend.movReg64(rd, rn);
+            try self.apply64(operation, rd, rm);
+        }
+    }
+
+    fn emitCommutative32(self: *Masm, value: Binary, operation: BinaryOp) Error!void {
+        const rd = xreg(value.rd);
+        const rn = xreg(value.rn);
+        const rm = xreg(value.rm);
+        if (rd == rn) {
+            try self.apply32(operation, rd, rm);
+        } else if (rd == rm) {
+            try self.apply32(operation, rd, rn);
+        } else {
+            try self.backend.movReg32(rd, rn);
+            try self.apply32(operation, rd, rm);
+        }
+    }
+
+    fn emitSub32(self: *Masm, value: Binary) Error!void {
+        const rd = xreg(value.rd);
+        const rn = xreg(value.rn);
+        const rm = xreg(value.rm);
+        if (rd == rn) {
+            try self.backend.subReg32(rd, rm);
+        } else if (rd == rm) {
+            if (rd == .rax) return error.UnsupportedInstruction;
+            // Preserve the right operand in call-clobbered rax.  The shared
+            // compiler has no live ABI argument/result across an ALU opcode.
+            try self.backend.movReg32(.rax, rm);
+            try self.backend.movReg32(rd, rn);
+            try self.backend.subReg32(rd, .rax);
+        } else {
+            try self.backend.movReg32(rd, rn);
+            try self.backend.subReg32(rd, rm);
+        }
+    }
+
+    fn apply64(self: *Masm, operation: BinaryOp, destination: x64.Reg, source: x64.Reg) Error!void {
+        switch (operation) {
+            .add => try self.backend.addReg64(destination, source),
+            .and_ => try self.backend.andReg64(destination, source),
+            .or_ => try self.backend.orReg64(destination, source),
+            .xor_ => try self.backend.xorReg64(destination, source),
+        }
+    }
+
+    fn apply32(self: *Masm, operation: BinaryOp, destination: x64.Reg, source: x64.Reg) Error!void {
+        switch (operation) {
+            .add => try self.backend.addReg32(destination, source),
+            .and_ => try self.backend.andReg32(destination, source),
+            .or_ => try self.backend.orReg32(destination, source),
+            .xor_ => try self.backend.xorReg32(destination, source),
+        }
+    }
+};
+
+fn areg(register: Reg) a64.Reg {
+    return switch (register) {
+        .x0 => .x0,
+        .x1 => .x1,
+        .x2 => .x2,
+        .x3 => .x3,
+        .x4 => .x4,
+        .x5 => .x5,
+        .x6 => .x6,
+        .x9 => .x9,
+        .x10 => .x10,
+        .x11 => .x11,
+        .x12 => .x12,
+        .x13 => .x13,
+        .x14 => .x14,
+        .x16 => .x16,
+        .x19 => .x19,
+        .x20 => .x20,
+        .x21 => .x21,
+        .x22 => .x22,
+        .x23 => .x23,
+        .x24 => .x24,
+    };
+}
+
+fn xreg(register: Reg) x64.Reg {
+    return switch (register) {
+        // Logical argument staging. x0 doubles as the C return register;
+        // `callAbs` moves it to SysV rdi only at the call boundary.
+        .x0 => .rax,
+        .x1 => .rsi,
+        .x2 => .rdx,
+        .x3 => .rcx,
+        .x4 => .r8,
+        .x5 => .r9,
+        .x6 => .r10,
+        // Bytecode scratch set.
+        .x9 => .rdi,
+        .x10 => .r10,
+        .x11 => .r11,
+        .x12 => .rdx,
+        .x13 => .rcx,
+        .x14 => .r8,
+        .x16 => .r11,
+        // Callee-saved frame state and tags.
+        .x19 => .r12,
+        .x20 => .r13,
+        .x21 => .r14,
+        .x22 => .r15,
+        .x23 => .rbx,
+        .x24 => .rbp,
+    };
+}
+
+fn aCond(condition: Cond) a64.Cond {
+    return switch (condition) {
+        .eq => .eq,
+        .ne => .ne,
+        .cs => .cs,
+        .cc => .cc,
+        .mi => .mi,
+        .pl => .pl,
+        .vs => .vs,
+        .vc => .vc,
+        .hi => .hi,
+        .ls => .ls,
+        .ge => .ge,
+        .lt => .lt,
+        .gt => .gt,
+        .le => .le,
+        .al => .al,
+        .nv => .nv,
+    };
+}
+
+fn xCond(condition: Cond) x64.Cond {
+    return switch (condition) {
+        .eq => .equal,
+        .ne => .not_equal,
+        .cs => .above_or_equal,
+        .cc => .below,
+        .mi => .sign,
+        .pl => .not_sign,
+        .vs => .overflow,
+        .vc => .not_overflow,
+        .hi => .above,
+        .ls => .below_or_equal,
+        .ge => .greater_or_equal,
+        .lt => .less,
+        .gt => .greater,
+        .le => .less_or_equal,
+        .al, .nv => unreachable,
+    };
+}

--- a/src/runtime/bistromath/masm.zig
+++ b/src/runtime/bistromath/masm.zig
@@ -559,7 +559,7 @@ pub const Masm = struct {
         if (rd == rn) {
             try self.backend.subReg32(rd, rm);
         } else if (rd == rm) {
-            if (rd == .rax) return error.UnsupportedInstruction;
+            if (rd == .rax or rn == .rax) return error.UnsupportedInstruction;
             // Preserve the right operand in call-clobbered rax.  The shared
             // compiler has no live ABI argument/result across an ALU opcode.
             try self.backend.movReg32(.rax, rm);

--- a/src/runtime/bistromath/stats.zig
+++ b/src/runtime/bistromath/stats.zig
@@ -7,13 +7,19 @@
 
 const std = @import("std");
 
+/// wasm32 supports atomics only up to 32 bits. The shared value is a positive
+/// execution witness, not a lossless profiler counter, so saturation at u32
+/// preserves its contract on every target while heap-local telemetry stays
+/// u64.
+pub const SharedEntryCounter = std.atomic.Value(u32);
+
 pub const Stats = struct {
     enabled: bool = false,
     executed_entries: u64 = 0,
     /// Optional cross-heap witness used by hosts that create independent
     /// agent realms. The owner must keep the atomic alive until every realm
     /// carrying this pointer has stopped executing generated code.
-    shared_entries: ?*std.atomic.Value(u64) = null,
+    shared_entries: ?*SharedEntryCounter = null,
 
     pub fn recordEntry(self: *Stats) void {
         if (!self.enabled) return;
@@ -28,9 +34,9 @@ pub const Stats = struct {
     }
 };
 
-fn incrementSaturating(counter: *std.atomic.Value(u64)) void {
+fn incrementSaturating(counter: *SharedEntryCounter) void {
     var current = counter.load(.monotonic);
-    while (current != std.math.maxInt(u64)) {
+    while (current != std.math.maxInt(u32)) {
         if (counter.cmpxchgWeak(current, current + 1, .monotonic, .monotonic)) |observed| {
             current = observed;
         } else return;
@@ -54,7 +60,7 @@ test "Bistromath stats merge saturates executed entries" {
 }
 
 test "Bistromath stats publish to a shared cross-heap witness" {
-    var shared = std.atomic.Value(u64).init(0);
+    var shared = SharedEntryCounter.init(0);
     var stats: Stats = .{ .enabled = true, .shared_entries = &shared };
     stats.recordEntry();
     try std.testing.expectEqual(@as(u64, 1), stats.executed_entries);

--- a/src/runtime/bistromath/stats.zig
+++ b/src/runtime/bistromath/stats.zig
@@ -1,0 +1,62 @@
+//! Opt-in execution witness for Bistromath.
+//!
+//! The test262 differential must prove that at least one published T1 entry
+//! was actually crossed.  Counting compilation attempts or installed code is
+//! insufficient because a dispatch regression could leave the entire sweep
+//! interpreted while preserving an identical pass set.
+
+const std = @import("std");
+
+pub const Stats = struct {
+    enabled: bool = false,
+    executed_entries: u64 = 0,
+    /// Optional cross-heap witness used by hosts that create independent
+    /// agent realms. The owner must keep the atomic alive until every realm
+    /// carrying this pointer has stopped executing generated code.
+    shared_entries: ?*std.atomic.Value(u64) = null,
+
+    pub fn recordEntry(self: *Stats) void {
+        if (!self.enabled) return;
+        self.executed_entries +|= 1;
+        if (self.shared_entries) |shared| incrementSaturating(shared);
+    }
+
+    /// Saturating aggregation for fixture heaps and test262 workers.
+    pub fn merge(self: *Stats, other: Stats) void {
+        self.enabled = self.enabled or other.enabled;
+        self.executed_entries +|= other.executed_entries;
+    }
+};
+
+fn incrementSaturating(counter: *std.atomic.Value(u64)) void {
+    var current = counter.load(.monotonic);
+    while (current != std.math.maxInt(u64)) {
+        if (counter.cmpxchgWeak(current, current + 1, .monotonic, .monotonic)) |observed| {
+            current = observed;
+        } else return;
+    }
+}
+
+test "Bistromath stats stay inert while disabled" {
+    var stats: Stats = .{};
+    stats.recordEntry();
+    try std.testing.expectEqual(@as(u64, 0), stats.executed_entries);
+}
+
+test "Bistromath stats merge saturates executed entries" {
+    var total: Stats = .{
+        .enabled = true,
+        .executed_entries = std.math.maxInt(u64) - 1,
+    };
+    total.merge(.{ .enabled = true, .executed_entries = 5 });
+    try std.testing.expect(total.enabled);
+    try std.testing.expectEqual(std.math.maxInt(u64), total.executed_entries);
+}
+
+test "Bistromath stats publish to a shared cross-heap witness" {
+    var shared = std.atomic.Value(u64).init(0);
+    var stats: Stats = .{ .enabled = true, .shared_entries = &shared };
+    stats.recordEntry();
+    try std.testing.expectEqual(@as(u64, 1), stats.executed_entries);
+    try std.testing.expectEqual(@as(u64, 1), shared.load(.monotonic));
+}

--- a/src/runtime/bistromath/x86_64_test.zig
+++ b/src/runtime/bistromath/x86_64_test.zig
@@ -1,0 +1,279 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const bistromath = @import("bistromath.zig");
+const bistro_masm = @import("masm.zig");
+const Chunk = @import("../../bytecode/chunk.zig").Chunk;
+const code_alloc = @import("../jit/code_alloc.zig");
+const lantern = @import("../lantern/interpreter.zig");
+const CallFrame = lantern.CallFrame;
+const Realm = @import("../realm.zig").Realm;
+const Value = @import("../value.zig").Value;
+
+const testing = std.testing;
+
+/// These tests are executable-ABI tests, not cross-assembly tests. Keep them
+/// off hosts that cannot execute x86_64 code, but fail (rather than silently
+/// skip) on an executable x86_64 target until the backend is enabled.
+fn requireNativeBackend() !void {
+    if (comptime builtin.cpu.arch != .x86_64 or !code_alloc.supported) {
+        return error.SkipZigTest;
+    }
+    try testing.expect(bistromath.supported);
+}
+
+fn evaluateValue(realm: *Realm, source: []const u8) !Value {
+    return switch (try lantern.evaluateScript(testing.allocator, realm, source)) {
+        .value, .yielded => |value| value,
+        .thrown => error.UncaughtException,
+    };
+}
+
+fn functionNamed(chunk: *const Chunk, name: []const u8) ?*const Chunk {
+    for (chunk.function_templates) |*template| {
+        if (template.name) |candidate| {
+            if (std.mem.eql(u8, candidate, name)) return &template.chunk;
+        }
+    }
+    return null;
+}
+
+fn expectCompiledFunction(chunk: *const Chunk, name: []const u8) !*const Chunk {
+    const body = functionNamed(chunk, name) orelse return error.FunctionTemplateMissing;
+    const state = body.jit_state orelse return error.MissingJitState;
+    try testing.expectEqual(Chunk.JitState.Tier.compiled, state.bistromath.code.tier);
+    try testing.expect(state.bistromath.entry() != null);
+    return body;
+}
+
+test "Bistromath x86_64: supported native hosts have a backend" {
+    if (comptime builtin.cpu.arch != .x86_64 or !code_alloc.supported) {
+        return error.SkipZigTest;
+    }
+
+    try testing.expect(bistromath.supported);
+}
+
+test "Bistromath x86_64: three-address multiply rejects its private-scratch alias" {
+    if (comptime builtin.cpu.arch != .x86_64) return error.SkipZigTest;
+    var machine = bistro_masm.Masm.init(testing.allocator);
+    defer machine.deinit();
+
+    try testing.expectError(
+        error.UnsupportedInstruction,
+        machine.emit(bistro_masm.smull(.x0, .x9, .x22)),
+    );
+}
+
+test "Bistromath x86_64: three-address subtract rejects its private-scratch alias" {
+    if (comptime builtin.cpu.arch != .x86_64) return error.SkipZigTest;
+    var machine = bistro_masm.Masm.init(testing.allocator);
+    defer machine.deinit();
+
+    try testing.expectError(
+        error.UnsupportedInstruction,
+        machine.emit(bistro_masm.subsRegW(.x0, .x13, .x0)),
+    );
+}
+
+test "Bistromath x86_64: entry prologue returns done with the accumulator result" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    realm.heap.bistromath_stats.enabled = true;
+
+    const value = try evaluateValue(&realm,
+        \\function answer() { return 42; }
+        \\answer();
+        \\answer();
+    );
+    try testing.expectEqual(Value.fromInt32(42).bits, value.bits);
+    try testing.expect(realm.heap.bistromath_stats.executed_entries >= 1);
+
+    const script = realm.script_chunks.items[0];
+    const body = try expectCompiledFunction(script, "answer");
+
+    // Invoke the published entry directly once as an ABI probe. This pins the
+    // SysV prologue/epilogue contract and the `EntryResult.done` value instead
+    // of accepting a result Lantern could have produced after a tier-down.
+    const registers = try realm.frame_pool.acquire(testing.allocator, body.register_count);
+    defer realm.frame_pool.release(testing.allocator, registers);
+    @memset(registers, Value.undefined_);
+    var frame: CallFrame = .{
+        .chunk = body,
+        .ip = 0,
+        .accumulator = Value.undefined_,
+        .registers = registers,
+        .env = null,
+        .this_value = Value.undefined_,
+    };
+    const entry: bistromath.EntryFn = @ptrCast(@alignCast(body.jit_state.?.bistromath.entry().?));
+    const verdict: bistromath.EntryResult = @enumFromInt(entry(&realm, &frame, registers.ptr));
+    try testing.expectEqual(bistromath.EntryResult.done, verdict);
+    try testing.expectEqual(Value.fromInt32(42).bits, frame.accumulator.bits);
+}
+
+test "Bistromath x86_64: int32 arithmetic and overflow tier-down stay equivalent" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+
+    const value = try evaluateValue(&realm,
+        \\function add(a, b) { return a + b; }
+        \\add(1, 2);
+        \\let fast = add(20, 22);
+        \\let overflow = add(2147483647, 1);
+        \\(fast === 42 && overflow === 2147483648) ? 1 : 0;
+    );
+    try testing.expectEqual(Value.fromInt32(1).bits, value.bits);
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "add");
+}
+
+test "Bistromath x86_64: forward conditionals and backward loop branches" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+
+    const value = try evaluateValue(&realm,
+        \\function branchLoop(n) {
+        \\  let i = 0;
+        \\  let sum = 0;
+        \\  while (i < n) {
+        \\    if (i < 3) sum = sum + 1;
+        \\    else sum = sum + 2;
+        \\    i = i + 1;
+        \\  }
+        \\  return sum;
+        \\}
+        \\branchLoop(1);
+        \\branchLoop(5);
+    );
+    try testing.expectEqual(Value.fromInt32(7).bits, value.bits);
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "branchLoop");
+}
+
+test "Bistromath x86_64: SysV helper call returns a value" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    try realm.installBuiltins();
+
+    // Bound functions deliberately cannot occupy a direct-call IC. A
+    // compiled `site` therefore reaches `boundAdd` through helperCall,
+    // exercising the SysV argument registers and stack alignment.
+    const value = try evaluateValue(&realm,
+        \\function add(a, b) { return a + b; }
+        \\const boundAdd = add.bind(null);
+        \\function site(a, b) { return boundAdd(a, b) + 0; }
+        \\site(1, 2);
+        \\site(20, 22);
+    );
+    try testing.expectEqual(Value.fromInt32(42).bits, value.bits);
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "site");
+}
+
+test "Bistromath x86_64: helper-call exception verdict unwinds" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    try realm.installBuiltins();
+
+    const value = try evaluateValue(&realm,
+        \\function maybe(flag) { if (flag) throw 9; return 3; }
+        \\const boundMaybe = maybe.bind(null);
+        \\function site(flag) { return boundMaybe(flag) + 0; }
+        \\site(false);
+        \\let caught = 0;
+        \\try { site(true); } catch (error) { caught = error; }
+        \\caught;
+    );
+    try testing.expectEqual(Value.fromInt32(9).bits, value.bits);
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "site");
+}
+
+test "Bistromath x86_64: helper-call host OOM verdict propagates" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    try realm.installBuiltins();
+
+    _ = try evaluateValue(&realm,
+        \\function allocate(flag) {
+        \\  if (flag) return "x".repeat(524288);
+        \\  return 0;
+        \\}
+        \\const boundAllocate = allocate.bind(null);
+        \\function oomSite(flag) { return boundAllocate(flag); }
+        \\oomSite(false);
+        \\oomSite(false);
+    );
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "oomSite");
+
+    // Leave room for the tiny follow-up Script and call frame, but not the
+    // 512 KiB String payload. helperCall must return `host_oom`; the compiled
+    // driver must propagate it as a Zig OOM rather than re-executing the call
+    // or turning it into an arbitrary JS exception.
+    realm.setMemoryLimit(realm.heap.bytes_live + 64 * 1024);
+    try testing.expectError(
+        error.OutOfMemory,
+        lantern.evaluateScript(testing.allocator, &realm, "oomSite(true);"),
+    );
+    try testing.expect(realm.terminationReason() == null);
+}
+
+test "Bistromath x86_64: helper re-entry roots arguments under GC pressure" {
+    try requireNativeBackend();
+
+    var realm = Realm.init(testing.allocator);
+    defer realm.deinit();
+    realm.jit_enabled = true;
+    realm.jit_threshold_override = 1;
+    try realm.installBuiltins();
+    realm.heap.setGcThreshold(1);
+
+    // `site` is compiled and invokes a bound target through helperCall. The
+    // target allocates on every loop iteration, forcing nested runFrames GC
+    // safepoints while `rooted` is still live in the compiled caller's
+    // register file and in the helper's argument window.
+    const value = try evaluateValue(&realm,
+        \\function churn(object, n) {
+        \\  let i = 0;
+        \\  let sum = 0;
+        \\  while (i < n) {
+        \\    const temporary = { value: i };
+        \\    sum = (sum + temporary.value) | 0;
+        \\    i = i + 1;
+        \\  }
+        \\  return (object.value + sum) | 0;
+        \\}
+        \\const boundChurn = churn.bind(null);
+        \\function site(object, n) { return boundChurn(object, n) + 0; }
+        \\const rooted = { value: 42 };
+        \\site(rooted, 1);
+        \\site(rooted, 50);
+    );
+    try testing.expectEqual(Value.fromInt32(1267).bits, value.bits);
+    _ = try expectCompiledFunction(realm.script_chunks.items[0], "site");
+
+    realm.collectGarbage();
+    const after_full_gc = try evaluateValue(&realm, "site(rooted, 2);");
+    try testing.expectEqual(Value.fromInt32(43).bits, after_full_gc.bits);
+}

--- a/src/runtime/bistromath/x86_64_test.zig
+++ b/src/runtime/bistromath/x86_64_test.zig
@@ -76,6 +76,20 @@ test "Bistromath x86_64: three-address subtract rejects its private-scratch alia
     );
 }
 
+test "Bistromath x86_64: subtraction preserves a left operand in private scratch" {
+    if (comptime builtin.cpu.arch != .x86_64) return error.SkipZigTest;
+    var machine = bistro_masm.Masm.init(testing.allocator);
+    defer machine.deinit();
+
+    // x0 maps to the private rax scratch. In the rd == rm lowering, saving
+    // the right operand into rax would destroy this left operand before the
+    // subtraction. Refuse the alias so the owning chunk stays in Lantern.
+    try testing.expectError(
+        error.UnsupportedInstruction,
+        machine.emit(bistro_masm.subsRegW(.x9, .x0, .x9)),
+    );
+}
+
 test "Bistromath x86_64: entry prologue returns done with the accumulator result" {
     try requireNativeBackend();
 

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -37,6 +37,7 @@ const Environment = @import("environment.zig").Environment;
 const Chunk = @import("../bytecode/chunk.zig").Chunk;
 const JSGenerator = @import("generator.zig").JSGenerator;
 const jit_code_alloc = @import("jit/code_alloc.zig");
+const BistromathStats = @import("bistromath/stats.zig").Stats;
 const OhaimarkStats = @import("ohaimark/stats.zig").Stats;
 const JSSymbol = @import("symbol.zig").JSSymbol;
 const JSBigInt = @import("bigint.zig").JSBigInt;
@@ -404,6 +405,9 @@ pub const Heap = struct {
     /// the reservation fails (tier-up then degrades to "stay
     /// interpreted").
     jit_code: ?jit_code_alloc.CodeAllocator = null,
+    /// Opt-in T1 execution witness. Heap scope aggregates child realms; when
+    /// disabled, native entry pays only the predictable flag check.
+    bistromath_stats: BistromathStats = .{},
     /// Opt-in T2 rollout counters. Heap scope deliberately aggregates child
     /// realms, which share executable memory and object identity with their
     /// parent. Disabled means no clock reads or hot-entry counter traffic.

--- a/src/runtime/jit/asm_x86_64.zig
+++ b/src/runtime/jit/asm_x86_64.zig
@@ -1,0 +1,646 @@
+//! Small x86_64 machine-code writer for the shared JIT substrate.
+//!
+//! This is intentionally a byte-oriented counterpart to `asm_aarch64.zig`.
+//! Bistromath's target-selecting facade uses it for SysV ABI entries, labels,
+//! guard branches, and indirect helper calls. Ohaimark remains AArch64-only;
+//! higher-level T1 call policy stays in Bistromath's shared compiler.
+
+const std = @import("std");
+const builtin = @import("builtin");
+const code_alloc = @import("code_alloc.zig");
+
+/// General-purpose x86_64 registers. Their discriminants are the architectural
+/// register numbers used directly by ModRM and REX.
+pub const Reg = enum(u4) {
+    rax = 0,
+    rcx = 1,
+    rdx = 2,
+    rbx = 3,
+    rsp = 4,
+    rbp = 5,
+    rsi = 6,
+    rdi = 7,
+    r8 = 8,
+    r9 = 9,
+    r10 = 10,
+    r11 = 11,
+    r12 = 12,
+    r13 = 13,
+    r14 = 14,
+    r15 = 15,
+};
+
+pub const Xmm = enum(u4) {
+    xmm0 = 0,
+    xmm1 = 1,
+    xmm2 = 2,
+    xmm3 = 3,
+    xmm4 = 4,
+    xmm5 = 5,
+    xmm6 = 6,
+    xmm7 = 7,
+    xmm8 = 8,
+    xmm9 = 9,
+    xmm10 = 10,
+    xmm11 = 11,
+    xmm12 = 12,
+    xmm13 = 13,
+    xmm14 = 14,
+    xmm15 = 15,
+};
+
+/// x86 condition-code low nibble, shared by short and near branches. The
+/// first x86 lowering uses near branches exclusively so forward guard exits do
+/// not depend on final code size.
+pub const Cond = enum(u4) {
+    overflow = 0,
+    not_overflow = 1,
+    below = 2,
+    above_or_equal = 3,
+    equal = 4,
+    not_equal = 5,
+    below_or_equal = 6,
+    above = 7,
+    sign = 8,
+    not_sign = 9,
+    parity = 10,
+    not_parity = 11,
+    less = 12,
+    greater_or_equal = 13,
+    less_or_equal = 14,
+    greater = 15,
+};
+
+/// True only when the code allocator can install and execute x86_64 code on
+/// this host. The encoder remains compileable for cross-target builds.
+pub const native_x86_64 = code_alloc.supported and builtin.cpu.arch == .x86_64;
+
+pub const Masm = struct {
+    gpa: std.mem.Allocator,
+    code: std.ArrayListUnmanaged(u8) = .empty,
+
+    pub fn init(gpa: std.mem.Allocator) Masm {
+        return .{ .gpa = gpa };
+    }
+
+    pub fn deinit(self: *Masm) void {
+        self.code.deinit(self.gpa);
+        self.* = undefined;
+    }
+
+    /// `mov r64, imm64`.
+    pub fn movImm64(self: *Masm, destination: Reg, value: u64) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, false, false, isExtended(destination)));
+        try self.emitByte(0xB8 + lowBits(destination));
+        try self.emitU64(value);
+    }
+
+    /// `mov destination, source`.
+    pub fn movReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x89, destination, source);
+    }
+
+    /// `mov destination32, source32`, zero-extending into the destination.
+    pub fn movReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x89, destination, source);
+    }
+
+    /// `add destination, source`.
+    pub fn addReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x01, destination, source);
+    }
+
+    /// `add destination32, source32`.
+    pub fn addReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x01, destination, source);
+    }
+
+    /// `add destination32, immediate32`.
+    pub fn addReg32Imm32(
+        self: *Masm,
+        destination: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(destination)));
+        try self.emitByte(0x81);
+        try self.emitByte(0xC0 | lowBits(destination));
+        try self.emitU32(immediate);
+    }
+
+    /// `sub destination, source`.
+    pub fn subReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x29, destination, source);
+    }
+
+    /// `sub destination32, source32`.
+    pub fn subReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x29, destination, source);
+    }
+
+    /// `imul destination32, source32`.
+    pub fn imulReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtended(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0xAF);
+        try self.emitByte(0xC0 | (lowBits(destination) << 3) | lowBits(source));
+    }
+
+    /// `imul destination, source` over signed 64-bit operands.
+    pub fn imulReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0xAF);
+        try self.emitByte(0xC0 | (lowBits(destination) << 3) | lowBits(source));
+    }
+
+    /// `movsxd destination, source32` — sign-extend an Int32 payload into
+    /// a 64-bit register without involving host-language casts.
+    pub fn signExtendReg32To64(
+        self: *Masm,
+        destination: Reg,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(destination), false, isExtended(source)));
+        try self.emitByte(0x63);
+        try self.emitByte(0xC0 | (lowBits(destination) << 3) | lowBits(source));
+    }
+
+    /// `add destination, immediate32`.
+    pub fn addRegImm32(
+        self: *Masm,
+        destination: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitRegImm32(0, destination, immediate);
+    }
+
+    /// `sub destination, immediate32`.
+    pub fn subRegImm32(
+        self: *Masm,
+        destination: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitRegImm32(5, destination, immediate);
+    }
+
+    /// `and destination, source`.
+    pub fn andReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x21, destination, source);
+    }
+
+    /// `and destination32, source32`.
+    pub fn andReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x21, destination, source);
+    }
+
+    /// `or destination, source`.
+    pub fn orReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x09, destination, source);
+    }
+
+    /// `or destination32, source32`.
+    pub fn orReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x09, destination, source);
+    }
+
+    /// `xor destination, source`.
+    pub fn xorReg64(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x31, destination, source);
+    }
+
+    /// `xor destination32, source32`.
+    pub fn xorReg32(self: *Masm, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x31, destination, source);
+    }
+
+    /// `test left, right`.
+    pub fn testReg64(self: *Masm, left: Reg, right: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x85, left, right);
+    }
+
+    /// `test value32, immediate32`.
+    pub fn testReg32Imm32(
+        self: *Masm,
+        value: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(value)));
+        try self.emitByte(0xF7);
+        try self.emitByte(0xC0 | lowBits(value));
+        try self.emitU32(immediate);
+    }
+
+    /// `cmp left, right`.
+    pub fn cmpReg64(self: *Masm, left: Reg, right: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg(0x39, left, right);
+    }
+
+    /// `cmp left32, right32`.
+    pub fn cmpReg32(self: *Masm, left: Reg, right: Reg) error{OutOfMemory}!void {
+        try self.emitRegReg32(0x39, left, right);
+    }
+
+    /// `cmp left, immediate32`.
+    pub fn cmpRegImm32(
+        self: *Masm,
+        left: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitRegImm32(7, left, immediate);
+    }
+
+    /// `shl destination, amount`.
+    pub fn shlImm8(self: *Masm, destination: Reg, amount: u8) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, false, false, isExtended(destination)));
+        try self.emitByte(0xC1);
+        try self.emitByte(0xE0 | lowBits(destination));
+        try self.emitByte(amount);
+    }
+
+    /// `shr destination, amount`.
+    pub fn shrImm8(self: *Masm, destination: Reg, amount: u8) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, false, false, isExtended(destination)));
+        try self.emitByte(0xC1);
+        try self.emitByte(0xE8 | lowBits(destination));
+        try self.emitByte(amount);
+    }
+
+    /// Materialize one condition bit and zero-extend it to the full
+    /// 32-bit destination without clobbering the flags before SETcc.
+    pub fn setCond32(
+        self: *Masm,
+        destination: Reg,
+        condition: Cond,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(destination)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x90 | @as(u8, @intFromEnum(condition)));
+        try self.emitByte(0xC0 | lowBits(destination));
+
+        try self.emitByte(rex(
+            false,
+            isExtended(destination),
+            false,
+            isExtended(destination),
+        ));
+        try self.emitByte(0x0F);
+        try self.emitByte(0xB6);
+        try self.emitByte(
+            0xC0 | (lowBits(destination) << 3) | lowBits(destination),
+        );
+    }
+
+    /// `lea destination, [base + displacement]`.
+    pub fn leaDisp32(
+        self: *Masm,
+        destination: Reg,
+        base: Reg,
+        displacement: i32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(
+            true,
+            isExtended(destination),
+            false,
+            isExtended(base),
+        ));
+        try self.emitByte(0x8D);
+        try self.emitDisp32ModRm(lowBits(destination), base, displacement);
+    }
+
+    /// `mov destination, qword ptr [base + displacement]`.
+    ///
+    /// Bistromath's entry ABI passes `CallFrame*` in `rsi` and the raw Lantern
+    /// register file in `rdx`; accepting any GPR here keeps the encoder useful
+    /// as its non-leaf lowering grows without duplicating ModRM mechanics.
+    pub fn load64Disp32(
+        self: *Masm,
+        destination: Reg,
+        base: Reg,
+        displacement: i32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(destination), false, isExtended(base)));
+        try self.emitByte(0x8B);
+        try self.emitDisp32ModRm(lowBits(destination), base, displacement);
+    }
+
+    /// `mov destination32, dword ptr [base + displacement]`, zero-extending
+    /// the loaded value into the full destination register.
+    pub fn load32Disp32(
+        self: *Masm,
+        destination: Reg,
+        base: Reg,
+        displacement: i32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtended(destination), false, isExtended(base)));
+        try self.emitByte(0x8B);
+        try self.emitDisp32ModRm(lowBits(destination), base, displacement);
+    }
+
+    /// `movzx destination32, byte ptr [base + displacement]`.
+    pub fn load8Disp32(
+        self: *Masm,
+        destination: Reg,
+        base: Reg,
+        displacement: i32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtended(destination), false, isExtended(base)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0xB6);
+        try self.emitDisp32ModRm(lowBits(destination), base, displacement);
+    }
+
+    /// `cmp qword ptr [base + displacement], source`.
+    pub fn cmp64Disp32Reg(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(source), false, isExtended(base)));
+        try self.emitByte(0x39);
+        try self.emitDisp32ModRm(lowBits(source), base, displacement);
+    }
+
+    /// `cmp dword ptr [base + displacement], immediate`.
+    pub fn cmp32Disp32Imm32(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(base)));
+        try self.emitByte(0x81);
+        try self.emitDisp32ModRm(7, base, displacement);
+        try self.emitU32(immediate);
+    }
+
+    /// `cmp qword ptr [base + displacement], immediate8`.
+    pub fn cmp64Disp32Imm8(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        immediate: u8,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, false, false, isExtended(base)));
+        try self.emitByte(0x83);
+        try self.emitDisp32ModRm(7, base, displacement);
+        try self.emitByte(immediate);
+    }
+
+    /// `cmp byte ptr [base + displacement], immediate8`.
+    pub fn cmp8Disp32Imm8(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        immediate: u8,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(base)));
+        try self.emitByte(0x80);
+        try self.emitDisp32ModRm(7, base, displacement);
+        try self.emitByte(immediate);
+    }
+
+    /// `mov qword ptr [base + displacement], source`.
+    pub fn store64Disp32(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(source), false, isExtended(base)));
+        try self.emitByte(0x89);
+        try self.emitDisp32ModRm(lowBits(source), base, displacement);
+    }
+
+    /// `mov dword ptr [base + displacement], source32`.
+    pub fn store32Disp32(
+        self: *Masm,
+        base: Reg,
+        displacement: i32,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtended(source), false, isExtended(base)));
+        try self.emitByte(0x89);
+        try self.emitDisp32ModRm(lowBits(source), base, displacement);
+    }
+
+    /// `cvtsi2sd destination, source32`.
+    pub fn cvtI32ToDouble(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(0xF2);
+        try self.emitByte(rex(false, isExtendedXmm(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x2A);
+        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBits(source));
+    }
+
+    /// `movq destination, source` where destination is an XMM register and
+    /// source is a 64-bit GPR.
+    pub fn movQXmmFromReg(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(0x66);
+        try self.emitByte(rex(true, isExtendedXmm(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x6E);
+        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBits(source));
+    }
+
+    /// `movq destination, source` where destination is a 64-bit GPR and
+    /// source is an XMM register.
+    pub fn movQRegFromXmm(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitByte(0x66);
+        try self.emitByte(rex(true, isExtendedXmm(source), false, isExtended(destination)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x7E);
+        try self.emitByte(0xC0 | (lowBitsXmm(source) << 3) | lowBits(destination));
+    }
+
+    pub fn mulDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x59, destination, source);
+    }
+
+    pub fn divDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x5E, destination, source);
+    }
+
+    /// `ucomisd left, right` — its parity flag reports an unordered (NaN)
+    /// comparison, which native lowering routes back to Lantern for canonical
+    /// NaN boxing.
+    pub fn ucomisDouble(self: *Masm, left: Xmm, right: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0x66, 0x2E, left, right);
+    }
+
+    /// `call target`.
+    pub fn callReg(self: *Masm, target: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(target)));
+        try self.emitByte(0xFF);
+        try self.emitByte(0xD0 | lowBits(target));
+    }
+
+    pub fn ret(self: *Masm) error{OutOfMemory}!void {
+        try self.emitByte(0xC3);
+    }
+
+    pub const Label = struct {
+        bound: ?usize = null,
+        fixups: std.ArrayListUnmanaged(usize) = .empty,
+
+        pub fn deinit(self: *Label, gpa: std.mem.Allocator) void {
+            self.fixups.deinit(gpa);
+            self.* = undefined;
+        }
+    };
+
+    /// Bind every recorded near-relative branch to this code position.
+    pub fn bind(self: *Masm, label: *Label) !void {
+        if (label.bound != null) return error.LabelAlreadyBound;
+        const target = self.code.items.len;
+        // Validate every fixup before changing code or publishing the label.
+        // A malformed or out-of-range branch must leave a fully retryable,
+        // unbound label so the owning tier can refuse compilation cleanly.
+        for (label.fixups.items) |at| _ = try self.rel32Displacement(at, target);
+        for (label.fixups.items) |at| try self.patchRel32(at, target);
+        label.bound = target;
+        label.fixups.clearRetainingCapacity();
+    }
+
+    /// `jmp rel32`.
+    pub fn jump(self: *Masm, label: *Label) !void {
+        try self.emitByte(0xE9);
+        try self.emitBranchDisplacement(label);
+    }
+
+    /// `jcc rel32`.
+    pub fn jumpCond(self: *Masm, condition: Cond, label: *Label) !void {
+        try self.emitByte(0x0F);
+        try self.emitByte(@as(u8, 0x80) | @as(u8, @intFromEnum(condition)));
+        try self.emitBranchDisplacement(label);
+    }
+
+    pub fn install(self: *Masm, allocator: *code_alloc.CodeAllocator) code_alloc.Error![]const u8 {
+        return allocator.install(self.code.items);
+    }
+
+    fn emitByte(self: *Masm, byte: u8) error{OutOfMemory}!void {
+        try self.code.append(self.gpa, byte);
+    }
+
+    fn emitRegReg(self: *Masm, opcode: u8, destination: Reg, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, isExtended(source), false, isExtended(destination)));
+        try self.emitByte(opcode);
+        try self.emitByte(0xC0 | (lowBits(source) << 3) | lowBits(destination));
+    }
+
+    fn emitRegReg32(
+        self: *Masm,
+        opcode: u8,
+        destination: Reg,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtended(source), false, isExtended(destination)));
+        try self.emitByte(opcode);
+        try self.emitByte(0xC0 | (lowBits(source) << 3) | lowBits(destination));
+    }
+
+    fn emitRegImm32(
+        self: *Masm,
+        operation: u3,
+        destination: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(true, false, false, isExtended(destination)));
+        try self.emitByte(0x81);
+        try self.emitByte(0xC0 | (@as(u8, operation) << 3) | lowBits(destination));
+        try self.emitU32(immediate);
+    }
+
+    fn emitDisp32ModRm(
+        self: *Masm,
+        reg_field: u8,
+        base: Reg,
+        displacement: i32,
+    ) error{OutOfMemory}!void {
+        std.debug.assert(reg_field < 8);
+        try self.emitByte(0x80 | (reg_field << 3) | lowBits(base));
+        // ModRM r/m=100 selects a SIB byte rather than rsp/r12 directly.
+        if (lowBits(base) == 4) try self.emitByte(0x24);
+        try self.emitI32(displacement);
+    }
+
+    fn emitXmmReg(
+        self: *Masm,
+        prefix: u8,
+        opcode: u8,
+        destination: Xmm,
+        source: Xmm,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(prefix);
+        try self.emitByte(rex(false, isExtendedXmm(destination), false, isExtendedXmm(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(opcode);
+        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBitsXmm(source));
+    }
+
+    fn emitBranchDisplacement(self: *Masm, label: *Label) !void {
+        const at = self.code.items.len;
+        try self.emitI32(0);
+        if (label.bound) |target| {
+            try self.patchRel32(at, target);
+        } else {
+            try label.fixups.append(self.gpa, at);
+        }
+    }
+
+    fn patchRel32(self: *Masm, at: usize, target: usize) !void {
+        const displacement = try self.rel32Displacement(at, target);
+        std.mem.writeInt(u32, self.code.items[at..][0..4], @bitCast(displacement), .little);
+    }
+
+    fn rel32Displacement(self: *const Masm, at: usize, target: usize) !i32 {
+        if (at > self.code.items.len or 4 > self.code.items.len - at) {
+            return error.InvalidLabel;
+        }
+        const delta: i128 = @as(i128, @intCast(target)) - @as(i128, @intCast(at + 4));
+        return std.math.cast(i32, delta) orelse error.BranchOutOfRange;
+    }
+
+    fn emitI32(self: *Masm, value: i32) error{OutOfMemory}!void {
+        var bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &bytes, @bitCast(value), .little);
+        try self.code.appendSlice(self.gpa, &bytes);
+    }
+
+    fn emitU32(self: *Masm, value: u32) error{OutOfMemory}!void {
+        var bytes: [4]u8 = undefined;
+        std.mem.writeInt(u32, &bytes, value, .little);
+        try self.code.appendSlice(self.gpa, &bytes);
+    }
+
+    fn emitU64(self: *Masm, value: u64) error{OutOfMemory}!void {
+        var bytes: [8]u8 = undefined;
+        std.mem.writeInt(u64, &bytes, value, .little);
+        try self.code.appendSlice(self.gpa, &bytes);
+    }
+};
+
+fn rex(w: bool, r: bool, x: bool, b: bool) u8 {
+    return 0x40 |
+        (@as(u8, @intFromBool(w)) << 3) |
+        (@as(u8, @intFromBool(r)) << 2) |
+        (@as(u8, @intFromBool(x)) << 1) |
+        @as(u8, @intFromBool(b));
+}
+
+fn isExtended(register: Reg) bool {
+    return @intFromEnum(register) >= 8;
+}
+
+fn lowBits(register: Reg) u8 {
+    return @intFromEnum(register) & 7;
+}
+
+fn isExtendedXmm(register: Xmm) bool {
+    return @intFromEnum(register) >= 8;
+}
+
+fn lowBitsXmm(register: Xmm) u8 {
+    return @intFromEnum(register) & 7;
+}

--- a/src/runtime/jit/asm_x86_64_test.zig
+++ b/src/runtime/jit/asm_x86_64_test.zig
@@ -1,0 +1,97 @@
+const std = @import("std");
+const builtin = @import("builtin");
+
+const x64 = @import("asm_x86_64.zig");
+const code_alloc = @import("code_alloc.zig");
+
+test "jit asm_x86_64: Bistromath integer primitives have stable encodings" {
+    var machine = x64.Masm.init(std.testing.allocator);
+    defer machine.deinit();
+
+    try machine.addReg32Imm32(.r8, 1);
+    try machine.andReg32(.r8, .r9);
+    try machine.orReg32(.r10, .r11);
+    try machine.shlImm8(.r12, 3);
+    try machine.setCond32(.r9, .less);
+    try machine.leaDisp32(.r10, .r13, 0x1234);
+    try machine.signExtendReg32To64(.r10, .r9);
+    try machine.imulReg64(.r11, .r10);
+
+    try std.testing.expectEqualSlices(u8, &.{
+        0x41, 0x81, 0xC0, 0x01, 0x00, 0x00, 0x00,
+        0x45, 0x21, 0xC8, 0x45, 0x09, 0xDA, 0x49,
+        0xC1, 0xE4, 0x03, 0x41, 0x0F, 0x9C, 0xC1,
+        0x45, 0x0F, 0xB6, 0xC9, 0x4D, 0x8D, 0x95,
+        0x34, 0x12, 0x00, 0x00, 0x4D, 0x63, 0xD1,
+        0x4D, 0x0F, 0xAF, 0xDA,
+    }, machine.code.items);
+}
+
+test "jit asm_x86_64: rel32 labels handle forward and backward edges" {
+    var machine = x64.Masm.init(std.testing.allocator);
+    defer machine.deinit();
+
+    var body = x64.Masm.Label{};
+    defer body.deinit(std.testing.allocator);
+    var loop = x64.Masm.Label{};
+    defer loop.deinit(std.testing.allocator);
+
+    try machine.jump(&body);
+    try machine.movImm64(.rax, 99);
+    try machine.bind(&body);
+    try machine.movImm64(.rax, 2);
+    try machine.bind(&loop);
+    try machine.subRegImm32(.rax, 1);
+    try machine.jumpCond(.not_equal, &loop);
+    try machine.ret();
+
+    try std.testing.expectEqualSlices(u8, &.{
+        0xE9, 0x0A, 0x00, 0x00, 0x00,
+        0x48, 0xB8, 0x63, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        0x48, 0xB8, 0x02, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00,
+        0x48, 0x81, 0xE8, 0x01, 0x00,
+        0x00, 0x00, 0x0F, 0x85, 0xF3,
+        0xFF, 0xFF, 0xFF, 0xC3,
+    }, machine.code.items);
+}
+
+test "jit asm_x86_64: a failed bind does not publish the label" {
+    var machine = x64.Masm.init(std.testing.allocator);
+    defer machine.deinit();
+    var label = x64.Masm.Label{};
+    defer label.deinit(std.testing.allocator);
+
+    // Model a corrupt/stale fixup without touching machine memory. Binding
+    // must fail transactionally so a JIT compiler can refuse the chunk rather
+    // than observing a label that claims to have been installed.
+    try label.fixups.append(std.testing.allocator, 1);
+    try std.testing.expectError(error.InvalidLabel, machine.bind(&label));
+    try std.testing.expectEqual(@as(?usize, null), label.bound);
+}
+
+test "jit asm_x86_64: installed rel32 loop executes natively" {
+    if (comptime builtin.cpu.arch != .x86_64 or !code_alloc.supported) {
+        return error.SkipZigTest;
+    }
+
+    var machine = x64.Masm.init(std.testing.allocator);
+    defer machine.deinit();
+    var loop = x64.Masm.Label{};
+    defer loop.deinit(std.testing.allocator);
+
+    try machine.movImm64(.rax, 2);
+    try machine.bind(&loop);
+    try machine.subRegImm32(.rax, 1);
+    try machine.jumpCond(.not_equal, &loop);
+    try machine.ret();
+
+    var executable = try code_alloc.CodeAllocator.init(std.testing.allocator, 64 * 1024);
+    defer executable.deinit();
+    const entry = code_alloc.asFn(
+        *const fn () callconv(.c) u64,
+        try machine.install(&executable),
+    );
+    try std.testing.expectEqual(@as(u64, 0), entry());
+}

--- a/src/runtime/jit/masm.zig
+++ b/src/runtime/jit/masm.zig
@@ -1,10 +1,10 @@
 //! MacroAssembler facade for the JIT substrate — the instruction
 //! buffer, labels with forward-fixup patching, and multi-instruction
 //! helpers (64-bit immediate materialization, absolute calls).
-//! Call sites stay target-independent; bodies are per-ISA
-//! (docs/jit.md §7 — the SpiderMonkey model). aarch64 only today;
-//! the x86_64 body is a mechanical port behind the same surface
-//! (docs/jit.md §14).
+//! This facade is AArch64-specific today and is shared by Ohaimark and
+//! Spasm. Bistromath's target-neutral adapter lives in
+//! `bistromath/masm.zig` and selects this facade or `asm_x86_64.zig`
+//! (docs/jit.md §7 — the SpiderMonkey model).
 //!
 //! The buffer is plain heap memory — code is assembled here in
 //! full, then copied into executable pages by
@@ -22,6 +22,17 @@ pub const Cond = a64.Cond;
 /// True when this build can both emit for and execute on the host —
 /// what the execution tests below require.
 pub const native_aarch64 = code_alloc.supported and builtin.cpu.arch == .aarch64;
+
+/// Assembly can fail because the byte buffer grows, or because a user-sized
+/// chunk cannot be represented by the selected ISA's relative branch.  The
+/// latter must make the tier refuse the chunk; it must never reach an
+/// `@intCast` trap and abort the host (AGENTS.md host-safety contract).
+pub const Error = error{
+    OutOfMemory,
+    LabelAlreadyBound,
+    InvalidLabel,
+    BranchOutOfRange,
+};
 
 pub const Masm = struct {
     gpa: std.mem.Allocator,
@@ -70,17 +81,18 @@ pub const Masm = struct {
         }
     };
 
-    pub fn bind(self: *Masm, label: *Label) void {
-        std.debug.assert(label.bound == null);
-        label.bound = self.offset();
-        for (label.fixups.items) |fixup| self.patch(fixup, label.bound.?);
+    pub fn bind(self: *Masm, label: *Label) Error!void {
+        if (label.bound != null) return error.LabelAlreadyBound;
+        const target = self.offset();
+        for (label.fixups.items) |fixup| try self.patch(fixup, target);
+        label.bound = target;
         label.fixups.clearRetainingCapacity();
     }
 
     /// B <label>
-    pub fn jump(self: *Masm, label: *Label) error{OutOfMemory}!void {
+    pub fn jump(self: *Masm, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.b(deltaWords(i26, self.offset(), target)));
+            try self.emit(a64.b(try deltaWords(i26, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm26 });
             try self.emit(a64.b(0));
@@ -88,9 +100,9 @@ pub const Masm = struct {
     }
 
     /// B.cond <label>
-    pub fn jumpCond(self: *Masm, cond: Cond, label: *Label) error{OutOfMemory}!void {
+    pub fn jumpCond(self: *Masm, cond: Cond, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.bCond(cond, deltaWords(i19, self.offset(), target)));
+            try self.emit(a64.bCond(cond, try deltaWords(i19, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm19 });
             try self.emit(a64.bCond(cond, 0));
@@ -98,9 +110,9 @@ pub const Masm = struct {
     }
 
     /// CBZ Xt, <label>
-    pub fn jumpCbz(self: *Masm, rt: Reg, label: *Label) error{OutOfMemory}!void {
+    pub fn jumpCbz(self: *Masm, rt: Reg, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.cbz(rt, deltaWords(i19, self.offset(), target)));
+            try self.emit(a64.cbz(rt, try deltaWords(i19, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm19 });
             try self.emit(a64.cbz(rt, 0));
@@ -108,9 +120,9 @@ pub const Masm = struct {
     }
 
     /// CBNZ Xt, <label>
-    pub fn jumpCbnz(self: *Masm, rt: Reg, label: *Label) error{OutOfMemory}!void {
+    pub fn jumpCbnz(self: *Masm, rt: Reg, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.cbnz(rt, deltaWords(i19, self.offset(), target)));
+            try self.emit(a64.cbnz(rt, try deltaWords(i19, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm19 });
             try self.emit(a64.cbnz(rt, 0));
@@ -118,9 +130,9 @@ pub const Masm = struct {
     }
 
     /// TBZ Xt, #bit, <label>
-    pub fn jumpTbz(self: *Masm, rt: Reg, bit: u6, label: *Label) error{OutOfMemory}!void {
+    pub fn jumpTbz(self: *Masm, rt: Reg, bit: u6, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.tbz(rt, bit, deltaWords(i14, self.offset(), target)));
+            try self.emit(a64.tbz(rt, bit, try deltaWords(i14, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm14 });
             try self.emit(a64.tbz(rt, bit, 0));
@@ -128,9 +140,9 @@ pub const Masm = struct {
     }
 
     /// TBNZ Xt, #bit, <label>
-    pub fn jumpTbnz(self: *Masm, rt: Reg, bit: u6, label: *Label) error{OutOfMemory}!void {
+    pub fn jumpTbnz(self: *Masm, rt: Reg, bit: u6, label: *Label) Error!void {
         if (label.bound) |target| {
-            try self.emit(a64.tbnz(rt, bit, deltaWords(i14, self.offset(), target)));
+            try self.emit(a64.tbnz(rt, bit, try deltaWords(i14, self.offset(), target)));
         } else {
             try label.fixups.append(self.gpa, .{ .at = self.offset(), .kind = .imm14 });
             try self.emit(a64.tbnz(rt, bit, 0));
@@ -165,25 +177,30 @@ pub const Masm = struct {
         return ca.install(self.code.items);
     }
 
-    fn deltaWords(comptime T: type, from: usize, to: usize) T {
-        const delta = @divExact(@as(isize, @intCast(to)) - @as(isize, @intCast(from)), 4);
-        return @intCast(delta);
+    fn deltaWords(comptime T: type, from: usize, to: usize) Error!T {
+        if ((from | to) & 3 != 0) return error.InvalidLabel;
+        const delta_bytes = @as(i128, @intCast(to)) - @as(i128, @intCast(from));
+        const delta_words = @divExact(delta_bytes, 4);
+        return std.math.cast(T, delta_words) orelse error.BranchOutOfRange;
     }
 
-    fn patch(self: *Masm, fixup: Label.Fixup, target: usize) void {
+    fn patch(self: *Masm, fixup: Label.Fixup, target: usize) Error!void {
+        if (fixup.at > self.code.items.len or 4 > self.code.items.len - fixup.at) {
+            return error.InvalidLabel;
+        }
         const slot = self.code.items[fixup.at..][0..4];
         var word = std.mem.readInt(u32, slot, .little);
         switch (fixup.kind) {
             .imm26 => {
-                const d = deltaWords(i26, fixup.at, target);
+                const d = try deltaWords(i26, fixup.at, target);
                 word |= @as(u32, @as(u26, @bitCast(d)));
             },
             .imm19 => {
-                const d = deltaWords(i19, fixup.at, target);
+                const d = try deltaWords(i19, fixup.at, target);
                 word |= @as(u32, @as(u19, @bitCast(d))) << 5;
             },
             .imm14 => {
-                const d = deltaWords(i14, fixup.at, target);
+                const d = try deltaWords(i14, fixup.at, target);
                 word |= @as(u32, @as(u14, @bitCast(d))) << 5;
             },
         }
@@ -268,13 +285,13 @@ test "jit masm: labels — backward and forward branches in a loop" {
 
     try m.movImm64(.x2, 0); // sum
     try m.movImm64(.x3, 0); // i
-    m.bind(&head);
+    try m.bind(&head);
     try m.emit(a64.cmpReg(.x3, .x0));
     try m.jumpCond(.eq, &done); // forward fixup
     try m.emit(a64.addReg(.x2, .x2, .x3));
     try m.emit(a64.addImm(.x3, .x3, 1, false));
     try m.jump(&head); // backward, already bound
-    m.bind(&done);
+    try m.bind(&done);
     try m.emit(a64.movReg(.x0, .x2));
     try m.emit(a64.ret());
 

--- a/src/runtime/jit/masm.zig
+++ b/src/runtime/jit/masm.zig
@@ -84,6 +84,11 @@ pub const Masm = struct {
     pub fn bind(self: *Masm, label: *Label) Error!void {
         if (label.bound != null) return error.LabelAlreadyBound;
         const target = self.offset();
+        // Preflight every fixup before changing any instruction. A later
+        // narrow branch may be out of range even when an earlier wide branch
+        // is valid; patching as we validate would leave a retryable label
+        // pointing at a partially-mutated buffer.
+        for (label.fixups.items) |fixup| try self.validateFixup(fixup, target);
         for (label.fixups.items) |fixup| try self.patch(fixup, target);
         label.bound = target;
         label.fixups.clearRetainingCapacity();
@@ -182,6 +187,17 @@ pub const Masm = struct {
         const delta_bytes = @as(i128, @intCast(to)) - @as(i128, @intCast(from));
         const delta_words = @divExact(delta_bytes, 4);
         return std.math.cast(T, delta_words) orelse error.BranchOutOfRange;
+    }
+
+    fn validateFixup(self: *const Masm, fixup: Label.Fixup, target: usize) Error!void {
+        if (fixup.at > self.code.items.len or 4 > self.code.items.len - fixup.at) {
+            return error.InvalidLabel;
+        }
+        switch (fixup.kind) {
+            .imm26 => _ = try deltaWords(i26, fixup.at, target),
+            .imm19 => _ = try deltaWords(i19, fixup.at, target),
+            .imm14 => _ = try deltaWords(i14, fixup.at, target),
+        }
     }
 
     fn patch(self: *Masm, fixup: Label.Fixup, target: usize) Error!void {

--- a/src/runtime/jit/masm_safety_test.zig
+++ b/src/runtime/jit/masm_safety_test.zig
@@ -1,0 +1,26 @@
+const std = @import("std");
+
+const a64 = @import("asm_aarch64.zig");
+const Masm = @import("masm.zig").Masm;
+
+test "jit masm: binding a label twice fails without aborting" {
+    var machine = Masm.init(std.testing.allocator);
+    defer machine.deinit();
+    var label = Masm.Label{};
+    defer label.deinit(std.testing.allocator);
+
+    try machine.bind(&label);
+    try std.testing.expectError(error.LabelAlreadyBound, machine.bind(&label));
+}
+
+test "jit masm: an out-of-range AArch64 conditional fixup fails without a cast trap" {
+    var machine = Masm.init(std.testing.allocator);
+    defer machine.deinit();
+    var far = Masm.Label{};
+    defer far.deinit(std.testing.allocator);
+
+    try machine.jumpTbz(.x0, 0, &far);
+    for (0..8192) |_| try machine.emit(a64.nop());
+
+    try std.testing.expectError(error.BranchOutOfRange, machine.bind(&far));
+}

--- a/src/runtime/jit/masm_safety_test.zig
+++ b/src/runtime/jit/masm_safety_test.zig
@@ -24,3 +24,40 @@ test "jit masm: an out-of-range AArch64 conditional fixup fails without a cast t
 
     try std.testing.expectError(error.BranchOutOfRange, machine.bind(&far));
 }
+
+test "jit masm: a failed mixed-fixup bind is transactional and retryable" {
+    var machine = Masm.init(std.testing.allocator);
+    defer machine.deinit();
+    var far = Masm.Label{};
+    defer far.deinit(std.testing.allocator);
+
+    // The first fixup (`B`, imm26) can reach the final target; the second
+    // (`TBZ`, imm14) cannot. Binding must preflight both before patching the
+    // first instruction, otherwise a later retry ORs a new displacement into
+    // the already-mutated branch word.
+    try machine.jump(&far);
+    try machine.jumpTbz(.x0, 0, &far);
+    for (0..8192) |_| try machine.emit(a64.nop());
+
+    const before = try std.testing.allocator.dupe(u8, machine.code.items);
+    defer std.testing.allocator.free(before);
+    try std.testing.expectError(error.BranchOutOfRange, machine.bind(&far));
+    try std.testing.expectEqualSlices(u8, before, machine.code.items);
+    try std.testing.expectEqual(@as(?usize, null), far.bound);
+    try std.testing.expectEqual(@as(usize, 2), far.fixups.items.len);
+
+    // Bring the target into range and prove the same label/buffer can bind
+    // correctly after the failed attempt.
+    machine.code.shrinkRetainingCapacity(8);
+    try machine.bind(&far);
+    try std.testing.expectEqual(@as(?usize, 8), far.bound);
+    try std.testing.expectEqual(@as(usize, 0), far.fixups.items.len);
+    try std.testing.expectEqual(
+        a64.b(2),
+        std.mem.readInt(u32, machine.code.items[0..4], .little),
+    );
+    try std.testing.expectEqual(
+        a64.tbz(.x0, 0, 1),
+        std.mem.readInt(u32, machine.code.items[4..8], .little),
+    );
+}

--- a/src/runtime/ohaimark/codegen_aarch64.zig
+++ b/src/runtime/ohaimark/codegen_aarch64.zig
@@ -245,14 +245,14 @@ const Compiler = struct {
         try self.emitEntryParameters();
         for (self.graph.blocks, 0..) |block, block_index| {
             if (!block.reachable) continue;
-            self.machine.bind(&self.block_labels[block_index]);
+            try self.machine.bind(&self.block_labels[block_index]);
             try self.emitBlock(block_index, block);
         }
         // OSR stubs after the ordinary body so fallthrough never lands in one.
         // Each stub shares the same spill layout and block labels as entry.
         try self.emitOsrEntries();
         for (self.physical_deopt.points, 0..) |_, point_index| {
-            self.machine.bind(&self.guard_labels[point_index]);
+            try self.machine.bind(&self.guard_labels[point_index]);
             try self.emitGuardExit(point_index);
         }
     }
@@ -371,7 +371,7 @@ const Compiler = struct {
                 // write it). Release the spill area and bail to Lantern —
                 // use the OSR-bail sentinel so thrash accounting only
                 // charges true enter-and-bail, not safepoint resumes.
-                self.machine.bind(&int32_fail);
+                try self.machine.bind(&int32_fail);
                 try self.machine.movImm64(.x0, osr_bail_sentinel_bits);
                 try emitter.emitEpilogue(self.machine, self.lowered.frame);
             }
@@ -574,7 +574,7 @@ const Compiler = struct {
         try self.machine.jumpCond(.ne, &nonzero);
         try self.machine.emit(a64.eorReg(guard_scratch, lhs_scratch, rhs_scratch));
         try self.jumpToGuardIfBitSet(guard_scratch, 31, guard);
-        self.machine.bind(&nonzero);
+        try self.machine.bind(&nonzero);
     }
 
     /// §6.1.6.1.5 Number::divide, exact-int32 subset. AArch64 `sdiv` is
@@ -590,7 +590,7 @@ const Compiler = struct {
         try self.machine.emit(a64.cmpImm(lhs_scratch, 0, false));
         try self.machine.jumpCond(.ne, &nonzero_lhs);
         try self.jumpToGuardIfBitSet(rhs_scratch, 31, guard);
-        self.machine.bind(&nonzero_lhs);
+        try self.machine.bind(&nonzero_lhs);
 
         try self.machine.emit(a64.sdivW(result_scratch, lhs_scratch, rhs_scratch));
         try self.machine.emit(a64.smull(guard_scratch, result_scratch, rhs_scratch));
@@ -688,9 +688,9 @@ const Compiler = struct {
         try self.machine.emit(a64.fmovXtoD(fp, result_scratch));
         try self.machine.jump(&done);
 
-        self.machine.bind(&int32_value);
+        try self.machine.bind(&int32_value);
         try self.machine.emit(a64.scvtfDfromW(fp, value));
-        self.machine.bind(&done);
+        try self.machine.bind(&done);
     }
 
     fn emitInt32Input(
@@ -822,7 +822,7 @@ const Compiler = struct {
         ));
         try self.machine.jumpCbnz(.x9, &have_running_realm);
         try self.machine.emit(a64.movReg(.x9, lowering.realm_register));
-        self.machine.bind(&have_running_realm);
+        try self.machine.bind(&have_running_realm);
 
         try property_codegen.emitRealmU64(
             self.machine,
@@ -894,7 +894,7 @@ const Compiler = struct {
         ));
         try self.machine.jumpCbnz(lhs_scratch, &have_running_realm);
         try self.machine.emit(a64.movReg(lhs_scratch, lowering.realm_register));
-        self.machine.bind(&have_running_realm);
+        try self.machine.bind(&have_running_realm);
 
         try property_codegen.emitRealmU64(
             self.machine,
@@ -1024,7 +1024,7 @@ const Compiler = struct {
         const inverse: a64.Cond = @enumFromInt(@intFromEnum(condition) ^ 1);
         try self.machine.jumpCond(inverse, &passed);
         try self.machine.jump(guard);
-        self.machine.bind(&passed);
+        try self.machine.bind(&passed);
     }
 
     fn jumpToGuardIfNonzero(
@@ -1036,7 +1036,7 @@ const Compiler = struct {
         defer zero.deinit(self.allocator);
         try self.machine.jumpCbz(value, &zero);
         try self.machine.jump(guard);
-        self.machine.bind(&zero);
+        try self.machine.bind(&zero);
     }
 
     fn jumpToGuardIfBitSet(
@@ -1049,7 +1049,7 @@ const Compiler = struct {
         defer clear.deinit(self.allocator);
         try self.machine.jumpTbz(value, bit, &clear);
         try self.machine.jump(guard);
-        self.machine.bind(&clear);
+        try self.machine.bind(&clear);
     }
 
     fn emitReturn(self: *Compiler, node_id: ir.ValueId) !void {
@@ -1196,7 +1196,7 @@ const Compiler = struct {
                 try self.machine.jumpCbz(value, &fallthrough);
             }
             try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_taken));
-            self.machine.bind(&fallthrough);
+            try self.machine.bind(&fallthrough);
             return;
         }
         var taken: Masm.Label = .{};
@@ -1207,7 +1207,7 @@ const Compiler = struct {
             try self.machine.jumpCbnz(value, &taken);
         }
         try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_fallthrough));
-        self.machine.bind(&taken);
+        try self.machine.bind(&taken);
         try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_taken));
     }
 
@@ -1222,14 +1222,14 @@ const Compiler = struct {
             const inverse: a64.Cond = @enumFromInt(@intFromEnum(taken_condition) ^ 1);
             try self.machine.jumpCond(inverse, &fallthrough);
             try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_taken));
-            self.machine.bind(&fallthrough);
+            try self.machine.bind(&fallthrough);
             return;
         }
         var taken: Masm.Label = .{};
         defer taken.deinit(self.allocator);
         try self.machine.jumpCond(taken_condition, &taken);
         try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_fallthrough));
-        self.machine.bind(&taken);
+        try self.machine.bind(&taken);
         try self.emitEdgeAndJump(try self.edgeForKind(block_index, .branch_taken));
     }
 
@@ -1282,7 +1282,7 @@ const Compiler = struct {
                 &slow,
             );
             try self.machine.jump(&self.block_labels[target]);
-            self.machine.bind(&slow);
+            try self.machine.bind(&slow);
             try self.emitSafepointExit(target);
             return;
         }

--- a/src/runtime/ohaimark/compiler.zig
+++ b/src/runtime/ohaimark/compiler.zig
@@ -22,8 +22,9 @@ const lowering = @import("lowering_aarch64.zig");
 const representation = @import("representation.zig");
 const specialize = @import("specialize.zig");
 const stats_mod = @import("stats.zig");
+const policy = @import("policy.zig");
 
-pub const supported = masm.native_aarch64;
+pub const supported = policy.supported;
 
 /// Realm-facing entry for the runtime dispatcher. Keeping allocator lookup here
 /// makes unavailable executable memory a T2-local refusal like every other

--- a/src/runtime/ohaimark/policy.zig
+++ b/src/runtime/ohaimark/policy.zig
@@ -4,6 +4,14 @@
 //! strike limits without forming a module import cycle (bistromath cannot
 //! import driver.zig). Keep every shared number here.
 
+const builtin = @import("builtin");
+const code_alloc = @import("../jit/code_alloc.zig");
+
+/// Cycle-free target gate shared by T2 itself and T1's optional OSR probe.
+/// Keeping this here prevents an x86_64 T1 from yielding to an unavailable
+/// AArch64-only T2 backend.
+pub const supported = code_alloc.supported and builtin.cpu.arch == .aarch64;
+
 /// Starting T2 heat floor (docs/ohaimark.md §3.15). Full threshold is
 /// `tier_up_base + 32 * min(code_len, 1<<20)`.
 pub const tier_up_base: u32 = 8 * 1024;

--- a/src/runtime/ohaimark/property_codegen_aarch64.zig
+++ b/src/runtime/ohaimark/property_codegen_aarch64.zig
@@ -274,7 +274,7 @@ pub fn emitSlotRead(
     try machine.emit(a64.addReg(destination, destination, object));
     try machine.emit(a64.ldrImm(destination, destination, layout.object.inline_slots));
     try machine.jump(&done);
-    machine.bind(&overflow);
+    try machine.bind(&overflow);
     try machine.emit(a64.ldrImm(destination, object, layout.object.overflow_items_ptr));
     try machine.emit(a64.subImm(
         slot,
@@ -285,7 +285,7 @@ pub fn emitSlotRead(
     try machine.emit(a64.lslImm(slot, slot, 3));
     try machine.emit(a64.addReg(destination, destination, slot));
     try machine.emit(a64.ldrImm(destination, destination, 0));
-    machine.bind(&done);
+    try machine.bind(&done);
 }
 
 /// Load an aligned u64 field from a Realm-sized base, materializing the high
@@ -320,7 +320,7 @@ fn jumpToGuardIf(
     const inverse: a64.Cond = @enumFromInt(@intFromEnum(condition) ^ 1);
     try machine.jumpCond(inverse, &passed);
     try machine.jump(guard);
-    machine.bind(&passed);
+    try machine.bind(&passed);
 }
 
 fn jumpToGuardIfNonzero(
@@ -333,5 +333,5 @@ fn jumpToGuardIfNonzero(
     defer zero.deinit(allocator);
     try machine.jumpCbz(value, &zero);
     try machine.jump(guard);
-    machine.bind(&zero);
+    try machine.bind(&zero);
 }

--- a/src/runtime/wasm/spasm.zig
+++ b/src/runtime/wasm/spasm.zig
@@ -84,7 +84,13 @@ pub const trap_invalid_conversion: u32 = 4;
 /// the channel having to enumerate each variant.
 pub const trap_pending: u32 = 5;
 
-pub const CompileError = error{ OutOfMemory, UnsupportedOp };
+pub const CompileError = error{
+    OutOfMemory,
+    UnsupportedOp,
+    LabelAlreadyBound,
+    InvalidLabel,
+    BranchOutOfRange,
+};
 
 /// The native call helper a compiled `call` (§5.4.1) branches to:
 /// `(instance, func_index, buf) -> status`. It marshals the args staged
@@ -890,7 +896,7 @@ pub fn compile(
                 try m.jumpCbz(.x0, &get_ok);
                 try m.emit(a64.addSpImm(framebytes));
                 try m.jump(&epilogue);
-                m.bind(&get_ok);
+                try m.bind(&get_ok);
 
                 // Success: the helper has written the ref into its depth-keyed
                 // cell. Recompute x6 from SP (AAPCS64 callee-restores SP;
@@ -1010,7 +1016,7 @@ pub fn compile(
                 try m.jumpCbz(.x0, &set_ok);
                 try m.emit(a64.addSpImm(framebytes));
                 try m.jump(&epilogue);
-                m.bind(&set_ok);
+                try m.bind(&set_ok);
 
                 // Success: recompute x6 from SP (AAPCS64 callee-restores SP;
                 // nothing moved it since the reserve), reload the boundary
@@ -1434,7 +1440,7 @@ pub fn compile(
                     try m.emit(a64.cmpRegW(ra, .x16));
                     try m.jumpCond(.eq, &trap_overflow);
                     trap_overflow_used = true;
-                    m.bind(&skip);
+                    try m.bind(&skip);
                 }
 
                 switch (op) {
@@ -1630,7 +1636,7 @@ pub fn compile(
                     try m.emit(a64.cmpReg(ra, .x16));
                     try m.jumpCond(.eq, &trap_overflow);
                     trap_overflow_used = true;
-                    m.bind(&skip);
+                    try m.bind(&skip);
                 }
 
                 switch (op) {
@@ -2161,13 +2167,13 @@ pub fn compile(
                     var fill_done: masm_mod.Masm.Label = .{};
                     defer fill_loop.deinit(gpa);
                     defer fill_done.deinit(gpa);
-                    m.bind(&fill_loop);
+                    try m.bind(&fill_loop);
                     try m.jumpCbz(r_n, &fill_done);
                     try m.emit(a64.strbRegW(r_val, .x2, r_dst));
                     try m.emit(a64.addImm(r_dst, r_dst, 1, false));
                     try m.emit(a64.subImm(r_n, r_n, 1, false));
                     try m.jump(&fill_loop);
-                    m.bind(&fill_done);
+                    try m.bind(&fill_done);
                     sp -= 3;
                 } else if (sub == 10) {
                     // §4.4.7 memory.copy — move n bytes from src to dst
@@ -2206,7 +2212,7 @@ pub fn compile(
                     // backward: start past the end and walk down.
                     try m.emit(a64.addReg(r_dst, r_dst, r_n));
                     try m.emit(a64.addReg(r_src, r_src, r_n));
-                    m.bind(&bwd_loop);
+                    try m.bind(&bwd_loop);
                     try m.jumpCbz(r_n, &copy_done);
                     try m.emit(a64.subImm(r_dst, r_dst, 1, false));
                     try m.emit(a64.subImm(r_src, r_src, 1, false));
@@ -2214,7 +2220,7 @@ pub fn compile(
                     try m.emit(a64.strbRegW(.x16, .x2, r_dst));
                     try m.emit(a64.subImm(r_n, r_n, 1, false));
                     try m.jump(&bwd_loop);
-                    m.bind(&fwd_loop);
+                    try m.bind(&fwd_loop);
                     try m.jumpCbz(r_n, &copy_done);
                     try m.emit(a64.ldrbRegW(.x16, .x2, r_src));
                     try m.emit(a64.strbRegW(.x16, .x2, r_dst));
@@ -2222,7 +2228,7 @@ pub fn compile(
                     try m.emit(a64.addImm(r_dst, r_dst, 1, false));
                     try m.emit(a64.subImm(r_n, r_n, 1, false));
                     try m.jump(&fwd_loop);
-                    m.bind(&copy_done);
+                    try m.bind(&copy_done);
                     sp -= 3;
                 } else if (sub == 8) {
                     // §4.4.7 memory.init — copy `len` bytes from passive data
@@ -2303,7 +2309,7 @@ pub fn compile(
                     try m.jumpCbz(.x0, &init_ok);
                     try m.emit(a64.addSpImm(framebytes));
                     try m.jump(&epilogue);
-                    m.bind(&init_ok);
+                    try m.bind(&init_ok);
 
                     // Success: recompute x6 from SP (AAPCS64 callee-restores SP;
                     // nothing moved it since the reserve), reload the boundary
@@ -2521,7 +2527,7 @@ pub fn compile(
                     try m.jumpCbz(.x0, &copy_ok);
                     try m.emit(a64.addSpImm(framebytes));
                     try m.jump(&epilogue);
-                    m.bind(&copy_ok);
+                    try m.bind(&copy_ok);
 
                     try m.emit(a64.addRegSp(.x6, 0));
                     try m.emit(a64.ldrImm(.x0, .x6, spill_off));
@@ -2598,7 +2604,7 @@ pub fn compile(
                     try m.jumpCbz(.x0, &init_ok);
                     try m.emit(a64.addSpImm(framebytes));
                     try m.jump(&epilogue);
-                    m.bind(&init_ok);
+                    try m.bind(&init_ok);
 
                     try m.emit(a64.addRegSp(.x6, 0));
                     try m.emit(a64.ldrImm(.x0, .x6, spill_off));
@@ -2853,7 +2859,7 @@ pub fn compile(
                     try m.jumpCbz(.x0, &fill_ok);
                     try m.emit(a64.addSpImm(framebytes));
                     try m.jump(&epilogue);
-                    m.bind(&fill_ok);
+                    try m.bind(&fill_ok);
 
                     try m.emit(a64.addRegSp(.x6, 0));
                     try m.emit(a64.ldrImm(.x0, .x6, spill_off));
@@ -3001,7 +3007,7 @@ pub fn compile(
                 const arity = readBlockArity(body, &i) orelse return null;
                 if (ctrl_len >= max_ctrl_depth) return null;
                 ctrl[ctrl_len] = .{ .label = .{}, .else_label = .{}, .height = sp, .branch_arity = 0, .result_arity = arity, .kind = .loop };
-                m.bind(&ctrl[ctrl_len].label);
+                try m.bind(&ctrl[ctrl_len].label);
                 ctrl_len += 1;
             },
             op_if => {
@@ -3032,7 +3038,7 @@ pub fn compile(
                     stack[d] = .{ .reg = r };
                 }
                 try m.jump(&c.label);
-                m.bind(&c.else_label);
+                try m.bind(&c.else_label);
                 c.kind = .if_else;
                 sp = c.height; // the else-arm starts with a fresh stack
             },
@@ -3069,7 +3075,7 @@ pub fn compile(
                 // result type for the continuation — those result values
                 // were placed in the canonical registers by whatever
                 // branch reaches the merge.
-                if (cur.kind == .block) m.bind(&cur.label);
+                if (cur.kind == .block) try m.bind(&cur.label);
                 cur.label.deinit(gpa);
                 cur.else_label.deinit(gpa); // `.empty` for block/loop — safe
                 sp = cur.height + cur.result_arity;
@@ -3145,7 +3151,7 @@ pub fn compile(
                 const cur = &ctrl[ctrl_len - 1];
                 if (cur.kind == .if_then or cur.kind == .if_else) return null;
                 skipToFrameEnd(body, &i) orelse return null;
-                if (cur.kind == .block) m.bind(&cur.label);
+                if (cur.kind == .block) try m.bind(&cur.label);
                 cur.label.deinit(gpa);
                 cur.else_label.deinit(gpa);
                 sp = cur.height + cur.result_arity;
@@ -3271,7 +3277,7 @@ pub fn compile(
                 try m.jumpCbz(.x0, &call_ok); // status == 0 -> success
                 try m.emit(a64.addSpImm(framebytes)); // release buffer
                 try m.jump(&epilogue); // propagate w0 (the status)
-                m.bind(&call_ok);
+                try m.bind(&call_ok);
 
                 // Success. x6 is caller-saved, so the helper may have
                 // clobbered it — but AAPCS64 guarantees SP is callee-
@@ -3394,7 +3400,7 @@ pub fn compile(
                 try m.jumpCbz(.x0, &call_ok);
                 try m.emit(a64.addSpImm(framebytes));
                 try m.jump(&epilogue);
-                m.bind(&call_ok);
+                try m.bind(&call_ok);
 
                 // Success: recompute x6 from SP, reload results above the
                 // survivors, restore the boundary registers and survivors,
@@ -3445,14 +3451,14 @@ pub fn compile(
                     // bind it here. A `loop`'s label was already bound at
                     // its header (no back-edge fixups: a back-edge jumps
                     // to an already-bound label).
-                    .block, .if_else => m.bind(&c.label),
+                    .block, .if_else => try m.bind(&c.label),
                     .loop => {},
                     // An `if` with no `else`: a false condition jumped to
                     // the else label, which lands straight at the `end`
                     // alongside the then-arm's fall-through.
                     .if_then => {
-                        m.bind(&c.label);
-                        m.bind(&c.else_label);
+                        try m.bind(&c.label);
+                        try m.bind(&c.else_label);
                     },
                 }
                 c.label.deinit(gpa);
@@ -3516,7 +3522,7 @@ pub fn compile(
     // the frame teardown (the non-leaf prologue's pop) is emitted once.
     // The normal return falls in; each trap exit jumps in after loading
     // its status. Pop x19 + the link register, then `ret`.
-    m.bind(&epilogue);
+    try m.bind(&epilogue);
     try m.emit(a64.ldpPostIdxSp(.x19, .lr, 16));
     try m.emit(a64.ret());
 
@@ -3525,22 +3531,22 @@ pub fn compile(
     // (which restores the frame), writing no result (the caller raises
     // the matching TrapError and ignores x1).
     if (trap_div0_used) {
-        m.bind(&trap_div0);
+        try m.bind(&trap_div0);
         try m.movImm64(.x0, trap_divide_by_zero);
         try m.jump(&epilogue);
     }
     if (trap_overflow_used) {
-        m.bind(&trap_overflow);
+        try m.bind(&trap_overflow);
         try m.movImm64(.x0, trap_int_overflow);
         try m.jump(&epilogue);
     }
     if (trap_oob_used) {
-        m.bind(&trap_oob);
+        try m.bind(&trap_oob);
         try m.movImm64(.x0, trap_out_of_bounds);
         try m.jump(&epilogue);
     }
     if (trap_invalid_used) {
-        m.bind(&trap_invalid);
+        try m.bind(&trap_invalid);
         try m.movImm64(.x0, trap_invalid_conversion);
         try m.jump(&epilogue);
     }

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -89,6 +89,10 @@
 //!
 //! Tier differentials:
 //!   --jit                   Force Bistromath T1 at threshold 1.
+//!   --require-bistromath-entry
+//!                           Fail with exit code 2 unless the sweep actually
+//!                           crosses at least one generated T1 entry. Requires
+//!                           `--jit`; works with the worker pool.
 //!   --ohaimark              Force Ohaimark T2 before T1, both at threshold 1.
 //!                           Production CLI T2 remains at its natural threshold.
 //!   --ohaimark-osr          Also enable default-off loop-header OSR (requires
@@ -424,6 +428,9 @@ const max_agents = 16;
 /// surface; the realm it runs in is the worker's, never touched here.
 const AgentThreadState = struct {
     group: *AgentGroup,
+    /// Sweep-wide native-entry witness inherited from the parent fixture.
+    /// `reapAgents` guarantees the sink outlives this task.
+    bistromath_entries: ?*std.atomic.Value(u64) = null,
     /// parent → agent: the broadcast block (set by `$262.agent.broadcast`).
     bcast: std.atomic.Value(?*AgentSDB) = std.atomic.Value(?*AgentSDB).init(null),
     /// owned copy of the agent source (page_allocator). The compiled
@@ -469,7 +476,7 @@ threadlocal var reap_group: ?*AgentGroup = null;
 /// worker lives on, reset, for the next task); a private fallback
 /// thread is joined. The agent's source stays owned by its runner
 /// (the pool worker, or the private thread) — never freed here.
-fn reapAgents(group: *AgentGroup) void {
+fn drainAgentGroup(group: *AgentGroup, reusable: bool) void {
     group.should_exit.store(true, .release);
     for (group.states[0..group.count]) |maybe| {
         if (maybe) |st| {
@@ -482,7 +489,15 @@ fn reapAgents(group: *AgentGroup) void {
             std.heap.page_allocator.destroy(st);
         }
     }
+    group.states = @splat(null);
+    group.count = 0;
     for (group.reports.items) |m| std.heap.page_allocator.free(m);
+    group.reports.clearRetainingCapacity();
+    if (reusable) group.should_exit.store(false, .release);
+}
+
+fn reapAgents(group: *AgentGroup) void {
+    drainAgentGroup(group, false);
     group.reports.deinit(std.heap.page_allocator);
     std.heap.page_allocator.destroy(group);
 }
@@ -762,8 +777,19 @@ fn poolWorkerMain(slot: *PoolWorker) void {
         // Take ownership of the source for this realm's lifetime.
         owned_srcs.append(realm.allocator, state.src) catch {};
         current_agent = state;
+        realm.heap.bistromath_stats = .{
+            .enabled = state.bistromath_entries != null,
+            .shared_entries = state.bistromath_entries,
+        };
         runAgentTask(&realm, state);
         resetRealm(&realm, &snapshot, &scratch);
+        // This agent realm may itself have called `$262.agent.start`.
+        // Realm reset drains pending microtasks, which can start another
+        // agent, so drain the reusable group only after reset and before
+        // publishing `state.done`. Otherwise a nested task could retain the
+        // parent sweep's witness pointer after its stack-owned atomic returns.
+        if (own_group) |group| drainAgentGroup(group, true);
+        realm.heap.bistromath_stats = .{};
         current_agent = null;
         // Signal completion (so `reapAgents` can free the task), THEN
         // release the slot for reuse. After `done` the task may be freed,
@@ -778,6 +804,10 @@ fn poolWorkerMain(slot: *PoolWorker) void {
 /// concurrency, so its create/destroy cost doesn't matter.
 fn agentMainPrivate(state: *AgentThreadState) void {
     var realm = cynic.runtime.Realm.init(std.heap.c_allocator);
+    realm.heap.bistromath_stats = .{
+        .enabled = state.bistromath_entries != null,
+        .shared_entries = state.bistromath_entries,
+    };
     realm.hardened = false;
     realm.allow_eval = true;
     configureForcedJit(&realm);
@@ -808,7 +838,6 @@ fn agentMainPrivate(state: *AgentThreadState) void {
 }
 
 fn agentStart(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const AgentVal) cynic.runtime.function.NativeError!AgentVal {
-    _ = realm;
     const group = agentGroupOf(this_value) orelse return AgentVal.undefined_;
     if (args.len == 0 or !args[0].isString()) return AgentVal.undefined_;
     const s: *cynic.runtime.JSString = @ptrCast(@alignCast(args[0].asString()));
@@ -817,7 +846,11 @@ fn agentStart(realm: *cynic.runtime.Realm, this_value: AgentVal, args: []const A
         std.heap.page_allocator.free(src_copy);
         return error.OutOfMemory;
     };
-    state.* = .{ .group = group, .src = src_copy };
+    state.* = .{
+        .group = group,
+        .bistromath_entries = realm.heap.bistromath_stats.shared_entries,
+        .src = src_copy,
+    };
 
     // Register the task with the fixture's group (under the lock) so
     // `reapAgents` waits on it, BEFORE dispatching it to run.
@@ -1031,6 +1064,26 @@ fn evalAgentInt(realm: *cynic.runtime.Realm, src: []const u8) ?i32 {
         .value, .yielded => |v| if (v.isInt32()) v.asInt32() else if (v.isDouble()) @intFromFloat(v.asDouble()) else null,
         .thrown => null,
     };
+}
+
+test "agent pool: reusable nested-agent groups drain between tasks" {
+    var group: AgentGroup = .{};
+    defer group.reports.deinit(std.heap.page_allocator);
+
+    const report = try std.heap.page_allocator.dupe(u8, "nested");
+    try group.reports.append(std.heap.page_allocator, report);
+    drainAgentGroup(&group, true);
+
+    try std.testing.expectEqual(@as(usize, 0), group.count);
+    try std.testing.expectEqual(@as(usize, 0), group.reports.items.len);
+    try std.testing.expect(!group.should_exit.load(.acquire));
+
+    // The same host object remains valid for the next pooled task.
+    const next_report = try std.heap.page_allocator.dupe(u8, "next");
+    try group.reports.append(std.heap.page_allocator, next_report);
+    drainAgentGroup(&group, true);
+    try std.testing.expectEqual(@as(usize, 0), group.reports.items.len);
+    try std.testing.expect(!group.should_exit.load(.acquire));
 }
 
 test "agent realm reset: a reused realm isolates one agent from the next" {
@@ -1303,6 +1356,10 @@ const Options = struct {
     /// finding leaks or oversized roots; pair with `--filter`
     /// to keep the output sane.
     gc_stats: bool = false,
+    /// Fail closed unless the main sweep actually crosses at least one
+    /// published Bistromath entry. `--jit` alone only forces the tier-up
+    /// threshold and cannot prove dispatch reached generated code.
+    require_bistromath_entry: bool = false,
     /// Aggregate opt-in Ohaimark counters and refusal histograms across
     /// fixture heaps and worker threads, then print one rollout summary after
     /// the main phase. Requires `--ohaimark`; unlike memory diagnostics this
@@ -2096,6 +2153,7 @@ fn runSweep(
         gc_time_list.deinit(gpa);
     }
     var mem_agg: MemAggregate = .{};
+    var bistromath_entries = std.atomic.Value(u64).init(0);
     var ohaimark_agg: OhaimarkStats = .{};
 
     // `--only-failing` shortcut: only the main phase consults the
@@ -2225,6 +2283,7 @@ fn runSweep(
                 opts.gc_threshold,
                 opts.gc_stats,
                 if (need_mem) &fx_mem else null,
+                if (opts.require_bistromath_entry) &bistromath_entries else null,
                 if (opts.ohaimark_stats) &fx_ohaimark else null,
                 phase,
             );
@@ -2282,6 +2341,7 @@ fn runSweep(
     } else {
         // Parallel path.
         var index: std.atomic.Value(usize) = .init(0);
+        var worker_failed: std.atomic.Value(bool) = .init(false);
         var merge_mu: std.Io.Mutex = .init;
 
         const current_paths = try gpa.alloc(std.atomic.Value(usize), thread_count);
@@ -2318,6 +2378,8 @@ fn runSweep(
                 .global_slow = &slow,
                 .global_heavy = &heavy,
                 .global_ohaimark = &ohaimark_agg,
+                .bistromath_entries = if (opts.require_bistromath_entry) &bistromath_entries else null,
+                .worker_failed = &worker_failed,
                 .is_full_run = is_full_run,
                 .phase = phase,
                 .worker_id = wid,
@@ -2348,6 +2410,21 @@ fn runSweep(
 
         monitor_done.store(true, .release);
         monitor_thread.join();
+
+        // A differential artifact is valid only if every worker completed.
+        // The ordinary harness historically treated a worker-local OOM/IO
+        // failure as best-effort, but silently omitting a fixture can make two
+        // pass lists compare equal. Fail closed for explicit pass-list or
+        // generated-entry evidence.
+        if ((opts.pass_list_out != null or opts.require_bistromath_entry) and
+            worker_failed.load(.acquire))
+        {
+            std.debug.print(
+                "test262: worker failed before completing the sweep; refusing differential evidence\n",
+                .{},
+            );
+            std.process.exit(2);
+        }
     }
 
     const elapsed = start_ts.untilNow(io, .awake).toMilliseconds();
@@ -2396,6 +2473,20 @@ fn runSweep(
         }
         if (opts.ohaimark_stats) {
             try printOhaimarkSummary(io, &ohaimark_agg);
+        }
+        if (opts.require_bistromath_entry) {
+            const executed_entries = bistromath_entries.load(.acquire);
+            std.debug.print(
+                "Bistromath generated entries executed: {d}\n",
+                .{executed_entries},
+            );
+            if (executed_entries == 0) {
+                std.debug.print(
+                    "test262: --require-bistromath-entry failed — no generated T1 entry executed\n",
+                    .{},
+                );
+                std.process.exit(2);
+            }
         }
     }
 
@@ -2672,6 +2763,12 @@ const WorkerCtx = struct {
     global_slow: *std.ArrayListUnmanaged(SlowEntry),
     global_heavy: *std.ArrayListUnmanaged(HeavyEntry),
     global_ohaimark: *OhaimarkStats,
+    /// Sweep-wide cross-heap T1 witness. Agent realms receive this same sink
+    /// through `AgentThreadState`.
+    bistromath_entries: ?*std.atomic.Value(u64),
+    /// Set when `workerLoop` returns a fatal error instead of draining its
+    /// assigned paths. Differential evidence refuses such a partial sweep.
+    worker_failed: *std.atomic.Value(bool),
     is_full_run: bool,
     /// Sweep phase selector. Forwarded to `classifyAndRun` so each
     /// worker filters fixtures the same way the orchestrator picked.
@@ -2731,19 +2828,25 @@ fn worker(ctx: WorkerCtx) void {
     var local_ohaimark: OhaimarkStats = .{};
 
     workerLoop(ctx, &local_arena, &local_stats, &local_buckets, &local_failures, &local_pass_paths, &local_slow, &local_heavy, &local_ohaimark) catch {
-        // Best-effort: skip merging silently on OOM / IO blow-up.
-        // The rolled-up totals will be slightly low, but the run
-        // doesn't deadlock and the surviving workers still merge.
+        // Let surviving workers finish and merge, but remember that this
+        // worker did not drain its paths. Explicit differential evidence
+        // fails closed after the joins instead of accepting partial totals.
+        ctx.worker_failed.store(true, .release);
     };
 
     ctx.merge_mu.lockUncancelable(ctx.io);
     defer ctx.merge_mu.unlock(ctx.io);
     mergeStats(ctx.global_stats, &local_stats);
-    mergeBuckets(ctx.global_buckets, &local_buckets) catch {};
-    ctx.global_failures.appendSlice(ctx.gpa, local_failures.items) catch {};
-    ctx.global_pass_paths.appendSlice(ctx.gpa, local_pass_paths.items) catch {};
-    ctx.global_slow.appendSlice(ctx.gpa, local_slow.items) catch {};
-    ctx.global_heavy.appendSlice(ctx.gpa, local_heavy.items) catch {};
+    mergeBuckets(ctx.global_buckets, &local_buckets) catch
+        ctx.worker_failed.store(true, .release);
+    ctx.global_failures.appendSlice(ctx.gpa, local_failures.items) catch
+        ctx.worker_failed.store(true, .release);
+    ctx.global_pass_paths.appendSlice(ctx.gpa, local_pass_paths.items) catch
+        ctx.worker_failed.store(true, .release);
+    ctx.global_slow.appendSlice(ctx.gpa, local_slow.items) catch
+        ctx.worker_failed.store(true, .release);
+    ctx.global_heavy.appendSlice(ctx.gpa, local_heavy.items) catch
+        ctx.worker_failed.store(true, .release);
     ctx.global_ohaimark.merge(local_ohaimark);
 
     // The merged-out arrays own their inner strings; we transferred
@@ -2815,6 +2918,7 @@ fn workerLoop(
             ctx.opts.gc_threshold,
             ctx.opts.gc_stats,
             null,
+            ctx.bistromath_entries,
             if (ctx.opts.ohaimark_stats) &fx_ohaimark else null,
             ctx.phase,
         ) catch |err| {
@@ -2889,6 +2993,7 @@ fn classifyAndRun(
     gc_threshold: u32,
     gc_stats: bool,
     mem_out: ?*FixtureMem,
+    bistromath_entries: ?*std.atomic.Value(u64),
     ohaimark_out: ?*OhaimarkStats,
     phase: Phase,
 ) !RunResult {
@@ -2902,6 +3007,7 @@ fn classifyAndRun(
         gc_threshold,
         gc_stats,
         mem_out,
+        bistromath_entries,
         ohaimark_out,
         phase,
     );
@@ -2934,6 +3040,10 @@ fn classifyAndRunInner(
     /// Optional out-param. Filled with the fixture's heap counters
     /// via a `defer` so every return point is covered.
     mem_out: ?*FixtureMem,
+    /// Optional sweep-wide T1 native-entry witness. Child realms share this
+    /// heap; independent agent realms receive the same atomic through their
+    /// task state.
+    bistromath_entries: ?*std.atomic.Value(u64),
     /// Optional T2 telemetry snapshot. A non-null pointer enables collection
     /// for this heap; child realms share it. Independent agent heaps are not
     /// included in the fixture-local snapshot.
@@ -3067,6 +3177,8 @@ fn classifyAndRunInner(
 
     var realm = cynic.runtime.Realm.initWithBytesAllocator(std.heap.c_allocator, bytes_allocator);
     defer realm.deinit();
+    realm.heap.bistromath_stats.enabled = bistromath_entries != null;
+    realm.heap.bistromath_stats.shared_entries = bistromath_entries;
     realm.heap.ohaimark_stats.enabled = ohaimark_out != null;
     // Wire the watchdog through the metering interrupt hook
     // (docs/resource-metering.md): past `--timeout`, `monitorLoop`
@@ -4872,6 +4984,8 @@ fn parseArgs(gpa: std.mem.Allocator, args: std.process.Args) !Options {
             opts.timeout_s = std.fmt.parseInt(u32, arg["--timeout=".len..], 10) catch 60;
         } else if (std.mem.eql(u8, arg, "--jit")) {
             g_jit_force = true;
+        } else if (std.mem.eql(u8, arg, "--require-bistromath-entry")) {
+            opts.require_bistromath_entry = true;
         } else if (std.mem.eql(u8, arg, "--ohaimark")) {
             g_ohaimark_force = true;
         } else if (std.mem.eql(u8, arg, "--ohaimark-osr")) {
@@ -4922,6 +5036,22 @@ fn parseArgs(gpa: std.mem.Allocator, args: std.process.Args) !Options {
 
     opts.exclude = try exclude_list.toOwnedSlice(gpa);
 
+    if (opts.require_bistromath_entry and !g_jit_force) {
+        std.debug.print("error: --require-bistromath-entry requires --jit\n", .{});
+        std.process.exit(1);
+    }
+    if (opts.require_bistromath_entry) {
+        if (opts.phase) |phase| switch (phase) {
+            .main => {},
+            .feature => {
+                std.debug.print(
+                    "error: --require-bistromath-entry requires a main-phase sweep\n",
+                    .{},
+                );
+                std.process.exit(1);
+            },
+        };
+    }
     if (opts.ohaimark_stats and !g_ohaimark_force) {
         std.debug.print("error: --ohaimark-stats requires --ohaimark\n", .{});
         std.process.exit(1);

--- a/tools/test262.zig
+++ b/tools/test262.zig
@@ -124,6 +124,7 @@
 const std = @import("std");
 const cynic = @import("cynic");
 const Op = cynic.bytecode.Op;
+const BistromathEntryCounter = cynic.runtime.BistromathEntryCounter;
 const OhaimarkStats = cynic.runtime.OhaimarkStats;
 
 const frontmatter = @import("test262/frontmatter.zig");
@@ -430,7 +431,7 @@ const AgentThreadState = struct {
     group: *AgentGroup,
     /// Sweep-wide native-entry witness inherited from the parent fixture.
     /// `reapAgents` guarantees the sink outlives this task.
-    bistromath_entries: ?*std.atomic.Value(u64) = null,
+    bistromath_entries: ?*BistromathEntryCounter = null,
     /// parent → agent: the broadcast block (set by `$262.agent.broadcast`).
     bcast: std.atomic.Value(?*AgentSDB) = std.atomic.Value(?*AgentSDB).init(null),
     /// owned copy of the agent source (page_allocator). The compiled
@@ -2153,7 +2154,7 @@ fn runSweep(
         gc_time_list.deinit(gpa);
     }
     var mem_agg: MemAggregate = .{};
-    var bistromath_entries = std.atomic.Value(u64).init(0);
+    var bistromath_entries = BistromathEntryCounter.init(0);
     var ohaimark_agg: OhaimarkStats = .{};
 
     // `--only-failing` shortcut: only the main phase consults the
@@ -2765,7 +2766,7 @@ const WorkerCtx = struct {
     global_ohaimark: *OhaimarkStats,
     /// Sweep-wide cross-heap T1 witness. Agent realms receive this same sink
     /// through `AgentThreadState`.
-    bistromath_entries: ?*std.atomic.Value(u64),
+    bistromath_entries: ?*BistromathEntryCounter,
     /// Set when `workerLoop` returns a fatal error instead of draining its
     /// assigned paths. Differential evidence refuses such a partial sweep.
     worker_failed: *std.atomic.Value(bool),
@@ -2993,7 +2994,7 @@ fn classifyAndRun(
     gc_threshold: u32,
     gc_stats: bool,
     mem_out: ?*FixtureMem,
-    bistromath_entries: ?*std.atomic.Value(u64),
+    bistromath_entries: ?*BistromathEntryCounter,
     ohaimark_out: ?*OhaimarkStats,
     phase: Phase,
 ) !RunResult {
@@ -3043,7 +3044,7 @@ fn classifyAndRunInner(
     /// Optional sweep-wide T1 native-entry witness. Child realms share this
     /// heap; independent agent realms receive the same atomic through their
     /// task state.
-    bistromath_entries: ?*std.atomic.Value(u64),
+    bistromath_entries: ?*BistromathEntryCounter,
     /// Optional T2 telemetry snapshot. A non-null pointer enables collection
     /// for this heap; child realms share it. Independent agent heaps are not
     /// included in the fixture-local snapshot.


### PR DESCRIPTION
## What changed

- Add an x86_64 instruction encoder and a target-neutral Bistromath MacroAssembler with the SysV ABI calling convention.
- Keep the shared one-pass Bistromath compiler while preserving safe Lantern fallback for unsupported operations, allocation failures, and unsupported hosts.
- Make shared AArch64 label patching fallible, transactional, and range-checked; update Ohaimark and Spasm call sites without changing their architecture support.
- Add native x86_64 ABI, semantics, exception, OOM, GC-pressure, encoder, and MacroAssembler safety tests.
- Add `--require-bistromath-entry`, backed by a shared atomic execution witness, so differential runs fail closed unless generated T1 code actually executes.
- Gate native x86_64 Linux and AArch64 macOS with exact interpreter-versus-Bistromath test262 pass-set comparisons.
- Update the repository support matrix and JIT documentation. Ohaimark T2 and Spasm remain AArch64-only.

## Why

Bistromath previously had only an AArch64 emitter. On x86_64 the compiler therefore refused native installation and correctly fell back to Lantern, which is why the public support matrix listed AArch64 alone. This adds and qualifies the missing x86_64 T1 backend without weakening fallback or host-safety behavior.

## Validation

- `zig build test-fast -Dtest-filter="Bistromath x86_64"`
- `zig build test-fast -Dtest-filter="jit asm_x86_64"`
- `zig build test-fast -Dtest-filter="jit masm"`
- Full interpreter versus forced-Bistromath test262 qualification: identical 48,517-fixture pass sets; the JIT run recorded 2,455,587 generated-code entries.
- Negative controls confirm the execution witness fails for parse-only, missing-`--jit`, and feature-only runs.
- Production cross-builds passed for `x86_64-linux-musl` and `aarch64-linux-musl`.
- `zig fmt --check` on all touched Zig files.
- `actionlint .github/workflows/ci.yml` and Ruby YAML parsing.
- `git diff --check`.

The separate website edit remains unpublished until this PR's native differential CI is green and the implementation is merged.
