### PR TITLE
jit: add x86_64 Spasm backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         run: zig build wasm
 
   wasm-testsuite:
-    name: WASM spec testsuite (Sarcasm)
+    name: WASM spec testsuite (Sarcasm + x86_64 Spasm)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     needs: build-and-test
@@ -280,15 +280,21 @@ jobs:
           zig build wasm-testsuite -Dwasm-corpus=vendor/wasm-testsuite -- \
             --quiet --min-pass-pct=100
 
+      - name: Score the spec testsuite through x86_64 Spasm (gating)
+        timeout-minutes: 12
+        run: |
+          zig build wasm-testsuite -Dwasm-corpus=vendor/wasm-testsuite -- \
+            --quiet --spasm --min-pass-pct=100
+
   wasm-testsuite-spasm:
     name: WASM spec testsuite (Spasm, AArch64)
     runs-on: macos-latest
     timeout-minutes: 25
     needs: build-and-test
-    # Spasm emits AArch64 machine code, so the Ubuntu Sarcasm gate above
-    # cannot exercise it. Force the tier over the same full corpus and keep
-    # the 100%-of-scored-commands floor: compilable functions run native and
-    # unsupported functions must degrade to Sarcasm without changing results.
+    # Force the mature AArch64 backend over the same full corpus and keep the
+    # 100%-of-scored-commands floor on both qualified architectures:
+    # compilable functions run native and unsupported functions must degrade
+    # to Sarcasm without changing results.
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,7 +284,7 @@ jobs:
         timeout-minutes: 12
         run: |
           zig build wasm-testsuite -Dwasm-corpus=vendor/wasm-testsuite -- \
-            --quiet --spasm --min-pass-pct=100
+            --quiet --spasm --require-spasm-entry --min-pass-pct=100
 
   wasm-testsuite-spasm:
     name: WASM spec testsuite (Spasm, AArch64)
@@ -292,9 +292,9 @@ jobs:
     timeout-minutes: 25
     needs: build-and-test
     # Force the mature AArch64 backend over the same full corpus and keep the
-    # 100%-of-scored-commands floor on both qualified architectures:
-    # compilable functions run native and unsupported functions must degrade
-    # to Sarcasm without changing results.
+    # 100%-of-scored-commands floor on both qualified architectures. The
+    # native-entry witness prevents an all-Sarcasm fallback from satisfying
+    # the differential gate.
     steps:
       - name: Audit egress (advisory)
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2
@@ -319,7 +319,7 @@ jobs:
         timeout-minutes: 15
         run: |
           zig build wasm-testsuite -Dwasm-corpus=vendor/wasm-testsuite -- \
-            --quiet --spasm --min-pass-pct=100
+            --quiet --spasm --require-spasm-entry --min-pass-pct=100
 
   cross-build:
     name: Cross-build (${{ matrix.target }})

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2292,8 +2292,14 @@ and the per-builtin checklist; this section tracks status.
   helper-free local link for eligible self-recursion), the table/reference
   family, the first SIMD data path, and Realm fuel/interrupt safe points at
   native entry plus taken structured-loop backedges ship and are default-on
-  for wasm. Remaining SIMD lane operations and the native-register /
-  imported-call ABI remain next.
+  for wasm. A qualified SysV x86_64 backend now covers the helper-free i32
+  scalar/control core, explicit div/overflow/stack traps, entry/backedge
+  execution polls, guarded self-links, and W^X-safe stable cross-function
+  gates. Unsupported x86 functions refuse transactionally and stay in
+  Sarcasm; the forced-tier spec sweep is exact at 58,779/58,779 on both
+  x86_64 and AArch64. Remaining x86 scalar/memory/SIMD parity, remaining SIMD
+  lane operations generally, and the native-register/imported-call ABI remain
+  next.
 
   The architecture for all three tiers — the shared codegen
   substrate and the JS↔wasm call-boundary fast path included — is

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2297,9 +2297,11 @@ and the per-builtin checklist; this section tracks status.
   execution polls, guarded self-links, and W^X-safe stable cross-function
   gates. Unsupported x86 functions refuse transactionally and stay in
   Sarcasm; the forced-tier spec sweep is exact at 58,779/58,779 on both
-  x86_64 and AArch64. Remaining x86 scalar/memory/SIMD parity, remaining SIMD
-  lane operations generally, and the native-register/imported-call ABI remain
-  next.
+  x86_64 and AArch64. The forced sweep is fail-closed on native engagement via
+  `--require-spasm-entry`, and the shared instance/cache, recursive stack,
+  cold-gate fallback, and post-entry interrupt tests now execute on both
+  architectures. Remaining x86 scalar/memory/SIMD parity, remaining SIMD lane
+  operations generally, and the native-register/imported-call ABI remain next.
 
   The architecture for all three tiers — the shared codegen
   substrate and the JS↔wasm call-boundary fast path included — is

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -1297,8 +1297,10 @@ useful:
    `.wast` files, 1232 skip) produces the interpreter's exact pass-set —
    the §10-analog authoritative correctness gate, reproduced with
    `zig build wasm-testsuite -Dwasm-corpus=vendor/wasm-testsuite --
-   --quiet [--spasm]` (the harness `--spasm` flag forces the per-instance
-   gate on for every loaded module). The **per-function code cache**
+   --quiet --spasm --require-spasm-entry` (the harness `--spasm` flag forces
+   the per-instance gate on for every loaded module, while
+   `--require-spasm-entry` fails if fallback alone produced the pass set).
+   The **per-function code cache**
    now ships (`spasmEntryFor`): each emittable function compiles once on
    its first Spasm-enabled invoke and the cached `EntryFn` runs every
    later call (the instance owns the executable pages for its lifetime;

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -44,8 +44,12 @@ worst at function entry and `0.338x` with `0.368x` worst for OSR. Current
 qualification and module ownership are recorded in
 [ohaimark.md](ohaimark.md) "x86_64 architecture-parity closure."
 Generalized JS-reentrant helpers, native post-call continuations, remaining
-opcode families, and additional codegen targets remain future work. Spasm's
-delivery state is tracked below. This document doubles as the design record
+opcode families, and additional codegen targets remain future work. Spasm now
+also has a qualified x86_64 SysV backend for its i32 scalar/control core,
+catchable integer/stack traps, Realm safe points, guarded self-links, and
+stable cross-function gates; unsupported functions retain transactional
+fallback to Sarcasm. Spasm's delivery state is tracked below. This document
+doubles as the design record
 that pinned the architecture before the first emitter was written and as the
 delivery ledger (the "Delivery order" section tracks what each increment
 shipped). It is the
@@ -699,16 +703,16 @@ same line.
 
 Spasm participates in the shared safe-point convention without giving up its
 unmetered fast path. Its append-only entry ABI carries an optional execution
-controller in `x7`; the prologue parks it in callee-saved `x21`, and direct
-self-links, W^X-safe call gates (including their cold helper), generic imported
-calls, and indirect dispatch propagate it to callees. Function entry and each
-taken structured-loop backedge first test `x21`. Null skips with one predictable
-branch. A non-null controller acquire-loads its wake byte and still skips all
-spills and host calls while that byte is clear; once set, Spasm spills the live
-operand bank, calls the outlined Realm poll, restores on success, or returns the
-poll's status through its existing trap epilogue. Sarcasm retains the same
-entry/backedge polls plus proper-tail-call re-entry for bodies Spasm cannot
-compile.
+controller, parked in a callee-saved register (`x21` on AArch64, `rbx` on
+x86_64), and direct self-links, W^X-safe call gates (including their cold
+helper), generic imported calls, and indirect dispatch propagate it to
+callees. Function entry and each taken structured-loop backedge first test that
+register. Null skips with one predictable branch. A non-null controller
+acquire-loads its wake byte and still skips all spills and host calls while that
+byte is clear; once set, Spasm calls the outlined Realm poll, restores any live
+state on success, or returns the poll's status through its existing trap
+epilogue. Sarcasm retains the same entry/backedge polls plus proper-tail-call
+re-entry for bodies Spasm cannot compile.
 
 The placement follows the established Wasm baseline practice:
 [SpiderMonkey's baseline compiler](https://searchfox.org/firefox-main/source/js/src/wasm/WasmBaselineCompile.cpp)
@@ -727,12 +731,14 @@ src/runtime/jit/            shared substrate (new)
                             per-code free; one region per Engine
   asm_aarch64.zig           encoder
   asm_x86_64.zig            encoder
-  masm.zig                  AArch64 facade used by Ohaimark/Spasm
+  masm.zig                  AArch64 facade used by mature Spasm lowering
 src/runtime/bistromath/     T1 JS baseline (per AGENTS.md repo map)
   bistromath.zig            target-neutral one-pass compiler
   masm.zig                  AArch64/x86_64 register + ABI adapter
 src/runtime/ohaimark/       T2 (M6; ADR first)
-src/runtime/wasm/spasm.zig  Spasm — the wasm T1 baseline (§6)
+src/runtime/wasm/spasm.zig  Spasm public ABI + mature AArch64 backend (§6)
+src/runtime/wasm/spasm_x86_64.zig
+                            qualified SysV i32/control/call backend
 ```
 
 ### 7.1 The JS↔wasm call boundary
@@ -760,9 +766,9 @@ the boundary gets the same treatment as everything else:
   compiled JS, compiled wasm, and every boundary thunk live in the
   one §8 reservation, inside `BL` (±128 MiB) range — a warm crossing
   never takes an indirect hop through engine plumbing. x86_64
-  Bistromath already uses the corresponding `rel32` (±2 GiB) scheme;
-  Spasm and the boundary thunks remain future x86_64 work and will
-  share that reservation when they gain an x86_64 backend.
+  Bistromath and Spasm use the corresponding `rel32` (±2 GiB) scheme;
+  the per-signature boundary thunks remain future x86_64 work and will
+  share that reservation.
 - **Per-signature thunks, compiled once, cached by canonical
   function type** (the same type identity `call_indirect` checks).
   The JS→wasm *entry thunk* unboxes arguments straight from the
@@ -1346,6 +1352,11 @@ useful:
    and follows the direct wasm-call / stable-frame shape used by
    [V8 Liftoff](https://chromium.googlesource.com/v8/v8/+/352e408b0edd6e574d251281e395fcde92ec6898/src/wasm/baseline/liftoff-assembler.h)
    and [Wasmtime Winch](https://github.com/bytecodealliance/rfcs/blob/main/accepted/wasmtime-baseline-compilation.md).
+   The x86_64 subset applies the same contract with a SysV frame: an eligible
+   self-call uses local `rel32`, a cross-function caller passes the stable gate
+   as a private ninth stack argument to a shared tail-jump stub, and its stack
+   guard includes the staging frame, return address, and target prologue.
+   Non-gated calls retain the checked helper and per-function Sarcasm fallback.
    Imports, `call_indirect`, cross-instance calls, overlarge frames, and bodies
    Spasm cannot compile keep the generic helper / `invoke` fallback. Operands
    live below the args are spilled across either helper call and reloaded after

--- a/docs/resource-metering.md
+++ b/docs/resource-metering.md
@@ -254,9 +254,9 @@ benchmark gained paired bare/wake modes in ABBA order. Three final samples kept
 every workload native with matching checksums and `helper 0/0`. The tight loop
 was flat within noise (`0.963-1.033x` wake/bare); self-recursive code measured
 `1.047-1.079x`, and cross-recursive code `1.036-1.153x`, exposing the expected
-extra probe at function-heavy entry boundaries. The configured remote host is
-x86_64 and cannot run AArch64-only Spasm, so the paired raw samples and host
-caveat are recorded in
+extra probe at function-heavy entry boundaries. Spasm now has a qualified
+x86_64 backend; its independent bare/wake qualification samples and the older
+AArch64 paired runs are recorded in
 [`wasm-bench-results.md`](../wasm-bench-results.md).
 
 ## 7. JIT interaction

--- a/docs/wasm-engine.md
+++ b/docs/wasm-engine.md
@@ -536,9 +536,10 @@ the measured design space:
   guarded local self-links, and stable W^X-safe cross-function call gates.
   Every other x86 body refuses before code publication and runs in Sarcasm.
   This is a coverage difference, not a semantic one: forced-Spasm sweeps on
-  both architectures pass all 58,779 scored spec commands, and focused x86
-  tests require actual native entry so the differential gate cannot be
-  satisfied by fallback alone.
+  both architectures pass all 58,779 scored spec commands. CI pairs
+  `--spasm` with `--require-spasm-entry`, and the focused x86 instance/cache,
+  trap, safe-point, self-link, and stable-gate tests require actual native
+  entry, so the differential gate cannot be satisfied by fallback alone.
 - **Narrowing the operand cell was measured and declined** (2026-06).
   Splitting the 128-bit `Cell` into parallel 64-bit lanes (scalars in
   the low lane only) was prototyped and benchmarked on Apple Silicon:

--- a/docs/wasm-engine.md
+++ b/docs/wasm-engine.md
@@ -529,6 +529,16 @@ the measured design space:
   [jit.md](jit.md) §6, with the JS↔wasm
   call-boundary fast path (per-signature thunks, IC-integrated dispatch)
   in jit.md §7.1 (still deferred).
+
+  The complete opcode surface above is the mature AArch64 backend. The
+  qualified x86_64 SysV backend currently emits the i32 scalar/control core,
+  catchable integer and native-stack traps, Realm entry/backedge polls,
+  guarded local self-links, and stable W^X-safe cross-function call gates.
+  Every other x86 body refuses before code publication and runs in Sarcasm.
+  This is a coverage difference, not a semantic one: forced-Spasm sweeps on
+  both architectures pass all 58,779 scored spec commands, and focused x86
+  tests require actual native entry so the differential gate cannot be
+  satisfied by fallback alone.
 - **Narrowing the operand cell was measured and declined** (2026-06).
   Splitting the 128-bit `Cell` into parallel 64-bit lanes (scalars in
   the low lane only) was prototyped and benchmarked on Apple Silicon:

--- a/src/runtime/builtins/webassembly.zig
+++ b/src/runtime/builtins/webassembly.zig
@@ -2180,7 +2180,7 @@ test "WebAssembly JS API: Realm.requestInterrupt wakes Spasm after native entry"
     const testing = std.testing;
     const lantern = @import("../lantern/interpreter.zig");
     const spasm = @import("../wasm/spasm.zig");
-    if (comptime !spasm.full_coverage_supported) return error.SkipZigTest;
+    if (comptime !spasm.supported) return error.SkipZigTest;
 
     // import host.barrier : () -> (); export run : () -> i32. The imported
     // host function parks after Spasm's entry poll; the two-trip loop then

--- a/src/runtime/builtins/webassembly.zig
+++ b/src/runtime/builtins/webassembly.zig
@@ -1930,7 +1930,7 @@ fn testRealmBackedMemoryGrow(jit_enabled: bool) !void {
         .value => |value| try testing.expectEqual(@as(i32, 1), value.asInt32()),
         else => return error.TestUnexpectedResult,
     }
-    if (jit_enabled and comptime @import("../wasm/spasm.zig").supported)
+    if (jit_enabled and comptime @import("../wasm/spasm.zig").full_coverage_supported)
         try testing.expect(record.instance.spasm_runs >= 1);
     if (!jit_enabled) {
         try testing.expect(!record.instance.spasm_enabled);
@@ -1950,7 +1950,7 @@ fn testRealmBackedMemoryGrow(jit_enabled: bool) !void {
         else => return error.TestUnexpectedResult,
     }
     try testing.expectEqual(live_before_grow + wasm.PAGE_SIZE, realm.heap.bytes_live);
-    if (jit_enabled and comptime @import("../wasm/spasm.zig").supported)
+    if (jit_enabled and comptime @import("../wasm/spasm.zig").full_coverage_supported)
         try testing.expect(record.instance.spasm_runs > runs_before_grow);
     if (!jit_enabled) try testing.expectEqual(@as(u32, 0), record.instance.spasm_runs);
     try testing.expect(old_buffer.getArrayBuffer() == null);
@@ -2009,7 +2009,7 @@ fn testRealmBackedTableGrow(jit_enabled: bool) !void {
         .value => |value| try testing.expectEqual(@as(i32, 2), value.asInt32()),
         else => return error.TestUnexpectedResult,
     }
-    if (jit_enabled and comptime @import("../wasm/spasm.zig").supported)
+    if (jit_enabled and comptime @import("../wasm/spasm.zig").full_coverage_supported)
         try testing.expect(record.instance.spasm_runs >= 1);
     if (!jit_enabled) {
         try testing.expect(!record.instance.spasm_enabled);
@@ -2025,7 +2025,7 @@ fn testRealmBackedTableGrow(jit_enabled: bool) !void {
     }
     try testing.expectEqual(live_before_grow + 3 * @sizeOf(u128), realm.heap.bytes_live);
     try testing.expectEqual(@as(usize, 5), record.instance.tables[0].elems.len);
-    if (jit_enabled and comptime @import("../wasm/spasm.zig").supported)
+    if (jit_enabled and comptime @import("../wasm/spasm.zig").full_coverage_supported)
         try testing.expect(record.instance.spasm_runs > runs_before_grow);
     if (!jit_enabled) try testing.expectEqual(@as(u32, 0), record.instance.spasm_runs);
 }
@@ -2180,7 +2180,7 @@ test "WebAssembly JS API: Realm.requestInterrupt wakes Spasm after native entry"
     const testing = std.testing;
     const lantern = @import("../lantern/interpreter.zig");
     const spasm = @import("../wasm/spasm.zig");
-    if (comptime !spasm.supported) return error.SkipZigTest;
+    if (comptime !spasm.full_coverage_supported) return error.SkipZigTest;
 
     // import host.barrier : () -> (); export run : () -> i32. The imported
     // host function parks after Spasm's entry poll; the two-trip loop then

--- a/src/runtime/jit/asm_x86_64.zig
+++ b/src/runtime/jit/asm_x86_64.zig
@@ -248,6 +248,37 @@ pub const Masm = struct {
         try self.emitRegImm32(7, left, immediate);
     }
 
+    /// `cmp left32, immediate32`.
+    pub fn cmpReg32Imm32(
+        self: *Masm,
+        left: Reg,
+        immediate: u32,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(left)));
+        try self.emitByte(0x81);
+        try self.emitByte(0xF8 | lowBits(left));
+        try self.emitU32(immediate);
+    }
+
+    /// `cdq` -- sign-extend eax into edx:eax before a signed divide.
+    pub fn signExtendAccumulator32(self: *Masm) error{OutOfMemory}!void {
+        try self.emitByte(0x99);
+    }
+
+    /// `div source32` -- divide edx:eax by the unsigned source.
+    pub fn divReg32(self: *Masm, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(source)));
+        try self.emitByte(0xF7);
+        try self.emitByte(0xF0 | lowBits(source));
+    }
+
+    /// `idiv source32` -- divide edx:eax by the signed source.
+    pub fn idivReg32(self: *Masm, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(source)));
+        try self.emitByte(0xF7);
+        try self.emitByte(0xF8 | lowBits(source));
+    }
+
     /// `shl destination, amount`.
     pub fn shlImm8(self: *Masm, destination: Reg, amount: u8) error{OutOfMemory}!void {
         try self.emitByte(rex(true, false, false, isExtended(destination)));
@@ -471,6 +502,19 @@ pub const Masm = struct {
         try self.emitByte(rex(false, false, false, isExtended(target)));
         try self.emitByte(0xFF);
         try self.emitByte(0xD0 | lowBits(target));
+    }
+
+    /// `call rel32` to a local label.
+    pub fn call(self: *Masm, label: *Label) !void {
+        try self.emitByte(0xE8);
+        try self.emitBranchDisplacement(label);
+    }
+
+    /// `jmp target`.
+    pub fn jumpReg(self: *Masm, target: Reg) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, false, false, isExtended(target)));
+        try self.emitByte(0xFF);
+        try self.emitByte(0xE0 | lowBits(target));
     }
 
     pub fn ret(self: *Masm) error{OutOfMemory}!void {

--- a/src/runtime/wasm/spasm.zig
+++ b/src/runtime/wasm/spasm.zig
@@ -5678,15 +5678,14 @@ test "spasm: br_table dispatches by index to distinct block ends" {
 }
 
 test "spasm: an unsupported opcode degrades to null (stay interpreted)" {
-    if (comptime !full_coverage_supported) return error.SkipZigTest;
+    if (comptime !supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
 
-    // `memory.grow` (0x40) is outside the baseline's current set —
-    // Spasm must refuse the whole function, not abort. The
-    // interpreter runs it. (`call` is now emittable, so this guard
-    // uses an op that still degrades.)
-    const body = [_]u8{ 0x40, 0x00, op_end };
+    // A supported prefix followed by `memory.grow` without its helper must
+    // refuse the whole function before publishing partial native code. The
+    // interpreter runs it instead.
+    const body = [_]u8{ op_i32_const, 0x01, 0x40, 0x00, op_end };
     const func: CompiledFunc = .{
         .type_index = 0,
         .local_types = &.{},
@@ -5695,5 +5694,7 @@ test "spasm: an unsupported opcode degrades to null (stay interpreted)" {
         .max_stack = 1,
     };
     const ftype: FuncType = .{ .params = &.{}, .results = &.{.i32} };
+    const top_before = ca.top;
     try testing.expectEqual(@as(?EntryFn, null), try compileT(&ca, &func, &ftype));
+    try testing.expectEqual(top_before, ca.top);
 }

--- a/src/runtime/wasm/spasm.zig
+++ b/src/runtime/wasm/spasm.zig
@@ -10,8 +10,9 @@
 //! dispatch.
 //!
 //! Spasm shares the codegen substrate in `src/runtime/jit/` with
-//! Bistromath — the per-ISA encoders, the masm facade, the
-//! executable-memory allocator (§7). What it does NOT share is the
+//! Bistromath — the per-ISA encoders and executable-memory allocator (§7).
+//! AArch64 uses the shared masm facade; the qualified x86_64 subset keeps its
+//! SysV frame/operand policy in `spasm_x86_64.zig`. What Spasm does NOT share is the
 //! abstract state above the assembler: Bistromath mirrors the
 //! interpreter's `CallFrame`; Spasm's operand-stack machine is its
 //! whole compiler, and wasm frames live on the native stack with no GC
@@ -20,8 +21,8 @@
 //! Build-up is incremental, like Bistromath's: each increment grows the
 //! compilable function class and is gated by the wasm spec-testsuite
 //! differential (a force-tier-up run must produce the identical
-//! pass-set). This first increment compiles the trivial class — a body
-//! that pushes constants and returns them.
+//! pass-set). Unsupported functions refuse transactionally before code
+//! publication and remain in Sarcasm.
 
 const std = @import("std");
 const builtin = @import("builtin");
@@ -29,50 +30,52 @@ const builtin = @import("builtin");
 const code_alloc = @import("../jit/code_alloc.zig");
 const masm_mod = @import("../jit/masm.zig");
 const a64 = @import("../jit/asm_aarch64.zig");
+const spasm_x86_64 = @import("spasm_x86_64.zig");
 const CompiledFunc = @import("code.zig").CompiledFunc;
 const FuncType = @import("types.zig").FuncType;
 const ValType = @import("types.zig").ValType;
 const Module = @import("module.zig").Module;
 
-/// Whether this target can host Spasm. Bistromath's gate, verbatim:
-/// the substrate emits aarch64 today (docs/jit.md §8/§14 keep x86_64
-/// a mechanical follow-up); elsewhere the tier is a comptime no-op and
-/// the interpreter runs everything.
-pub const supported = code_alloc.supported and builtin.cpu.arch == .aarch64;
+/// Whether this target can host at least the helper-free Spasm core. The
+/// AArch64 backend remains the full implementation while x86_64 grows through
+/// the same transactional-refusal boundary; every unsupported body falls back
+/// to Sarcasm.
+pub const supported = code_alloc.supported and switch (builtin.cpu.arch) {
+    .aarch64, .x86_64 => true,
+    else => false,
+};
+
+/// Tests that exercise the complete opcode surface use this narrower gate
+/// until the x86_64 backend reaches parity.
+pub const full_coverage_supported = code_alloc.supported and builtin.cpu.arch == .aarch64;
 
 /// The interpreter's value cell — a 16-byte slot holding any wasm
 /// scalar (low bits) or a `v128`.
 pub const Cell = u128;
 
-/// v1 boundary ABI. The interpreter already marshals a call's
+/// Native boundary ABI. The interpreter already marshals a call's
 /// arguments and results as `Cell` arrays (`interpreter.invoke`), so
-/// the first boundary reuses that representation verbatim: `locals`
-/// (x0) is the param+local cell array the caller seeded, `results`
-/// (x1) is where the compiled body writes its result cells. `mem_base`
-/// (x2) and `mem_len` (x3) are the active linear memory's byte pointer
+/// the boundary reuses that representation verbatim: `locals` is the
+/// param+local cell array the caller seeded, `results` is where the compiled
+/// body writes its result cells. `mem_base` and `mem_len` are the active linear memory's byte pointer
 /// and length — every memory op bounds-checks against `mem_len` and
-/// addresses off `mem_base`. They are stable for the body's duration:
-/// the only ops that resize memory (`memory.grow`) or could call into
-/// resizing code (`call`) are outside the emittable class, so a compiled
-/// body never observes a mid-execution change. The optimized
+/// addresses off `mem_base`; helper paths that can resize memory must refresh
+/// the cached pair. The optimized
 /// native-register boundary (the per-signature §7.1 thunks) is a later
 /// increment; correctness first.
 ///
-/// The `u32` return (w0) is the trap channel: `trap_ok` (0) means the
+/// The `u32` return (`w0`/`eax`) is the trap channel: `trap_ok` (0) means the
 /// body completed and `results` is valid; a non-zero `TrapCode` means
 /// the body trapped before writing results, and the caller maps it to
 /// the matching `TrapError` (so a Spasm trap is indistinguishable from
 /// an interpreter trap at the boundary). This is the mechanism every
 /// trapping op reuses — divide-by-zero and memory bounds today.
 ///
-/// `instance` (x5 on entry) is the opaque `*Instance` the compiled body
-/// passes to the call helper when it emits a `call` (§5.4.1). `stack_limit`
-/// (x6) is the current thread's native-stack cutoff; the prologue parks it
-/// in x20 so any helper-free same-instance link can compare projected SP
-/// without re-entering Zig. `execution_control` (x7) is null on the ordinary
-/// unmetered path; otherwise it points at the embedding's shared execution
-/// controller and the prologue parks it in x21. All three are append-only
-/// boundary arguments.
+/// `instance` is the opaque `*Instance` used by call helpers. `stack_limit` is
+/// the current thread's native-stack cutoff used before every linked call.
+/// `execution_control` is null on the ordinary unmetered path; otherwise it
+/// points at the embedding's shared controller. All three are append-only
+/// boundary arguments; each backend owns its register/stack mapping.
 pub const EntryFn = *const fn (
     locals: [*]Cell,
     results: [*]Cell,
@@ -88,7 +91,7 @@ pub const EntryFn = *const fn (
 /// callers embed only this heap address, never a lazily-installed code address:
 /// the gate stub loads `entry` on every call and tail-branches when it is hot.
 /// `entry` must stay first because the stub's load is intentionally a fixed
-/// zero-offset AArch64 instruction.
+/// zero-offset load on both backends.
 pub const CallGate = extern struct {
     entry: ?EntryFn,
     instance: *anyopaque,
@@ -103,8 +106,9 @@ comptime {
 }
 
 /// The generated gate accepts the EntryFn ABI. Generated callers additionally
-/// carry the stable gate record in x8, an internal extension beyond the C ABI.
-/// On the hot path it tail-branches to `CallGate.entry`, which receives x0..x7
+/// carry the stable gate record in an internal extension beyond the C ABI
+/// (`x8` on AArch64, a private ninth stack argument on SysV). On the hot path
+/// it tail-branches to `CallGate.entry` with the ordinary eight arguments
 /// unchanged and returns directly to the compiled caller.
 pub const CallGateStubFn = *const fn (
     locals: [*]Cell,
@@ -139,6 +143,16 @@ pub fn compileCallGateStub(
     slow: CallGateSlowHelperFn,
 ) ?CallGateStubFn {
     if (comptime !supported) return null;
+    if (comptime builtin.cpu.arch == .x86_64) {
+        const installed = (spasm_x86_64.compileCallGateStub(
+            gpa,
+            ca,
+            @intFromPtr(slow),
+            @intCast(@offsetOf(CallGate, "entry")),
+        ) catch return null) orelse return null;
+        return code_alloc.asFn(CallGateStubFn, installed);
+    }
+    if (comptime builtin.cpu.arch != .aarch64) return null;
 
     var m = masm_mod.Masm.init(gpa);
     defer m.deinit();
@@ -642,6 +656,12 @@ const Loc = union(enum) {
 /// this deep, so at most this many references are simultaneously live.
 pub const operand_reg_count = 7;
 
+comptime {
+    if (spasm_x86_64.operand_stack_capacity != operand_reg_count) {
+        @compileError("Spasm backends must reserve the same operand scratch capacity");
+    }
+}
+
 /// Cells a native `EntryFn` needs for its locals and depth-keyed reference / SIMD
 /// scratch slots, or null if the count overflows. `results` may alias this
 /// buffer: compiled bodies materialize results only after consuming locals.
@@ -804,6 +824,59 @@ pub fn compile(
     execution_poll_helper: ExecutionPollHelperFn,
 ) CompileError!?EntryFn {
     if (comptime !supported) return null;
+    if (comptime builtin.cpu.arch == .x86_64) {
+        const installed = try spasm_x86_64.compile(
+            gpa,
+            ca,
+            func,
+            ftype,
+            module,
+            funcs,
+            func_index,
+            .{
+                .execution_poll_helper = @intFromPtr(execution_poll_helper),
+                .call_helper = if (helpers.call) |helper| @intFromPtr(helper) else null,
+                .call_gate_stub = if (call_gate_stub) |stub| @intFromPtr(stub) else null,
+                .call_gates_base = if (call_gates.len == 0) null else @intFromPtr(call_gates.ptr),
+                .call_gates_len = call_gates.len,
+                .call_gate_stride = @sizeOf(CallGate),
+                .wake_flag_offset = @intCast(@offsetOf(NativeExecutionControl, "wake_flag")),
+                .trap_divide_by_zero = trap_divide_by_zero,
+                .trap_int_overflow = trap_int_overflow,
+                .trap_call_stack_exhausted = trap_call_stack_exhausted,
+            },
+        );
+        return if (installed) |bytes| code_alloc.asFn(EntryFn, bytes) else null;
+    }
+    return compileAarch64(
+        gpa,
+        ca,
+        func,
+        ftype,
+        module,
+        funcs,
+        func_index,
+        call_gates,
+        call_gate_stub,
+        helpers,
+        execution_poll_helper,
+    );
+}
+
+fn compileAarch64(
+    gpa: std.mem.Allocator,
+    ca: *code_alloc.CodeAllocator,
+    func: *const CompiledFunc,
+    ftype: *const FuncType,
+    module: *const Module,
+    funcs: []const CompiledFunc,
+    func_index: u32,
+    call_gates: []const CallGate,
+    call_gate_stub: ?CallGateStubFn,
+    helpers: Helpers,
+    execution_poll_helper: ExecutionPollHelperFn,
+) CompileError!?EntryFn {
+    if (comptime builtin.cpu.arch != .aarch64 or !code_alloc.supported) return null;
     // The operand-stack bank is fixed (regForDepth); a deeper body
     // tiers down.
     if (func.max_stack > operand_reg_count) return null;
@@ -4564,6 +4637,319 @@ fn readV128Bytes(body: []const u8, i: *usize) ?struct { lo: u64, hi: u64 } {
 
 const testing = std.testing;
 
+test "spasm: x86_64 executable hosts are supported" {
+    if (comptime builtin.cpu.arch != .x86_64 or !code_alloc.supported) {
+        return error.SkipZigTest;
+    }
+    try testing.expect(supported);
+}
+
+test "spasm: x86_64 native entry returns an i32 constant" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    const body = [_]u8{ op_i32_const, 42, op_end };
+    const func: CompiledFunc = .{
+        .type_index = 0,
+        .local_types = &.{},
+        .body = &body,
+        .side_table = &.{},
+        .max_stack = 1,
+    };
+    const ftype: FuncType = .{ .params = &.{}, .results = &.{.i32} };
+    const entry = (try compileT(&ca, &func, &ftype)) orelse return error.SpasmRefused;
+
+    var frame: [operand_reg_count]Cell = @splat(0);
+    var results: [1]Cell = .{0};
+    const status = entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null);
+    try testing.expectEqual(trap_ok, status);
+    try testing.expectEqual(@as(u32, 42), @as(u32, @truncate(results[0])));
+}
+
+test "spasm: x86_64 native loop computes sum of squares" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    // `(param n) (local i acc); sum i*i for i in [0,n)` -- the same scalar
+    // control-flow kernel used by tools/wasm_bench.zig, minus its locals header.
+    const body = [_]u8{
+        op_block,     0x40,
+        op_loop,      0x40,
+        op_local_get, 0x01,
+        op_local_get, 0x00,
+        op_i32_ge_s,  op_br_if,
+        0x01,         op_local_get,
+        0x02,         op_local_get,
+        0x01,         op_local_get,
+        0x01,         op_i32_mul,
+        op_i32_add,   op_local_set,
+        0x02,         op_local_get,
+        0x01,         op_i32_const,
+        0x01,         op_i32_add,
+        op_local_set, 0x01,
+        op_br,        0x00,
+        op_end,       op_end,
+        op_local_get, 0x02,
+        op_end,
+    };
+    const func: CompiledFunc = .{
+        .type_index = 0,
+        .local_types = &.{ .i32, .i32, .i32 },
+        .body = &body,
+        .side_table = &.{},
+        .max_stack = 3,
+    };
+    const ftype: FuncType = .{ .params = &.{.i32}, .results = &.{.i32} };
+    const entry = (try compileT(&ca, &func, &ftype)) orelse return error.SpasmRefused;
+
+    var frame: [3 + operand_reg_count]Cell = @splat(0);
+    frame[0] = 10;
+    var results: [1]Cell = .{0};
+    const status = entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null);
+    try testing.expectEqual(trap_ok, status);
+    try testing.expectEqual(@as(u32, 285), @as(u32, @truncate(results[0])));
+}
+
+test "spasm: x86_64 signed division preserves wasm traps" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    const body = [_]u8{ op_local_get, 0x00, op_local_get, 0x01, op_i32_div_s, op_end };
+    const func: CompiledFunc = .{
+        .type_index = 0,
+        .local_types = &.{ .i32, .i32 },
+        .body = &body,
+        .side_table = &.{},
+        .max_stack = 2,
+    };
+    const ftype: FuncType = .{ .params = &.{ .i32, .i32 }, .results = &.{.i32} };
+    const entry = (try compileT(&ca, &func, &ftype)) orelse return error.SpasmRefused;
+
+    var frame: [2 + operand_reg_count]Cell = @splat(0);
+    var results: [1]Cell = .{0};
+    frame[0] = 84;
+    frame[1] = 2;
+    try testing.expectEqual(trap_ok, entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null));
+    try testing.expectEqual(@as(u32, 42), @as(u32, @truncate(results[0])));
+
+    frame[1] = 0;
+    results[0] = 0xfeed;
+    try testing.expectEqual(trap_divide_by_zero, entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null));
+    try testing.expectEqual(@as(Cell, 0xfeed), results[0]);
+
+    frame[0] = 0x8000_0000;
+    frame[1] = @as(u32, @bitCast(@as(i32, -1)));
+    try testing.expectEqual(trap_int_overflow, entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null));
+    try testing.expectEqual(@as(Cell, 0xfeed), results[0]);
+}
+
+const X86CallTestState = struct {
+    called: bool = false,
+    func_index: u32 = 0,
+    argument: u32 = 0,
+    capacity: u32 = 0,
+    control_was_null: bool = false,
+
+    fn call(
+        instance: *anyopaque,
+        func_index: u32,
+        buf: [*]Cell,
+        buf_cells: u32,
+        execution_control: ?*anyopaque,
+    ) callconv(.c) u32 {
+        const self: *X86CallTestState = @ptrCast(@alignCast(instance));
+        self.called = true;
+        self.func_index = func_index;
+        self.argument = @truncate(buf[0]);
+        self.capacity = buf_cells;
+        self.control_was_null = execution_control == null;
+        buf[0] = self.argument + 1;
+        return trap_ok;
+    }
+};
+
+test "spasm: x86_64 checked call marshals cells through the helper" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    const caller_body = [_]u8{ op_local_get, 0x00, op_call, 0x01, op_end };
+    const callee_body = [_]u8{ op_local_get, 0x00, op_end };
+    const ftype: FuncType = .{ .params = &.{.i32}, .results = &.{.i32} };
+    const funcs = [_]CompiledFunc{
+        .{ .type_index = 0, .local_types = &.{.i32}, .body = &caller_body, .side_table = &.{}, .max_stack = 1 },
+        .{ .type_index = 0, .local_types = &.{.i32}, .body = &callee_body, .side_table = &.{}, .max_stack = 1 },
+    };
+    const types = [_]FuncType{ftype};
+    const module: Module = .{ .types = &types, .funcs = &.{ 0, 0 } };
+    const entry = (try compile(
+        testing.allocator,
+        &ca,
+        &funcs[0],
+        &ftype,
+        &module,
+        &funcs,
+        0,
+        &.{},
+        null,
+        .{ .call = X86CallTestState.call },
+        testExecutionPoll,
+    )) orelse return error.SpasmRefused;
+
+    var state: X86CallTestState = .{};
+    var frame: [1 + operand_reg_count]Cell = @splat(0);
+    frame[0] = 41;
+    var results: [1]Cell = .{0};
+    const status = entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&state), 0, null);
+    try testing.expectEqual(trap_ok, status);
+    try testing.expect(state.called);
+    try testing.expectEqual(@as(u32, 1), state.func_index);
+    try testing.expectEqual(@as(u32, 41), state.argument);
+    try testing.expect(state.capacity >= 1);
+    try testing.expect(state.control_was_null);
+    try testing.expectEqual(@as(u32, 42), @as(u32, @truncate(results[0])));
+}
+
+test "spasm: x86_64 self recursion links directly with a stack guard" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    // factorial(n): n == 0 ? 1 : n * factorial(n - 1)
+    const body = [_]u8{
+        op_local_get, 0x00,         op_i32_eqz,
+        op_if,        0x7f,         op_i32_const,
+        0x01,         op_else,      op_local_get,
+        0x00,         op_local_get, 0x00,
+        op_i32_const, 0x01,         op_i32_sub,
+        op_call,      0x00,         op_i32_mul,
+        op_end,       op_end,
+    };
+    const func: CompiledFunc = .{
+        .type_index = 0,
+        .local_types = &.{.i32},
+        .body = &body,
+        .side_table = &.{},
+        .max_stack = 3,
+    };
+    const ftype: FuncType = .{ .params = &.{.i32}, .results = &.{.i32} };
+    const types = [_]FuncType{ftype};
+    const funcs = [_]CompiledFunc{func};
+    const module: Module = .{ .types = &types, .funcs = &.{0} };
+    const entry = (try compile(
+        testing.allocator,
+        &ca,
+        &func,
+        &ftype,
+        &module,
+        &funcs,
+        0,
+        &.{},
+        null,
+        .{},
+        testExecutionPoll,
+    )) orelse return error.SpasmRefused;
+
+    var frame: [1 + operand_reg_count]Cell = @splat(0);
+    frame[0] = 5;
+    var results: [1]Cell = .{0};
+    const status = entry(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&frame), 0, null);
+    try testing.expectEqual(trap_ok, status);
+    try testing.expectEqual(@as(u32, 120), @as(u32, @truncate(results[0])));
+
+    results[0] = 0xfeed;
+    const exhausted = entry(
+        &frame,
+        &results,
+        @ptrCast(&frame),
+        0,
+        @ptrCast(&frame),
+        @ptrCast(&frame),
+        std.math.maxInt(usize),
+        null,
+    );
+    try testing.expectEqual(trap_call_stack_exhausted, exhausted);
+    try testing.expectEqual(@as(Cell, 0xfeed), results[0]);
+}
+
+fn x86CallGateSlowTest(
+    _: [*]Cell,
+    _: *const CallGate,
+    _: ?*anyopaque,
+) callconv(.c) u32 {
+    return trap_pending;
+}
+
+test "spasm: x86_64 cross-function call uses the stable gate" {
+    if (comptime builtin.cpu.arch != .x86_64 or !supported) {
+        return error.SkipZigTest;
+    }
+    var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
+    defer ca.deinit();
+
+    const caller_body = [_]u8{ op_local_get, 0x00, op_call, 0x01, op_end };
+    const callee_body = [_]u8{ op_local_get, 0x00, op_i32_const, 0x01, op_i32_add, op_end };
+    const ftype: FuncType = .{ .params = &.{.i32}, .results = &.{.i32} };
+    const funcs = [_]CompiledFunc{
+        .{ .type_index = 0, .local_types = &.{.i32}, .body = &caller_body, .side_table = &.{}, .max_stack = 1 },
+        .{ .type_index = 0, .local_types = &.{.i32}, .body = &callee_body, .side_table = &.{}, .max_stack = 2 },
+    };
+    const types = [_]FuncType{ftype};
+    const module: Module = .{ .types = &types, .funcs = &.{ 0, 0 } };
+    var gates = [_]CallGate{
+        .{ .entry = null, .instance = @ptrCast(&ca), .func_index = 0, .frame_cells = 8 },
+        .{ .entry = null, .instance = @ptrCast(&ca), .func_index = 1, .frame_cells = 8 },
+    };
+    const gate_stub = compileCallGateStub(testing.allocator, &ca, x86CallGateSlowTest) orelse
+        return error.SpasmRefused;
+    gates[1].entry = (try compile(
+        testing.allocator,
+        &ca,
+        &funcs[1],
+        &ftype,
+        &module,
+        &funcs,
+        1,
+        &gates,
+        gate_stub,
+        .{},
+        testExecutionPoll,
+    )) orelse return error.SpasmRefused;
+    const caller = (try compile(
+        testing.allocator,
+        &ca,
+        &funcs[0],
+        &ftype,
+        &module,
+        &funcs,
+        0,
+        &gates,
+        gate_stub,
+        .{},
+        testExecutionPoll,
+    )) orelse return error.SpasmRefused;
+
+    var frame: [1 + operand_reg_count]Cell = @splat(0);
+    frame[0] = 41;
+    var results: [1]Cell = .{0};
+    const status = caller(&frame, &results, @ptrCast(&frame), 0, @ptrCast(&frame), @ptrCast(&ca), 0, null);
+    try testing.expectEqual(trap_ok, status);
+    try testing.expectEqual(@as(u32, 42), @as(u32, @truncate(results[0])));
+}
+
 fn testExecutionPoll(_: *anyopaque) callconv(.c) u32 {
     return trap_ok;
 }
@@ -4610,7 +4996,7 @@ fn compileWithPollT(
 }
 
 test "spasm: a const-return function compiles and returns its constant" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
 
@@ -4637,7 +5023,7 @@ test "spasm: a const-return function compiles and returns its constant" {
 }
 
 test "spasm: a negative constant sign-extends through the LEB path" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
 
@@ -4662,7 +5048,7 @@ test "spasm: a negative constant sign-extends through the LEB path" {
 }
 
 test "spasm: i32 add of two params compiles and computes" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32 i32) (result i32) local.get 0; local.get 1; i32.add)
@@ -4677,7 +5063,7 @@ test "spasm: i32 add of two params compiles and computes" {
 }
 
 test "spasm: i32 sub and mul of params compute" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     const ftype: FuncType = .{ .params = &.{ .i32, .i32 }, .results = &.{.i32} };
@@ -4704,7 +5090,7 @@ test "spasm: i32 sub and mul of params compute" {
 }
 
 test "spasm: i32 arithmetic folds two constants at compile time" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (result i32) i32.const 40; i32.const 2; i32.add) -> 42, no runtime add
@@ -4719,7 +5105,7 @@ test "spasm: i32 arithmetic folds two constants at compile time" {
 }
 
 test "spasm: i32 bitwise and/or/xor compute and fold" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     const ftype: FuncType = .{ .params = &.{ .i32, .i32 }, .results = &.{.i32} };
@@ -4747,7 +5133,7 @@ test "spasm: i32 bitwise and/or/xor compute and fold" {
 }
 
 test "spasm: local.set writes a local that local.get reads back" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) i32.const 5; local.set 0; local.get 0)
@@ -4762,7 +5148,7 @@ test "spasm: local.set writes a local that local.get reads back" {
 }
 
 test "spasm: local.tee stores and leaves the value on the stack" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) i32.const 7; local.tee 0; local.get 0; i32.add) -> 14
@@ -4777,7 +5163,7 @@ test "spasm: local.tee stores and leaves the value on the stack" {
 }
 
 test "spasm: i32 comparisons distinguish signed from unsigned" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     const ftype: FuncType = .{ .params = &.{ .i32, .i32 }, .results = &.{.i32} };
@@ -4803,7 +5189,7 @@ test "spasm: i32 comparisons distinguish signed from unsigned" {
 }
 
 test "spasm: i32.eqz computes and folds" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     const ftype: FuncType = .{ .params = &.{.i32}, .results = &.{.i32} };
@@ -4828,7 +5214,7 @@ test "spasm: i32.eqz computes and folds" {
 }
 
 test "spasm: i32 shifts (shl, shr_s, shr_u) with count mod 32 and folding" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     const ftype: FuncType = .{ .params = &.{ .i32, .i32 }, .results = &.{.i32} };
@@ -4860,7 +5246,7 @@ test "spasm: i32 shifts (shl, shr_s, shr_u) with count mod 32 and folding" {
 }
 
 test "spasm: select picks an operand by the condition (branchless)" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32 i32 i32) (result i32)
@@ -4880,7 +5266,7 @@ test "spasm: select picks an operand by the condition (branchless)" {
 }
 
 test "spasm: drop pops a value; nop is a no-op" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32 i32) (result i32) nop; local.get 0; local.get 1; drop; nop)
@@ -4897,7 +5283,7 @@ test "spasm: drop pops a value; nop is a no-op" {
 }
 
 test "spasm: block with br_if picks a result by condition (forward branch)" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32)
@@ -4932,7 +5318,7 @@ test "spasm: block with br_if picks a result by condition (forward branch)" {
 }
 
 test "spasm: empty block with br_if as an early break (arity 0)" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)
@@ -4965,7 +5351,7 @@ test "spasm: empty block with br_if as an early break (arity 0)" {
 }
 
 test "spasm: nested block, br_if 1 exits two levels carrying a result" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32)
@@ -5001,7 +5387,7 @@ test "spasm: nested block, br_if 1 exits two levels carrying a result" {
 }
 
 test "spasm: loop with backward br_if accumulates (do-while)" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)
@@ -5034,7 +5420,7 @@ test "spasm: loop with backward br_if accumulates (do-while)" {
 }
 
 test "spasm: execution polls preserve live operands and propagate termination" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
 
@@ -5088,7 +5474,7 @@ test "spasm: execution polls preserve live operands and propagate termination" {
 }
 
 test "spasm: loop (result i32) iterates then yields its result" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)
@@ -5121,7 +5507,7 @@ test "spasm: loop (result i32) iterates then yields its result" {
 }
 
 test "spasm: while loop — br as continue, br_if as break" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)        ;; n = p0, sum = l1
@@ -5160,7 +5546,7 @@ test "spasm: while loop — br as continue, br_if as break" {
 }
 
 test "spasm: br exits a block forward; dead code (nested block) is skipped" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (result i32)
@@ -5190,7 +5576,7 @@ test "spasm: br exits a block forward; dead code (nested block) is skipped" {
 }
 
 test "spasm: if/else picks a result arm by the condition" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32)
@@ -5222,7 +5608,7 @@ test "spasm: if/else picks a result arm by the condition" {
 }
 
 test "spasm: if without else conditionally overwrites a local" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)
@@ -5253,7 +5639,7 @@ test "spasm: if without else conditionally overwrites a local" {
 }
 
 test "spasm: br_table dispatches by index to distinct block ends" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
     // (func (param i32) (result i32) (local i32)         ;; i=p0, r=l1
@@ -5292,7 +5678,7 @@ test "spasm: br_table dispatches by index to distinct block ends" {
 }
 
 test "spasm: an unsupported opcode degrades to null (stay interpreted)" {
-    if (comptime !supported) return error.SkipZigTest;
+    if (comptime !full_coverage_supported) return error.SkipZigTest;
     var ca = try code_alloc.CodeAllocator.init(testing.allocator, 64 * 1024);
     defer ca.deinit();
 

--- a/src/runtime/wasm/spasm_x86_64.zig
+++ b/src/runtime/wasm/spasm_x86_64.zig
@@ -1,0 +1,843 @@
+//! x86_64 Spasm backend.
+//!
+//! This first backend slice keeps scalar operands in the existing trailing
+//! `Cell` scratch area rather than trying to project AArch64's seven-register
+//! cache onto the smaller SysV register file. The validated-bytecode compiler
+//! remains one pass, constants still fold, and unsupported instructions refuse
+//! transactionally so Sarcasm remains the semantic fallback.
+
+const std = @import("std");
+
+const x64 = @import("../jit/asm_x86_64.zig");
+const code_alloc = @import("../jit/code_alloc.zig");
+const CompiledFunc = @import("code.zig").CompiledFunc;
+const Module = @import("module.zig").Module;
+const FuncType = @import("types.zig").FuncType;
+
+pub const operand_stack_capacity = 7;
+
+pub const Error = error{
+    OutOfMemory,
+    LabelAlreadyBound,
+    InvalidLabel,
+    BranchOutOfRange,
+};
+
+pub const Config = struct {
+    execution_poll_helper: usize,
+    call_helper: ?usize,
+    call_gate_stub: ?usize,
+    call_gates_base: ?usize,
+    call_gates_len: usize,
+    call_gate_stride: usize,
+    wake_flag_offset: i32,
+    trap_divide_by_zero: u32,
+    trap_int_overflow: u32,
+    trap_call_stack_exhausted: u32,
+};
+
+const frame_size: u32 = 56;
+const saved_r12_off: i32 = 8;
+const saved_r13_off: i32 = 16;
+const saved_r14_off: i32 = 24;
+const saved_r15_off: i32 = 32;
+const saved_rbx_off: i32 = 40;
+const saved_rbp_off: i32 = 48;
+const entry_stack_limit_off: i32 = frame_size + 8;
+const entry_execution_control_off: i32 = frame_size + 16;
+const native_entry_stack_bytes: u32 = frame_size + 8; // return address + target prologue
+// stack_limit, execution_control, private CallGate*, then 8 bytes of padding
+// so the Cell buffer remains 16-byte aligned.
+const call_stack_args_size: usize = 32;
+const max_call_frame_bytes: usize = 64 * 1024;
+
+const op_nop: u8 = 0x01;
+const op_block: u8 = 0x02;
+const op_loop: u8 = 0x03;
+const op_if: u8 = 0x04;
+const op_else: u8 = 0x05;
+const op_end: u8 = 0x0b;
+const op_br: u8 = 0x0c;
+const op_br_if: u8 = 0x0d;
+const op_call: u8 = 0x10;
+const op_drop: u8 = 0x1a;
+const op_local_get: u8 = 0x20;
+const op_local_set: u8 = 0x21;
+const op_local_tee: u8 = 0x22;
+const op_i32_const: u8 = 0x41;
+const op_i32_eqz: u8 = 0x45;
+const op_i32_eq: u8 = 0x46;
+const op_i32_ne: u8 = 0x47;
+const op_i32_lt_s: u8 = 0x48;
+const op_i32_lt_u: u8 = 0x49;
+const op_i32_gt_s: u8 = 0x4a;
+const op_i32_gt_u: u8 = 0x4b;
+const op_i32_le_s: u8 = 0x4c;
+const op_i32_le_u: u8 = 0x4d;
+const op_i32_ge_s: u8 = 0x4e;
+const op_i32_ge_u: u8 = 0x4f;
+const op_i32_add: u8 = 0x6a;
+const op_i32_sub: u8 = 0x6b;
+const op_i32_mul: u8 = 0x6c;
+const op_i32_div_s: u8 = 0x6d;
+const op_i32_div_u: u8 = 0x6e;
+const op_i32_rem_s: u8 = 0x6f;
+const op_i32_rem_u: u8 = 0x70;
+const op_i32_and: u8 = 0x71;
+const op_i32_or: u8 = 0x72;
+const op_i32_xor: u8 = 0x73;
+
+const Loc = union(enum) {
+    const_i32: i32,
+    runtime,
+};
+
+const Ctrl = struct {
+    label: x64.Masm.Label = .{},
+    else_label: x64.Masm.Label = .{},
+    height: usize,
+    branch_arity: u32,
+    result_arity: u32,
+    kind: Kind,
+
+    const Kind = enum { block, loop, if_then, if_else };
+};
+
+const max_ctrl_depth = 64;
+
+/// Install the SysV half of Spasm's stable call gate. Generated callers pass
+/// the gate as a private ninth argument; the hot path tail-jumps to its current
+/// EntryFn, while the cold path tail-jumps to the existing checked resolver.
+pub fn compileCallGateStub(
+    gpa: std.mem.Allocator,
+    ca: *code_alloc.CodeAllocator,
+    slow_helper: usize,
+    gate_entry_offset: i32,
+) Error!?[]const u8 {
+    var m = x64.Masm.init(gpa);
+    defer m.deinit();
+    var cold: x64.Masm.Label = .{};
+    defer cold.deinit(gpa);
+
+    try m.load64Disp32(.r10, .rsp, 24); // private ninth argument: CallGate*
+    try m.load64Disp32(.r11, .r10, gate_entry_offset);
+    try m.testReg64(.r11, .r11);
+    try m.jumpCond(.equal, &cold);
+    try m.jumpReg(.r11);
+
+    try m.bind(&cold);
+    // Slow helper ABI: rdi already carries the Cell buffer.
+    try m.movReg64(.rsi, .r10);
+    try m.load64Disp32(.rdx, .rsp, 16); // EntryFn execution controller
+    try m.movImm64(.r11, slow_helper);
+    try m.jumpReg(.r11);
+
+    return m.install(ca) catch null;
+}
+
+/// Compile the x86_64 scalar/control core, returning null for every body
+/// outside this backend's current surface. The ordinary wake-flag load is
+/// acquire under TSO, matching the AArch64 backend's LDARB contract.
+pub fn compile(
+    gpa: std.mem.Allocator,
+    ca: *code_alloc.CodeAllocator,
+    func: *const CompiledFunc,
+    ftype: *const FuncType,
+    module: *const Module,
+    funcs: []const CompiledFunc,
+    function_index: u32,
+    config: Config,
+) Error!?[]const u8 {
+    if (func.max_stack > operand_stack_capacity) return null;
+    const num_locals = func.local_types.len;
+    const highest_slot = std.math.add(usize, num_locals, operand_stack_capacity) catch return null;
+    if (highest_slot > @as(usize, std.math.maxInt(i32)) / 16) return null;
+
+    // The first x86 slice is deliberately type-narrow. Wider scalar and SIMD
+    // families refuse before any executable code is published.
+    for (func.local_types) |local_type| if (local_type != .i32) return null;
+    for (ftype.params) |param_type| if (param_type != .i32) return null;
+    for (ftype.results) |result_type| if (result_type != .i32) return null;
+
+    var m = x64.Masm.init(gpa);
+    defer m.deinit();
+
+    var entry: x64.Masm.Label = .{};
+    var epilogue: x64.Masm.Label = .{};
+    var trap_div0: x64.Masm.Label = .{};
+    var trap_overflow: x64.Masm.Label = .{};
+    var trap_stack_exhausted: x64.Masm.Label = .{};
+    defer entry.deinit(gpa);
+    defer epilogue.deinit(gpa);
+    defer trap_div0.deinit(gpa);
+    defer trap_overflow.deinit(gpa);
+    defer trap_stack_exhausted.deinit(gpa);
+    var trap_div0_used = false;
+    var trap_overflow_used = false;
+    var trap_stack_exhausted_used = false;
+
+    try m.bind(&entry);
+    try emitPrologue(&m);
+    try emitExecutionPoll(&m, &epilogue, config.execution_poll_helper, config.wake_flag_offset);
+
+    var stack: [operand_stack_capacity]Loc = undefined;
+    var sp: usize = 0;
+    var ctrl: [max_ctrl_depth]Ctrl = undefined;
+    var ctrl_len: usize = 0;
+    defer for (ctrl[0..ctrl_len]) |*c| {
+        c.label.deinit(gpa);
+        c.else_label.deinit(gpa);
+    };
+
+    const body = func.body;
+    var i: usize = 0;
+    var function_ended = false;
+    body_loop: while (i < body.len) {
+        const op = body[i];
+        i += 1;
+        switch (op) {
+            op_nop => {},
+            op_i32_const => {
+                const value = readSleb32(body, &i) orelse return null;
+                if (sp >= operand_stack_capacity) return null;
+                stack[sp] = .{ .const_i32 = value };
+                sp += 1;
+            },
+            op_drop => {
+                if (sp == 0) return null;
+                sp -= 1;
+            },
+            op_call => {
+                const callee_index = readUleb32(body, &i) orelse return null;
+                const callee = calleeFuncType(module, callee_index) orelse return null;
+                for (callee.params) |param_type| if (param_type != .i32) return null;
+                for (callee.results) |result_type| if (result_type != .i32) return null;
+
+                const param_count = callee.params.len;
+                const result_count = callee.results.len;
+                if (sp < param_count) return null;
+                const below = sp - param_count;
+                if (below + result_count > operand_stack_capacity) return null;
+                const direct_self = callee_index == function_index and func.local_types.len == ftype.params.len;
+                const base_capacity = @max(param_count, result_count);
+                const defined_callee = definedCallee(module, funcs, callee_index);
+                const buffer_capacity = if (defined_callee) |defined| defined.frame_cells else base_capacity;
+                const call_frame_bytes = callFrameBytes(buffer_capacity) orelse return null;
+                const gate_address = if (!direct_self and defined_callee != null)
+                    callGateAddress(config, defined_callee.?)
+                else
+                    null;
+                if (!direct_self and gate_address == null and config.call_helper == null) return null;
+
+                var param_index: usize = 0;
+                while (param_index < param_count) : (param_index += 1) {
+                    const depth = below + param_index;
+                    try materialize(&m, stack[depth], num_locals, depth);
+                }
+
+                if (!(try emitCallStackGuard(&m, &trap_stack_exhausted, call_frame_bytes))) return null;
+                trap_stack_exhausted_used = true;
+                try m.load64Disp32(.r11, .rsp, entry_stack_limit_off);
+                try m.subRegImm32(.rsp, call_frame_bytes);
+                try m.store64Disp32(.rsp, 0, .r11);
+                try m.store64Disp32(.rsp, 8, .rbx);
+
+                param_index = 0;
+                while (param_index < param_count) : (param_index += 1) {
+                    const depth = below + param_index;
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    try m.store64Disp32(.rsp, callBufferOffset(param_index), .rax);
+                    try m.movImm64(.rax, 0);
+                    try m.store64Disp32(.rsp, callBufferOffset(param_index) + 8, .rax);
+                }
+
+                if (gate_address) |gate| {
+                    const defined = defined_callee.?;
+                    var local_index = defined.ftype.params.len;
+                    while (local_index < defined.func.local_types.len) : (local_index += 1) {
+                        try m.movImm64(.rax, 0);
+                        try m.store64Disp32(.rsp, callBufferOffset(local_index), .rax);
+                        try m.store64Disp32(.rsp, callBufferOffset(local_index) + 8, .rax);
+                    }
+                    try m.movImm64(.r11, gate);
+                    try m.store64Disp32(.rsp, 16, .r11);
+                    try m.leaDisp32(.rdi, .rsp, @intCast(call_stack_args_size));
+                    try m.movReg64(.rsi, .rdi);
+                    try m.movReg64(.rdx, .r14);
+                    try m.movReg64(.rcx, .r15);
+                    try m.movReg64(.r8, .rbp);
+                    try m.load64Disp32(.r9, .rsp, @intCast(call_frame_bytes));
+                    try m.movImm64(.r11, config.call_gate_stub.?);
+                    try m.callReg(.r11);
+                } else if (direct_self) {
+                    try m.leaDisp32(.rdi, .rsp, @intCast(call_stack_args_size));
+                    try m.movReg64(.rsi, .rdi);
+                    try m.movReg64(.rdx, .r14);
+                    try m.movReg64(.rcx, .r15);
+                    try m.movReg64(.r8, .rbp);
+                    try m.load64Disp32(.r9, .rsp, @intCast(call_frame_bytes));
+                    try m.call(&entry);
+                } else {
+                    try m.load64Disp32(.rdi, .rsp, @intCast(call_frame_bytes));
+                    try m.movImm64(.rsi, callee_index);
+                    try m.leaDisp32(.rdx, .rsp, @intCast(call_stack_args_size));
+                    try m.movImm64(.rcx, buffer_capacity);
+                    try m.movReg64(.r8, .rbx);
+                    try m.movImm64(.r11, config.call_helper.?);
+                    try m.callReg(.r11);
+                }
+                try m.testReg64(.rax, .rax);
+                var call_ok: x64.Masm.Label = .{};
+                defer call_ok.deinit(gpa);
+                try m.jumpCond(.equal, &call_ok);
+                try m.addRegImm32(.rsp, call_frame_bytes);
+                try m.jump(&epilogue);
+                try m.bind(&call_ok);
+
+                var result_index: usize = 0;
+                while (result_index < result_count) : (result_index += 1) {
+                    try m.load64Disp32(.rax, .rsp, callBufferOffset(result_index));
+                    try m.store64Disp32(.r12, scratchOffset(num_locals, below + result_index), .rax);
+                    stack[below + result_index] = .runtime;
+                }
+                try m.addRegImm32(.rsp, call_frame_bytes);
+                sp = below + result_count;
+            },
+            op_local_get => {
+                const index = readUleb32(body, &i) orelse return null;
+                if (index >= num_locals or sp >= operand_stack_capacity) return null;
+                try m.load32Disp32(.rax, .r12, localOffset(index));
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp), .rax);
+                stack[sp] = .runtime;
+                sp += 1;
+            },
+            op_local_set, op_local_tee => {
+                const index = readUleb32(body, &i) orelse return null;
+                if (index >= num_locals or sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                try m.store64Disp32(.r12, localOffset(index), .rax);
+                if (op == op_local_set) {
+                    sp -= 1;
+                } else {
+                    stack[depth] = .runtime;
+                }
+            },
+            op_i32_eqz => {
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                switch (stack[depth]) {
+                    .const_i32 => |value| stack[depth] = .{ .const_i32 = @intFromBool(value == 0) },
+                    .runtime => {
+                        try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                        try m.cmpRegImm32(.rax, 0);
+                        try m.setCond32(.rax, .equal);
+                        try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                    },
+                }
+            },
+            op_i32_eq,
+            op_i32_ne,
+            op_i32_lt_s,
+            op_i32_lt_u,
+            op_i32_gt_s,
+            op_i32_gt_u,
+            op_i32_le_s,
+            op_i32_le_u,
+            op_i32_ge_s,
+            op_i32_ge_u,
+            => {
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                if (left == .const_i32 and right == .const_i32) {
+                    const a = left.const_i32;
+                    const b = right.const_i32;
+                    const au: u32 = @bitCast(a);
+                    const bu: u32 = @bitCast(b);
+                    stack[sp - 1] = .{ .const_i32 = @intFromBool(switch (op) {
+                        op_i32_eq => a == b,
+                        op_i32_ne => a != b,
+                        op_i32_lt_s => a < b,
+                        op_i32_lt_u => au < bu,
+                        op_i32_gt_s => a > b,
+                        op_i32_gt_u => au > bu,
+                        op_i32_le_s => a <= b,
+                        op_i32_le_u => au <= bu,
+                        op_i32_ge_s => a >= b,
+                        else => au >= bu,
+                    }) };
+                    continue;
+                }
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                try m.cmpReg32(.rax, .rcx);
+                try m.setCond32(.rax, compareCondition(op));
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_i32_add, op_i32_sub, op_i32_mul, op_i32_and, op_i32_or, op_i32_xor => {
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                if (left == .const_i32 and right == .const_i32) {
+                    const a = left.const_i32;
+                    const b = right.const_i32;
+                    stack[sp - 1] = .{ .const_i32 = switch (op) {
+                        op_i32_add => a +% b,
+                        op_i32_sub => a -% b,
+                        op_i32_mul => a *% b,
+                        op_i32_and => a & b,
+                        op_i32_or => a | b,
+                        else => a ^ b,
+                    } };
+                    continue;
+                }
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                switch (op) {
+                    op_i32_add => try m.addReg32(.rax, .rcx),
+                    op_i32_sub => try m.subReg32(.rax, .rcx),
+                    op_i32_mul => try m.imulReg32(.rax, .rcx),
+                    op_i32_and => try m.andReg32(.rax, .rcx),
+                    op_i32_or => try m.orReg32(.rax, .rcx),
+                    else => try m.xorReg32(.rax, .rcx),
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_i32_div_s, op_i32_div_u, op_i32_rem_s, op_i32_rem_u => {
+                if (sp < 2) return null;
+                const divisor = stack[sp - 1];
+                const dividend = stack[sp - 2];
+                sp -= 1;
+                try materialize(&m, dividend, num_locals, sp - 1);
+                try materialize(&m, divisor, num_locals, sp);
+                try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+
+                try m.cmpReg32Imm32(.rcx, 0);
+                try m.jumpCond(.equal, &trap_div0);
+                trap_div0_used = true;
+
+                if (op == op_i32_div_s or op == op_i32_rem_s) {
+                    var ordinary: x64.Masm.Label = .{};
+                    var done: x64.Masm.Label = .{};
+                    defer ordinary.deinit(gpa);
+                    defer done.deinit(gpa);
+
+                    try m.cmpReg32Imm32(.rcx, 0xffff_ffff);
+                    try m.jumpCond(.not_equal, &ordinary);
+                    try m.cmpReg32Imm32(.rax, 0x8000_0000);
+                    try m.jumpCond(.not_equal, &ordinary);
+                    if (op == op_i32_div_s) {
+                        try m.jump(&trap_overflow);
+                        trap_overflow_used = true;
+                    } else {
+                        try m.movImm64(.rax, 0);
+                        try m.jump(&done);
+                    }
+
+                    try m.bind(&ordinary);
+                    try m.signExtendAccumulator32();
+                    try m.idivReg32(.rcx);
+                    if (op == op_i32_rem_s) try m.movReg32(.rax, .rdx);
+                    try m.bind(&done);
+                } else {
+                    try m.xorReg32(.rdx, .rdx);
+                    try m.divReg32(.rcx);
+                    if (op == op_i32_rem_u) try m.movReg32(.rax, .rdx);
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_block => {
+                const arity = readBlockArity(body, &i) orelse return null;
+                if (ctrl_len >= max_ctrl_depth) return null;
+                ctrl[ctrl_len] = .{ .height = sp, .branch_arity = arity, .result_arity = arity, .kind = .block };
+                ctrl_len += 1;
+            },
+            op_loop => {
+                const arity = readBlockArity(body, &i) orelse return null;
+                if (ctrl_len >= max_ctrl_depth) return null;
+                ctrl[ctrl_len] = .{ .height = sp, .branch_arity = 0, .result_arity = arity, .kind = .loop };
+                try m.bind(&ctrl[ctrl_len].label);
+                ctrl_len += 1;
+            },
+            op_if => {
+                if (sp == 0) return null;
+                sp -= 1;
+                const condition = stack[sp];
+                const arity = readBlockArity(body, &i) orelse return null;
+                if (ctrl_len >= max_ctrl_depth) return null;
+                try materialize(&m, condition, num_locals, sp);
+                try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp));
+                try m.cmpRegImm32(.rax, 0);
+                ctrl[ctrl_len] = .{ .height = sp, .branch_arity = arity, .result_arity = arity, .kind = .if_then };
+                try m.jumpCond(.equal, &ctrl[ctrl_len].else_label);
+                ctrl_len += 1;
+            },
+            op_else => {
+                if (ctrl_len == 0) return null;
+                const current = &ctrl[ctrl_len - 1];
+                if (current.kind != .if_then or sp != current.height + current.result_arity) return null;
+                if (!(try materializeRange(&m, stack[0..], num_locals, current.height, current.result_arity))) return null;
+                try m.jump(&current.label);
+                try m.bind(&current.else_label);
+                current.kind = .if_else;
+                sp = current.height;
+            },
+            op_br => {
+                const depth = readUleb32(body, &i) orelse return null;
+                if (depth >= ctrl_len) return null;
+                const target = &ctrl[ctrl_len - 1 - depth];
+                if (sp != target.height + target.branch_arity) return null;
+                if (!(try materializeRange(&m, stack[0..], num_locals, target.height, target.branch_arity))) return null;
+                if (target.kind == .loop) {
+                    try emitExecutionPoll(&m, &epilogue, config.execution_poll_helper, config.wake_flag_offset);
+                }
+                try m.jump(&target.label);
+
+                // The first x86 slice accepts an unconditional terminator only
+                // when it is immediately followed by the current frame's end.
+                // This covers canonical loop backedges without duplicating the
+                // mature AArch64 dead-code skipper.
+                if (ctrl_len == 0 or i >= body.len or body[i] != op_end) return null;
+                i += 1;
+                const current = &ctrl[ctrl_len - 1];
+                if (current.kind == .if_then or current.kind == .if_else) return null;
+                if (current.kind == .block) try m.bind(&current.label);
+                current.label.deinit(gpa);
+                current.else_label.deinit(gpa);
+                sp = current.height + current.result_arity;
+                var result_depth = current.height;
+                while (result_depth < sp) : (result_depth += 1) stack[result_depth] = .runtime;
+                ctrl_len -= 1;
+            },
+            op_br_if => {
+                const depth = readUleb32(body, &i) orelse return null;
+                if (sp == 0 or depth >= ctrl_len) return null;
+                sp -= 1;
+                const condition = stack[sp];
+                const target = &ctrl[ctrl_len - 1 - depth];
+                if (sp != target.height + target.branch_arity) return null;
+                if (!(try materializeRange(&m, stack[0..], num_locals, target.height, target.branch_arity))) return null;
+                try materialize(&m, condition, num_locals, sp);
+                try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp));
+                try m.cmpRegImm32(.rax, 0);
+                if (target.kind == .loop) {
+                    var not_taken: x64.Masm.Label = .{};
+                    defer not_taken.deinit(gpa);
+                    try m.jumpCond(.equal, &not_taken);
+                    try emitExecutionPoll(&m, &epilogue, config.execution_poll_helper, config.wake_flag_offset);
+                    try m.jump(&target.label);
+                    try m.bind(&not_taken);
+                } else {
+                    try m.jumpCond(.not_equal, &target.label);
+                }
+            },
+            op_end => {
+                if (ctrl_len == 0) {
+                    function_ended = true;
+                    break :body_loop;
+                }
+                ctrl_len -= 1;
+                const current = &ctrl[ctrl_len];
+                if (sp != current.height + current.result_arity) return null;
+                if (!(try materializeRange(&m, stack[0..], num_locals, current.height, current.result_arity))) return null;
+                switch (current.kind) {
+                    .block, .if_else => try m.bind(&current.label),
+                    .loop => {},
+                    .if_then => {
+                        try m.bind(&current.label);
+                        try m.bind(&current.else_label);
+                    },
+                }
+                current.label.deinit(gpa);
+                current.else_label.deinit(gpa);
+            },
+            else => return null,
+        }
+    }
+
+    if (!function_ended or ctrl_len != 0 or sp != ftype.results.len) return null;
+    for (ftype.results, 0..) |_, result_index| {
+        try materialize(&m, stack[result_index], num_locals, result_index);
+        try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, result_index));
+        try m.store64Disp32(.r13, resultOffset(result_index), .rax);
+        try m.movImm64(.rcx, 0);
+        try m.store64Disp32(.r13, resultOffset(result_index) + 8, .rcx);
+    }
+
+    try m.movImm64(.rax, 0);
+    try m.jump(&epilogue);
+    if (trap_div0_used) {
+        try m.bind(&trap_div0);
+        try m.movImm64(.rax, config.trap_divide_by_zero);
+        try m.jump(&epilogue);
+    }
+    if (trap_overflow_used) {
+        try m.bind(&trap_overflow);
+        try m.movImm64(.rax, config.trap_int_overflow);
+        try m.jump(&epilogue);
+    }
+    if (trap_stack_exhausted_used) {
+        try m.bind(&trap_stack_exhausted);
+        try m.movImm64(.rax, config.trap_call_stack_exhausted);
+        try m.jump(&epilogue);
+    }
+    try m.bind(&epilogue);
+    try emitEpilogue(&m);
+
+    return m.install(ca) catch null;
+}
+
+fn emitPrologue(m: *x64.Masm) Error!void {
+    // SysV enters with rsp % 16 == 8. Reserving 56 bytes aligns every helper
+    // call while leaving one outgoing stack-argument slot at [rsp+0].
+    try m.subRegImm32(.rsp, frame_size);
+    try m.store64Disp32(.rsp, saved_r12_off, .r12);
+    try m.store64Disp32(.rsp, saved_r13_off, .r13);
+    try m.store64Disp32(.rsp, saved_r14_off, .r14);
+    try m.store64Disp32(.rsp, saved_r15_off, .r15);
+    try m.store64Disp32(.rsp, saved_rbx_off, .rbx);
+    try m.store64Disp32(.rsp, saved_rbp_off, .rbp);
+    try m.movReg64(.r12, .rdi); // locals + operand scratch cells
+    try m.movReg64(.r13, .rsi); // results
+    try m.movReg64(.r14, .rdx); // memory base (reserved for the next slice)
+    try m.movReg64(.r15, .rcx); // memory length
+    try m.movReg64(.rbp, .r8); // globals base (reserved for the next slice)
+    try m.store64Disp32(.rsp, 0, .r9); // instance for checked call helpers
+    try m.load64Disp32(.rbx, .rsp, entry_execution_control_off);
+}
+
+fn emitEpilogue(m: *x64.Masm) Error!void {
+    try m.load64Disp32(.r12, .rsp, saved_r12_off);
+    try m.load64Disp32(.r13, .rsp, saved_r13_off);
+    try m.load64Disp32(.r14, .rsp, saved_r14_off);
+    try m.load64Disp32(.r15, .rsp, saved_r15_off);
+    try m.load64Disp32(.rbx, .rsp, saved_rbx_off);
+    try m.load64Disp32(.rbp, .rsp, saved_rbp_off);
+    try m.addRegImm32(.rsp, frame_size);
+    try m.ret();
+}
+
+fn emitExecutionPoll(
+    m: *x64.Masm,
+    epilogue: *x64.Masm.Label,
+    poll_helper: usize,
+    wake_flag_offset: i32,
+) Error!void {
+    var done: x64.Masm.Label = .{};
+    defer done.deinit(m.gpa);
+
+    try m.testReg64(.rbx, .rbx);
+    try m.jumpCond(.equal, &done);
+    try m.load64Disp32(.r11, .rbx, wake_flag_offset);
+    try m.load8Disp32(.rax, .r11, 0);
+    try m.testReg64(.rax, .rax);
+    try m.jumpCond(.equal, &done);
+
+    try m.movReg64(.rdi, .rbx);
+    try m.movImm64(.r11, poll_helper);
+    try m.callReg(.r11);
+    try m.testReg64(.rax, .rax);
+    try m.jumpCond(.not_equal, epilogue);
+    try m.bind(&done);
+}
+
+fn materialize(m: *x64.Masm, loc: Loc, num_locals: usize, depth: usize) Error!void {
+    switch (loc) {
+        .runtime => {},
+        .const_i32 => |value| {
+            try m.movImm64(.rax, @as(u32, @bitCast(value)));
+            try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+        },
+    }
+}
+
+fn materializeRange(
+    m: *x64.Masm,
+    stack: []Loc,
+    num_locals: usize,
+    start: usize,
+    count: u32,
+) Error!bool {
+    if (start > stack.len) return false;
+    var depth = start;
+    const end = std.math.add(usize, start, count) catch return false;
+    if (end > stack.len) return false;
+    while (depth < end) : (depth += 1) {
+        try materialize(m, stack[depth], num_locals, depth);
+        stack[depth] = .runtime;
+    }
+    return true;
+}
+
+fn compareCondition(op: u8) x64.Cond {
+    return switch (op) {
+        op_i32_eq => .equal,
+        op_i32_ne => .not_equal,
+        op_i32_lt_s => .less,
+        op_i32_lt_u => .below,
+        op_i32_gt_s => .greater,
+        op_i32_gt_u => .above,
+        op_i32_le_s => .less_or_equal,
+        op_i32_le_u => .below_or_equal,
+        op_i32_ge_s => .greater_or_equal,
+        else => .above_or_equal,
+    };
+}
+
+fn localOffset(index: usize) i32 {
+    return @intCast(index * 16);
+}
+
+fn scratchOffset(num_locals: usize, depth: usize) i32 {
+    return @intCast((num_locals + depth) * 16);
+}
+
+fn resultOffset(index: usize) i32 {
+    return @intCast(index * 16);
+}
+
+fn callBufferOffset(index: usize) i32 {
+    return @intCast(call_stack_args_size + index * 16);
+}
+
+fn callFrameBytes(buffer_cells: usize) ?u32 {
+    const buffer_bytes = std.math.mul(usize, buffer_cells, 16) catch return null;
+    const total = std.math.add(usize, call_stack_args_size, buffer_bytes) catch return null;
+    if (total > max_call_frame_bytes) return null;
+    return @intCast(total);
+}
+
+fn emitCallStackGuard(
+    m: *x64.Masm,
+    trap: *x64.Masm.Label,
+    call_frame_bytes: u32,
+) Error!bool {
+    const projected_bytes = std.math.add(u32, call_frame_bytes, native_entry_stack_bytes) catch
+        return false;
+    try m.leaDisp32(.r10, .rsp, -@as(i32, @intCast(projected_bytes)));
+    try m.load64Disp32(.r11, .rsp, entry_stack_limit_off);
+    try m.cmpReg64(.r10, .r11);
+    try m.jumpCond(.below_or_equal, trap);
+    return true;
+}
+
+fn calleeFuncType(module: *const Module, func_index: u32) ?*const FuncType {
+    var seen: u32 = 0;
+    for (module.imports) |import| {
+        if (import.desc != .func) continue;
+        if (seen == func_index) {
+            const type_index = import.desc.func;
+            if (type_index >= module.types.len) return null;
+            return &module.types[type_index];
+        }
+        seen += 1;
+    }
+    if (func_index < seen) return null;
+    const local_index: usize = func_index - seen;
+    if (local_index >= module.funcs.len) return null;
+    const type_index = module.funcs[local_index];
+    if (type_index >= module.types.len) return null;
+    return &module.types[type_index];
+}
+
+const DefinedCallee = struct {
+    func: *const CompiledFunc,
+    ftype: *const FuncType,
+    local_index: usize,
+    frame_cells: usize,
+};
+
+fn definedCallee(
+    module: *const Module,
+    funcs: []const CompiledFunc,
+    func_index: u32,
+) ?DefinedCallee {
+    var imported_count: u32 = 0;
+    for (module.imports) |import| {
+        if (import.desc == .func) imported_count += 1;
+    }
+    if (func_index < imported_count) return null;
+    const local_index: usize = @intCast(func_index - imported_count);
+    if (local_index >= funcs.len) return null;
+    const callee = &funcs[local_index];
+    if (callee.type_index >= module.types.len) return null;
+    const callee_type = &module.types[callee.type_index];
+    const locals_and_scratch = std.math.add(usize, callee.local_types.len, operand_stack_capacity) catch return null;
+    return .{
+        .func = callee,
+        .ftype = callee_type,
+        .local_index = local_index,
+        .frame_cells = @max(locals_and_scratch, callee_type.results.len),
+    };
+}
+
+fn callGateAddress(config: Config, callee: DefinedCallee) ?usize {
+    const stub = config.call_gate_stub orelse return null;
+    _ = stub;
+    const base = config.call_gates_base orelse return null;
+    if (callee.local_index >= config.call_gates_len) return null;
+    for (callee.func.local_types) |local_type| if (local_type != .i32) return null;
+    const offset = std.math.mul(usize, callee.local_index, config.call_gate_stride) catch return null;
+    return std.math.add(usize, base, offset) catch null;
+}
+
+fn readBlockArity(body: []const u8, index: *usize) ?u32 {
+    if (index.* >= body.len) return null;
+    return switch (body[index.*]) {
+        0x40 => blk: {
+            index.* += 1;
+            break :blk 0;
+        },
+        0x7f => blk: {
+            index.* += 1;
+            break :blk 1;
+        },
+        else => null,
+    };
+}
+
+fn readUleb32(body: []const u8, index: *usize) ?u32 {
+    var result: u64 = 0;
+    var shift: u6 = 0;
+    while (index.* < body.len) {
+        const byte = body[index.*];
+        index.* += 1;
+        result |= @as(u64, byte & 0x7f) << shift;
+        if (byte & 0x80 == 0) return std.math.cast(u32, result);
+        shift += 7;
+        if (shift >= 35) return null;
+    }
+    return null;
+}
+
+fn readSleb32(body: []const u8, index: *usize) ?i32 {
+    var result: i64 = 0;
+    var shift: u6 = 0;
+    while (index.* < body.len) {
+        const byte = body[index.*];
+        index.* += 1;
+        result |= @as(i64, byte & 0x7f) << shift;
+        if (byte & 0x80 == 0) {
+            if (shift < 63 and (byte & 0x40) != 0) {
+                result |= @as(i64, -1) << (shift + 7);
+            }
+            if (result < std.math.minInt(i32) or result > std.math.maxInt(i32)) return null;
+            return @intCast(result);
+        }
+        shift += 7;
+        if (shift >= 35) return null;
+    }
+    return null;
+}

--- a/src/runtime/wasm/spasm_x86_64.zig
+++ b/src/runtime/wasm/spasm_x86_64.zig
@@ -286,7 +286,7 @@ pub fn compile(
                     try m.movImm64(.r11, config.call_helper.?);
                     try m.callReg(.r11);
                 }
-                try m.testReg64(.rax, .rax);
+                try m.cmpReg32Imm32(.rax, 0);
                 var call_ok: x64.Masm.Label = .{};
                 defer call_ok.deinit(gpa);
                 try m.jumpCond(.equal, &call_ok);
@@ -642,13 +642,13 @@ fn emitExecutionPoll(
     try m.jumpCond(.equal, &done);
     try m.load64Disp32(.r11, .rbx, wake_flag_offset);
     try m.load8Disp32(.rax, .r11, 0);
-    try m.testReg64(.rax, .rax);
+    try m.cmpReg32Imm32(.rax, 0);
     try m.jumpCond(.equal, &done);
 
     try m.movReg64(.rdi, .rbx);
     try m.movImm64(.r11, poll_helper);
     try m.callReg(.r11);
-    try m.testReg64(.rax, .rax);
+    try m.cmpReg32Imm32(.rax, 0);
     try m.jumpCond(.not_equal, epilogue);
     try m.bind(&done);
 }

--- a/src/runtime/wasm/tests.zig
+++ b/src/runtime/wasm/tests.zig
@@ -399,7 +399,7 @@ test "wasm decoder: decodes a full adder module" {
 }
 
 test "wasm spasm: a compilable function runs Spasm-compiled with an identical result" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + adder_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &adder_body);
 
@@ -430,7 +430,7 @@ test "wasm spasm: a compilable function runs Spasm-compiled with an identical re
 }
 
 test "wasm spasm: the per-function code cache compiles once across repeated invokes" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + adder_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &adder_body);
 
@@ -475,7 +475,7 @@ const div_s_body = [_]u8{
 };
 
 test "wasm spasm: i32.div_s compiles and runs Spasm-compiled" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + div_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &div_s_body);
 
@@ -512,7 +512,7 @@ test "wasm spasm: a direct call to a leaf function runs Spasm-compiled" {
     // the callee inline, so `spasm_runs` stayed 0. With the direct-call
     // ABI, "main" runs via Spasm and the leaf enters its cached native
     // EntryFn without re-entering `invoke`.
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -569,8 +569,8 @@ test "wasm spasm: a direct call to a leaf function runs Spasm-compiled" {
     try testing.expectEqual(@as(u32, 25), @as(u32, @truncate(warm_res[0])));
     try testing.expectEqual(@as(u32, 1), instance.spasm_native_calls);
 
-    // The warm gate carries the armed execution controller in x7 while its
-    // stable gate record lives in x8. Both main and square poll at entry.
+    // The warm gate carries both the armed execution controller and its stable
+    // gate record through the backend's private ABI. Both functions poll at entry.
     var control: CountingExecutionControl = .{};
     instance.execution_control = control.control();
     const metered_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
@@ -592,12 +592,76 @@ test "wasm spasm: a direct call to a leaf function runs Spasm-compiled" {
     try testing.expectEqual(native_calls_before, instance.spasm_native_calls);
 }
 
+test "wasm spasm: x86 cold gate preserves interpreter fallback for a refused callee" {
+    const spasm = @import("spasm.zig");
+    if (comptime !spasm.supported or spasm.full_coverage_supported) return error.SkipZigTest;
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Both functions have the x86-qualified i32 signature. The caller is
+    // emittable, while the callee's i32.rotl remains outside the x86 subset.
+    // Its cold stable gate must resolve through Sarcasm without publishing a
+    // bogus native entry or changing the result.
+    const tbody = [_]u8{ 0x01, 0x60, 0x01, 0x7f, 0x01, 0x7f };
+    const fbody = [_]u8{ 0x02, 0x00, 0x00 };
+    const xbody = [_]u8{ 0x01, 0x04, 'm', 'a', 'i', 'n', 0x00, 0x00 };
+    const cbody = [_]u8{
+        0x02,
+        0x06,
+        0x00,
+        0x20,
+        0x00,
+        0x10,
+        0x01,
+        0x0b,
+        0x07,
+        0x00,
+        0x20,
+        0x00,
+        0x41,
+        0x01,
+        0x77,
+        0x0b,
+    };
+    const bytes = try assemble(a, &.{
+        .{ .id = 1, .body = &tbody },
+        .{ .id = 3, .body = &fbody },
+        .{ .id = 7, .body = &xbody },
+        .{ .id = 10, .body = &cbody },
+    });
+
+    const m = try wasm.decode(a, bytes);
+    const mp = try a.create(wasm.Module);
+    mp.* = m;
+
+    var instance: interp.Instance = undefined;
+    try interp.instantiate(&instance, a, testing.allocator, mp, .{});
+    defer instance.deinit();
+    instance.spasm_enabled = true;
+
+    const fidx = funcExport(mp, "main") orelse return error.NoSuchExport;
+    const cells = try a.alloc(u128, 1);
+    cells[0] = 21;
+
+    var invocation: usize = 0;
+    while (invocation < 2) : (invocation += 1) {
+        const result = try interp.invoke(&instance, testing.allocator, fidx, cells);
+        defer testing.allocator.free(result);
+        try testing.expectEqual(@as(u32, 42), @as(u32, @truncate(result[0])));
+    }
+    try testing.expectEqual(@as(u32, 2), instance.spasm_runs);
+    try testing.expectEqual(@as(u32, 1), instance.spasm_compiles);
+    try testing.expectEqual(@as(u32, 0), instance.spasm_native_calls);
+}
+
 test "wasm spasm: warm mutually recursive calls use same-instance native links" {
     // §4.4.1 / §5.4.1 — `even(n)` and `odd(n)` call one another. Unlike a
     // self-recursive BL, each edge needs a stable target entry that survives
     // the lazy compilation order. The first invocation may visit the cold
     // helper while it compiles `odd`; after that, no recursive edge may do so.
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -693,7 +757,7 @@ test "wasm spasm: a warm native link reinitializes declared callee locals" {
     // initial value, then writes 42 into it. The cold helper initializes the
     // first frame; the second call reuses the native stack area and proves the
     // hot gate emits the same zero-initialization before entering the target.
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -766,7 +830,7 @@ test "wasm spasm: a call with a live operand under the args runs Spasm-compiled"
     // live operand below the args across the helper call and reload it
     // after, then `i32.add` it to the result. Before this, a deeper-than-
     // arity stack at a call degraded to the interpreter.
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -825,7 +889,7 @@ test "wasm spasm: a constant under an if/else with calls in both arms is not cor
     // else-arm, whose path never ran the `mov`, so main(0) would read a
     // garbage "7". The const must stay a const, re-materialized after the
     // call on whichever arm runs. main(0) == 7 (else), main(1) == 8 (then).
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1051,7 +1115,7 @@ test "wasm spasm: a self-recursive call traps CallStackExhausted, never crashes"
     //   ...
     // Simpler shape: `local.get 0; if (result i32) ... else 0 end`. We
     // hand-assemble: if n==0 return 0, else return f(n-1).
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -5169,7 +5233,7 @@ test "wasm spasm: an imported call keeps the generic invocation boundary" {
 }
 
 test "wasm spasm: imported execution control reaches a cold native callee" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -5217,7 +5281,7 @@ test "wasm spasm: imported execution control reaches a cold native callee" {
 }
 
 test "wasm spasm: an interrupt raised after native entry stops the next backedge" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();

--- a/src/runtime/wasm/tests.zig
+++ b/src/runtime/wasm/tests.zig
@@ -399,7 +399,7 @@ test "wasm decoder: decodes a full adder module" {
 }
 
 test "wasm spasm: a compilable function runs Spasm-compiled with an identical result" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + adder_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &adder_body);
 
@@ -430,7 +430,7 @@ test "wasm spasm: a compilable function runs Spasm-compiled with an identical re
 }
 
 test "wasm spasm: the per-function code cache compiles once across repeated invokes" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + adder_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &adder_body);
 
@@ -475,7 +475,7 @@ const div_s_body = [_]u8{
 };
 
 test "wasm spasm: i32.div_s compiles and runs Spasm-compiled" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + div_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &div_s_body);
 
@@ -512,7 +512,7 @@ test "wasm spasm: a direct call to a leaf function runs Spasm-compiled" {
     // the callee inline, so `spasm_runs` stayed 0. With the direct-call
     // ABI, "main" runs via Spasm and the leaf enters its cached native
     // EntryFn without re-entering `invoke`.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -597,7 +597,7 @@ test "wasm spasm: warm mutually recursive calls use same-instance native links" 
     // self-recursive BL, each edge needs a stable target entry that survives
     // the lazy compilation order. The first invocation may visit the cold
     // helper while it compiles `odd`; after that, no recursive edge may do so.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -693,7 +693,7 @@ test "wasm spasm: a warm native link reinitializes declared callee locals" {
     // initial value, then writes 42 into it. The cold helper initializes the
     // first frame; the second call reuses the native stack area and proves the
     // hot gate emits the same zero-initialization before entering the target.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -766,7 +766,7 @@ test "wasm spasm: a call with a live operand under the args runs Spasm-compiled"
     // live operand below the args across the helper call and reload it
     // after, then `i32.add` it to the result. Before this, a deeper-than-
     // arity stack at a call degraded to the interpreter.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -825,7 +825,7 @@ test "wasm spasm: a constant under an if/else with calls in both arms is not cor
     // else-arm, whose path never ran the `mov`, so main(0) would read a
     // garbage "7". The const must stay a const, re-materialized after the
     // call on whichever arm runs. main(0) == 7 (else), main(1) == 8 (then).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -891,7 +891,7 @@ test "wasm spasm: call_indirect dispatches through a table, runs Spasm-compiled"
     // `add10`, so main(x) == x + 10. The index is the top operand (consumed);
     // the arg sits under it. A Spasm `call_indirect` resolves the element +
     // type via a native helper, then dispatches like a direct call.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -956,7 +956,7 @@ test "wasm spasm: ref.is_null folds ref.null to 1 and ref.func to 0, runs Spasm-
     // reference value materialized. Both functions return i32, so the body
     // never has to place a reference into a runtime location; the slice
     // stays inside the scalar operand bank.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1051,7 +1051,7 @@ test "wasm spasm: a self-recursive call traps CallStackExhausted, never crashes"
     //   ...
     // Simpler shape: `local.get 0; if (result i32) ... else 0 end`. We
     // hand-assemble: if n==0 return 0, else return f(n-1).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1147,7 +1147,7 @@ fn runSpasmDiv(a_alloc: std.mem.Allocator, arg_a: u32, arg_b: u32) ![]u128 {
 }
 
 test "wasm spasm: i32.div_s by zero raises a catchable divide-by-zero trap" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     // The Spasm-compiled body's explicit b==0 check (AArch64 sdiv would
@@ -1156,7 +1156,7 @@ test "wasm spasm: i32.div_s by zero raises a catchable divide-by-zero trap" {
 }
 
 test "wasm spasm: i32.div_s INT_MIN / -1 raises a catchable integer-overflow trap" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     // INT_MIN / -1 overflows i32; AArch64 sdiv returns INT_MIN, so the
@@ -1185,7 +1185,7 @@ const mem_module_body = [_]u8{
 };
 
 test "wasm spasm: i32.load compiles and reads linear memory" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + mem_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &mem_module_body);
 
@@ -1226,7 +1226,7 @@ fn setupMemModule(instance: *interp.Instance, a: std.mem.Allocator, bytes: []con
 }
 
 test "wasm spasm: i32.store compiles and writes linear memory" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + mem_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &mem_module_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1251,7 +1251,7 @@ test "wasm spasm: i32.store compiles and writes linear memory" {
 }
 
 test "wasm spasm: an out-of-bounds load raises a catchable trap" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + mem_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &mem_module_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1294,7 +1294,7 @@ const subwidth_module_body = [_]u8{
 };
 
 test "wasm spasm: i32.load8_u compiles and zero-extends a byte" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + subwidth_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &subwidth_module_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1338,7 +1338,7 @@ const memfill_body = [_]u8{
 };
 
 test "wasm spasm: memory.fill writes the byte range, then loads it back" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + memfill_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &memfill_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1381,7 +1381,7 @@ const memcopy_body = [_]u8{
 };
 
 test "wasm spasm: memory.copy moves a byte range" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + memcopy_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &memcopy_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -1418,7 +1418,7 @@ test "wasm spasm: memory.init copies from a passive data segment, then data.drop
     //            then loads the byte at offset x — proving the copy landed.
     //   "dr"():  data.drop 0, then returns 42 — proving the op compiled.
     // Both must run Spasm-compiled (spasm_runs counts each compiled entry).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1499,7 +1499,7 @@ test "wasm spasm: table.size returns the table length" {
     // table 0 as i32. The module declares a funcref table with min 3 and
     // no element segment, so the size is exactly 3. "sz"() must run
     // Spasm-compiled (spasm_runs counts each compiled entry).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1561,7 +1561,7 @@ test "wasm spasm: table.init then table.copy populate the table, then elem.drop 
     //   "again"(): a fresh table.init of length 2 — after "go" dropped the
     //           segment it now traps OutOfBoundsTableAccess, proving the drop.
     // Both must run Spasm-compiled (spasm_runs counts each compiled entry).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1668,7 +1668,7 @@ test "wasm spasm: table.get reads a runtime funcref, ref.is_null inspects it" {
     // filling table[0] with `ref.func 0` (the defined function `dummy`),
     // leaving table[1] null. So main(0) == 0 (populated, non-null) and
     // main(1) == 1 (null) — the same the interpreter gives.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1744,7 +1744,7 @@ test "wasm spasm: table.set writes a funcref, then call_indirect dispatches thro
     //       table[1] with table.set, then call_indirect table[1](5) == 15 —
     //       proving the runtime-.ref write path too.
     // Both must run Spasm-compiled (spasm_runs counts each compiled entry).
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -1860,7 +1860,7 @@ test "wasm spasm: reference locals round-trip through local.get/set/tee, declare
     //       so uninit() == 1. This pins the declared-ref-local zero-vs-null
     //       initialization: a zeroed (not all-ones) cell would wrongly read
     //       as non-null and return 0.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -2024,7 +2024,7 @@ test "wasm spasm: typed select picks a reference operand by the condition" {
     //   seltrt(cond): a RUNTIME `.ref` first operand (read with table.get) vs
     //       `ref.null func`, proving the slot-copy path. cond != 0 ->
     //       is_null(table[0]) 0; cond == 0 -> is_null(null) 1.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -2126,7 +2126,7 @@ test "wasm spasm: table.set out of bounds raises a catchable trap" {
     // §4.4.x table.set traps OutOfBoundsTableAccess when the index is past the
     // table — the same the interpreter gives. "oob"() writes ref.func 0 at
     // index 9 of a min-2 table.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -2179,7 +2179,7 @@ test "wasm spasm: table.grow grows the table and returns the previous size" {
     // leaf (no call), so `spasm_runs >= 1` is a true signal that `table.grow`
     // compiled — not an unrelated function inflating the counter. The grown
     // slot's content (the `init` funcref) is checked directly from Zig.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -2244,7 +2244,7 @@ test "wasm spasm: table.fill fills a range, observed via call_indirect" {
     //   "fill"(): i32.const 1; ref.func 0; i32.const 2; table.fill 0 — fills
     //       table[1] and table[2] with add10; then call_indirect through
     //       table[2] with arg 5 → add10(5) == 15, observing the fill landed.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -2305,7 +2305,7 @@ const memsize_body = [_]u8{
 };
 
 test "wasm spasm: memory.size returns the page count" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + memsize_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &memsize_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2336,7 +2336,7 @@ const memgrow_body = [_]u8{
 };
 
 test "wasm spasm: memory.grow grows the memory and returns the previous page count" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + memgrow_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &memgrow_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2369,7 +2369,7 @@ const i32_rotl_body = [_]u8{
 };
 
 test "wasm spasm: i32.rotl rotates left via RORV by (32 - count)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_rotl_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_rotl_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2405,7 +2405,7 @@ const i32_rotr_body = [_]u8{
 };
 
 test "wasm spasm: i32.rotr rotates right via RORV" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_rotr_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_rotr_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2434,7 +2434,7 @@ test "wasm spasm: i32.rotr rotates right via RORV" {
 }
 
 test "wasm spasm: i32.load8_s sign-extends a byte" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + subwidth_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &subwidth_module_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2459,7 +2459,7 @@ test "wasm spasm: i32.load8_s sign-extends a byte" {
 }
 
 test "wasm spasm: i32.store8 writes only the low byte" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + subwidth_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &subwidth_module_body);
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
@@ -2495,7 +2495,7 @@ const i64_add_body = [_]u8{
 };
 
 test "wasm spasm: i64.add compiles and runs Spasm-compiled (full 64-bit)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_add_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_add_body);
 
@@ -2534,7 +2534,7 @@ const i64_lt_s_body = [_]u8{
 };
 
 test "wasm spasm: i64.lt_s compiles and compares the full 64 bits" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_lt_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_lt_s_body);
 
@@ -2593,7 +2593,7 @@ fn runSpasmI64Div(a_alloc: std.mem.Allocator, arg_a: u64, arg_b: u64) ![]u128 {
 }
 
 test "wasm spasm: i64.div_s compiles and divides the full 64 bits" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_div_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_div_s_body);
 
@@ -2623,7 +2623,7 @@ test "wasm spasm: i64.div_s compiles and divides the full 64 bits" {
 }
 
 test "wasm spasm: i64.div_s by zero raises a catchable trap" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     try testing.expectError(error.IntegerDivideByZero, runSpasmI64Div(arena.allocator(), 5, 0));
@@ -2649,7 +2649,7 @@ const i64_mem_module_body = [_]u8{
 };
 
 test "wasm spasm: i64.load compiles and reads eight bytes" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_mem_module_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_mem_module_body);
 
@@ -2687,7 +2687,7 @@ const i64_extend_body = [_]u8{
 };
 
 test "wasm spasm: i64.extend_i32_s sign-extends a negative i32" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_extend_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_extend_body);
 
@@ -2725,7 +2725,7 @@ const f64_add_body = [_]u8{
 };
 
 test "wasm spasm: f64.add compiles and runs Spasm-compiled" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_add_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_add_body);
 
@@ -2764,7 +2764,7 @@ const f64_sqrt_body = [_]u8{
 };
 
 test "wasm spasm: f64.sqrt compiles and runs in the FP unit" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_sqrt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_sqrt_body);
 
@@ -2801,7 +2801,7 @@ const f64_min_body = [_]u8{
 };
 
 test "wasm spasm: f64.min compiles and runs in the FP unit" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_min_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_min_body);
 
@@ -2839,7 +2839,7 @@ const f64_copysign_body = [_]u8{
 };
 
 test "wasm spasm: f64.copysign combines magnitude and sign by bit ops" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_copysign_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_copysign_body);
 
@@ -2878,7 +2878,7 @@ const reinterpret_body = [_]u8{
 };
 
 test "wasm spasm: i32.reinterpret_f32 passes the bits through" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + reinterpret_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &reinterpret_body);
 
@@ -2915,7 +2915,7 @@ const promote_body = [_]u8{
 };
 
 test "wasm spasm: f64.promote_f32 widens via FCVT" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + promote_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &promote_body);
 
@@ -2952,7 +2952,7 @@ const demote_body = [_]u8{
 };
 
 test "wasm spasm: f32.demote_f64 narrows via FCVT" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + demote_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &demote_body);
 
@@ -2989,7 +2989,7 @@ const convert_i32_s_body = [_]u8{
 };
 
 test "wasm spasm: f64.convert_i32_s widens a signed i32 via SCVTF" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + convert_i32_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i32_s_body);
 
@@ -3027,7 +3027,7 @@ const convert_i32_u_body = [_]u8{
 };
 
 test "wasm spasm: f32.convert_i32_u widens an unsigned i32 via UCVTF" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + convert_i32_u_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i32_u_body);
 
@@ -3064,7 +3064,7 @@ const convert_i64_s_body = [_]u8{
 };
 
 test "wasm spasm: f64.convert_i64_s widens a signed i64 via SCVTF (X-form)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + convert_i64_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i64_s_body);
 
@@ -3102,7 +3102,7 @@ const trunc_sat_s_body = [_]u8{
 };
 
 test "wasm spasm: i32.trunc_sat_f32_s saturates out-of-range via FCVTZS" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + trunc_sat_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &trunc_sat_s_body);
 
@@ -3140,7 +3140,7 @@ const trunc_sat_u_body = [_]u8{
 };
 
 test "wasm spasm: i64.trunc_sat_f64_u maps NaN to zero via FCVTZU" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + trunc_sat_u_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &trunc_sat_u_body);
 
@@ -3195,7 +3195,7 @@ fn truncTrapInstance(a: std.mem.Allocator, mp: **wasm.Module) !interp.Instance {
 }
 
 test "wasm spasm: i32.trunc_f32_s converts an in-range value via FCVTZS" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3216,7 +3216,7 @@ test "wasm spasm: i32.trunc_f32_s converts an in-range value via FCVTZS" {
 }
 
 test "wasm spasm: i32.trunc_f32_s traps on NaN (invalid conversion)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3234,7 +3234,7 @@ test "wasm spasm: i32.trunc_f32_s traps on NaN (invalid conversion)" {
 }
 
 test "wasm spasm: i32.trunc_f32_s traps on overflow (out of range)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3259,7 +3259,7 @@ const i32_clz_body = [_]u8{
 };
 
 test "wasm spasm: i32.clz counts leading zeros via CLZ" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_clz_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_clz_body);
 
@@ -3296,7 +3296,7 @@ const i32_ctz_body = [_]u8{
 };
 
 test "wasm spasm: i32.ctz counts trailing zeros via RBIT+CLZ" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_ctz_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_ctz_body);
 
@@ -3333,7 +3333,7 @@ const i64_clz_body = [_]u8{
 };
 
 test "wasm spasm: i64.clz counts leading zeros via CLZ (X-form)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_clz_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_clz_body);
 
@@ -3370,7 +3370,7 @@ const i32_extend8_body = [_]u8{
 };
 
 test "wasm spasm: i32.extend8_s sign-extends the low byte via SXTB" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_extend8_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_extend8_body);
 
@@ -3407,7 +3407,7 @@ const i64_extend32_body = [_]u8{
 };
 
 test "wasm spasm: i64.extend32_s sign-extends the low word via SXTW" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_extend32_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_extend32_body);
 
@@ -3444,7 +3444,7 @@ const i32_popcnt_body = [_]u8{
 };
 
 test "wasm spasm: i32.popcnt counts set bits via CNT+ADDV" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i32_popcnt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i32_popcnt_body);
 
@@ -3481,7 +3481,7 @@ const i64_popcnt_body = [_]u8{
 };
 
 test "wasm spasm: i64.popcnt counts set bits via CNT+ADDV (X-form)" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + i64_popcnt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &i64_popcnt_body);
 
@@ -3521,7 +3521,7 @@ const global_get_body = [_]u8{
 };
 
 test "wasm spasm: global.get reads the instance global" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + global_get_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &global_get_body);
 
@@ -3558,7 +3558,7 @@ const global_set_body = [_]u8{
 };
 
 test "wasm spasm: global.set then global.get round-trips" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + global_set_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &global_set_body);
 
@@ -3596,7 +3596,7 @@ const f64_lt_body = [_]u8{
 };
 
 test "wasm spasm: f64.lt compiles and compares in the FP unit" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_lt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_lt_body);
 
@@ -3635,7 +3635,7 @@ const f64_load_body = [_]u8{
 };
 
 test "wasm spasm: f64.load reads an eight-byte double" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f64_load_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_load_body);
 
@@ -3672,7 +3672,7 @@ const f32_add_body = [_]u8{
 };
 
 test "wasm spasm: f32.add compiles and runs Spasm-compiled" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f32_add_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f32_add_body);
 
@@ -3711,7 +3711,7 @@ const f32_sqrt_body = [_]u8{
 };
 
 test "wasm spasm: f32.sqrt compiles and runs in the FP unit" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var buf: [8 + f32_sqrt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f32_sqrt_body);
 
@@ -5102,7 +5102,7 @@ test "wasm spasm: an imported call keeps the generic invocation boundary" {
     // the compact call buffer coincidentally as large as a leaf EntryFn's
     // scratch requirement, so this proves direct entry is gated on instance
     // identity rather than buffer capacity alone.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -5169,7 +5169,7 @@ test "wasm spasm: an imported call keeps the generic invocation boundary" {
 }
 
 test "wasm spasm: imported execution control reaches a cold native callee" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -5217,7 +5217,7 @@ test "wasm spasm: imported execution control reaches a cold native callee" {
 }
 
 test "wasm spasm: an interrupt raised after native entry stops the next backedge" {
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -6616,7 +6616,7 @@ test "wasm spasm: i32x4.add of two v128.const vectors, stored and lane-read, run
     // `i32.load` and returns it. `i32x4.extract_lane` is out of scope, so
     // the store+scalar-load round-trip is how the test observes one lane.
     // [1,2,3,4] + [10,20,30,40] = [11,22,33,44]; lane 1 = 2+20 = 22.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
@@ -6701,7 +6701,7 @@ test "wasm spasm: a v128 param flows through a local and out as the result, Spas
     // whole 128-bit value must round-trip unchanged. A v128 param seeds its
     // cell from the args buffer; `local.get` copies cell→operand-slot; the
     // epilogue copies the result operand's cell back to the results buffer.
-    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
 
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();

--- a/tools/wasm_testsuite.zig
+++ b/tools/wasm_testsuite.zig
@@ -15,7 +15,8 @@
 //!
 //! Usage:
 //!   zig build wasm-testsuite -- [--gen-dir=<dir>] [--filter=<s>]
-//!                               [--quiet] [--write-results]
+//!                               [--quiet] [--write-results] [--spasm]
+//!                               [--require-spasm-entry]
 
 const std = @import("std");
 const cynic = @import("cynic");
@@ -28,11 +29,15 @@ const Counts = struct {
     pass: u32 = 0,
     fail: u32 = 0,
     skip: u32 = 0,
+    spasm_runs: u64 = 0,
+    spasm_compiles: u64 = 0,
 
     fn add(self: *Counts, other: Counts) void {
         self.pass += other.pass;
         self.fail += other.fail;
         self.skip += other.skip;
+        self.spasm_runs += other.spasm_runs;
+        self.spasm_compiles += other.spasm_compiles;
     }
 };
 
@@ -47,6 +52,10 @@ const Options = struct {
     /// default interpreter run: that diff is the goes-live correctness
     /// gate (compilable functions run native, everything else degrades).
     spasm: bool = false,
+    /// Fail unless a forced-Spasm run actually enters generated code. Semantic
+    /// parity alone is insufficient because an all-interpreter fallback can
+    /// produce the same pass set while leaving the native tier broken.
+    require_spasm_entry: bool = false,
     /// Headline floor. Exit 2 if `pass%` falls below it (0 = no gate).
     /// Mirrors the test262 harness so CI can gate the Sarcasm engine.
     min_pass_pct: f64 = 0.0,
@@ -71,12 +80,19 @@ pub fn main(init: std.process.Init) !void {
                 opts.write_results = true;
             } else if (std.mem.eql(u8, a, "--spasm")) {
                 opts.spasm = true;
+            } else if (std.mem.eql(u8, a, "--require-spasm-entry")) {
+                opts.require_spasm_entry = true;
             } else if (std.mem.startsWith(u8, a, "--min-pass-pct=")) {
                 opts.min_pass_pct = std.fmt.parseFloat(f64, a["--min-pass-pct=".len..]) catch 0.0;
             } else if (std.mem.eql(u8, a, "--debug-loads")) {
                 debug_loads = true;
             }
         }
+    }
+
+    if (opts.require_spasm_entry and !opts.spasm) {
+        try std.Io.File.stderr().writeStreamingAll(io, "wasm-testsuite: --require-spasm-entry requires --spasm\n");
+        std.process.exit(2);
     }
 
     const cwd = std.Io.Dir.cwd();
@@ -124,6 +140,15 @@ pub fn main(init: std.process.Init) !void {
     var line: [512]u8 = undefined;
     const summary = try std.fmt.bufPrint(&line, "\nwasm spec testsuite: {d}/{d} pass ({d:.2}%), {d} skip across {d} files\n", .{ total.pass, scored, pct, total.skip, files });
     try std.Io.File.stdout().writeStreamingAll(io, summary);
+    if (opts.spasm) {
+        var spasm_line: [256]u8 = undefined;
+        const spasm_summary = try std.fmt.bufPrint(
+            &spasm_line,
+            "Spasm engagement: {d} native entries, {d} compiled functions\n",
+            .{ total.spasm_runs, total.spasm_compiles },
+        );
+        try std.Io.File.stdout().writeStreamingAll(io, spasm_summary);
+    }
 
     if (opts.write_results) try writeResults(gpa, io, total, files);
 
@@ -138,6 +163,10 @@ pub fn main(init: std.process.Init) !void {
         try std.Io.File.stderr().writeStreamingAll(io, fmsg);
         std.process.exit(2);
     }
+    if (opts.require_spasm_entry and total.spasm_runs == 0) {
+        try std.Io.File.stderr().writeStreamingAll(io, "wasm-testsuite: --require-spasm-entry failed -- no generated Spasm entry executed\n");
+        std.process.exit(2);
+    }
 }
 
 // ── per-manifest execution ──────────────────────────────────────────
@@ -149,6 +178,7 @@ fn runManifest(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, json_path:
 
     var counts: Counts = .{};
     var current: ?*wasm.Instance = null;
+    var spasm_instances: std.ArrayListUnmanaged(*wasm.Instance) = .empty;
 
     // Cross-module linking registry: registered name → instance. Names
     // a `register` command exposes for a later module's imports.
@@ -169,13 +199,14 @@ fn runManifest(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, json_path:
         const kind = (cmd.get("type") orelse continue).string;
 
         if (std.mem.eql(u8, kind, "module")) {
-            const res = loadModule(arena, io, dir, cmd, &registry) catch null;
+            const res = loadModule(arena, io, dir, cmd, &registry, spasm_enabled) catch null;
             if (res) |loaded| {
                 current = loaded.instance;
-                // Force the baseline tier on this instance so every
-                // subsequent action/assert runs the compilable functions
-                // as native code — the differential gate's whole point.
-                if (spasm_enabled) loaded.instance.spasm_enabled = true;
+                // loadModule enabled the tier before any start function ran;
+                // retain the instance so the harness can prove native entry.
+                if (spasm_enabled) {
+                    try spasm_instances.append(arena, loaded.instance);
+                }
                 // A named module ((module $M …)) is addressable by later
                 // actions and registers via its internal name.
                 if (cmd.get("name")) |n| registry.put(arena, n.string, loaded.instance) catch {};
@@ -216,12 +247,16 @@ fn runManifest(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, json_path:
             // Instantiate the module and expect a trap. Side effects that
             // ran before the trap (e.g. an active element segment writing
             // into a shared imported table) persist by design.
-            const res = loadModule(arena, io, dir, cmd, &registry) catch null;
+            const res = loadModule(arena, io, dir, cmd, &registry, spasm_enabled) catch null;
             if (res == null) counts.pass += 1 else counts.fail += 1;
         } else {
             // register / assert_unlinkable — not yet scored.
             counts.skip += 1;
         }
+    }
+    for (spasm_instances.items) |instance| {
+        counts.spasm_runs += instance.spasm_runs;
+        counts.spasm_compiles += instance.spasm_compiles;
     }
     return counts;
 }
@@ -369,7 +404,14 @@ fn resolveImports(arena: std.mem.Allocator, modp: *wasm.Module, registry: *const
     return .{ .funcs = funcs, .globals = globals, .tables = tables, .memories = memories, .share_memory = true, .tags = tags };
 }
 
-fn loadModule(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, cmd: std.json.ObjectMap, registry: *const Registry) !?Loaded {
+fn loadModule(
+    arena: std.mem.Allocator,
+    io: std.Io,
+    dir: std.Io.Dir,
+    cmd: std.json.ObjectMap,
+    registry: *const Registry,
+    spasm_enabled: bool,
+) !?Loaded {
     const filename = (cmd.get("filename") orelse return null).string;
     const bytes = dir.readFileAlloc(io, filename, arena, .limited(64 * 1024 * 1024)) catch return null;
     const modp = try arena.create(wasm.Module);
@@ -388,6 +430,10 @@ fn loadModule(arena: std.mem.Allocator, io: std.Io, dir: std.Io.Dir, cmd: std.js
         if (debug_loads) logLoadError(io, filename, "instantiate", err);
         return null;
     };
+    if (spasm_enabled) {
+        ip.spasm_enabled = true;
+        ip.spasm_diagnostics = true;
+    }
     // §5.5.11 — the start function runs as part of instantiation; a trap
     // here means the module failed to instantiate.
     wasm.runStart(ip, arena) catch |err| {

--- a/wasm-bench-results.md
+++ b/wasm-bench-results.md
@@ -16,6 +16,25 @@ run against the previous section with the *same host*.
 
 ## History
 
+### 2026-08-10, x86_64 Spasm qualification, current worktree, target `x86_64-macos` under Rosetta on `Darwin 25.6.0 arm64`
+
+Three ReleaseFast ABBA samples after adding the SysV backend. The qualified
+surface covers the i32 scalar/control kernel, explicit integer/native-stack
+traps, entry/backedge polls, guarded local self-recursion, and stable
+cross-function call gates. Every checksum matched, every row stayed native in
+bare and wake modes, and timed diagnostics reported `helper 0/0` throughout.
+
+These are same-binary interpreter/Spasm ratios and include Rosetta in both
+lanes; they qualify the backend but are not absolute native-Linux timings. The
+loop and both recursive workloads clear the existing 5x Spasm target in every
+sample. Wake/bare remains noise-sized and has no one-direction regression.
+
+| bench | interpreter ms/rep | Spasm bare ms/rep | Spasm wake ms/rep | paired speedup | wake / bare |
+|---|---:|---:|---:|---:|---:|
+| loop `sum(i*i)`, n=2,000,000 | 107.401-155.358 | 11.675-15.852 | 12.110-15.113 | 9.20-11.81x | 0.926-1.077x |
+| `fib(32)` self-recursive | 376.010-511.721 | 52.251-83.956 | 54.418-76.863 | 6.10-7.42x | 0.916-1.045x |
+| `fib(32)` cross-recursive | 360.922-655.387 | 64.183-73.269 | 61.785-76.031 | 5.62-8.94x | 0.963-1.042x |
+
 ### 2026-08-08, asynchronous Realm wake-byte paired A/B, current worktree, host `Darwin 25.6.0 arm64`
 
 Three ReleaseFast ABBA samples from the final implementation. Each sample runs
@@ -29,9 +48,9 @@ The tight loop is flat within noise (`0.963-1.033x`). Entry-heavy recursive
 code exposes the expected extra function-entry probe: `1.047-1.079x` for
 self-recursion and a noisier `1.036-1.153x` for cross-recursion. This is the
 measured correctness/performance tradeoff for interrupts raised after native
-entry; the clear path performs no spills and no host call. The configured
-remote benchmark host is `Linux x86_64`, while Spasm is AArch64-only, so this
-paired A/B cannot be reproduced on that box.
+entry; the clear path performs no spills and no host call. At this checkpoint
+the configured remote benchmark host was `Linux x86_64` while Spasm was still
+AArch64-only, so this paired A/B could not be reproduced on that box.
 
 | bench | interpreter ms/rep | Spasm bare ms/rep | Spasm wake ms/rep | wake / bare |
 |---|---:|---:|---:|---:|

--- a/wasm-results.md
+++ b/wasm-results.md
@@ -28,3 +28,10 @@ proposal's `(ref exn)` text syntax, so its `.wast` files don't lower
 | passing | failing | pass% | skipped | files |
 |---|---|---|---|---|
 | 58779 | 0 | 100.00 | 1232 | 222 |
+
+The forced-Spasm differential posture (`--spasm`) produces this exact score on
+both qualified code-generation targets: native AArch64 and x86_64-macos under
+Rosetta (2026-08-10). Focused target tests additionally require generated x86
+entry, trap, safe-point, self-link, and stable-gate execution; unsupported x86
+opcode families fall back per function and therefore remain covered by the
+same semantic sweep.

--- a/wasm-results.md
+++ b/wasm-results.md
@@ -31,7 +31,9 @@ proposal's `(ref exn)` text syntax, so its `.wast` files don't lower
 
 The forced-Spasm differential posture (`--spasm`) produces this exact score on
 both qualified code-generation targets: native AArch64 and x86_64-macos under
-Rosetta (2026-08-10). Focused target tests additionally require generated x86
-entry, trap, safe-point, self-link, and stable-gate execution; unsupported x86
-opcode families fall back per function and therefore remain covered by the
-same semantic sweep.
+Rosetta (2026-08-10). Gating runs add `--require-spasm-entry`; focused target
+tests additionally require generated x86 instance/cache, trap, safe-point,
+self-link, and stable-gate execution. Unsupported x86 opcode families fall
+back per function and therefore remain covered by the same semantic sweep.
+The fail-closed witness observed 880 native entries / 559 compiled functions
+on x86_64 and 53,718 / 3,648 on AArch64 in the qualification rerun.


### PR DESCRIPTION
## Summary

- add a qualified SysV x86_64 backend for the helper-free Spasm i32 scalar and control core
- implement explicit Wasm traps, execution polling, guarded self-recursion, and W^X-safe stable cross-function call gates
- preserve transactional per-function fallback to Sarcasm for unsupported bodies
- gate forced Spasm execution on Linux x86_64 CI and document conformance and benchmark evidence

## Why

Spasm was production-ready only on AArch64. This establishes a native x86_64 baseline tier without weakening fallback, host safety, W^X, metering, or differential-conformance contracts.

## Validation

- x86_64 direct library suite: 3,379 passed, 432 skipped, 0 failed
- forced-Spasm official Wasm suite: 58,779/58,779 on x86_64 and AArch64
- fail-closed native-entry witnesses: 880 x86 entries / 559 compiles; 53,718 AArch64 entries / 3,648 compiles
- focused x86 Spasm and public JS interrupt tests
- x86_64-linux-gnu and x86_64-linux-musl cross-builds
- x86 benchmark qualification exceeded the 5x target
- format, diff, workflow YAML, and actionlint checks