### PR TITLE
Add x86_64 Spasm scalar floating-point support

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2302,19 +2302,21 @@ and the per-builtin checklist; this section tracks status.
   helper-free local link for eligible self-recursion), the table/reference
   family, the first SIMD data path, and Realm fuel/interrupt safe points at
   native entry plus taken structured-loop backedges ship and are default-on
-  for wasm. A qualified SysV x86_64 backend now covers the i32/i64
-  scalar/control core, integer globals and memory access, memory
-  size/grow/fill/copy, explicit integer/memory/stack traps, entry/backedge
-  execution polls, guarded self-links, and W^X-safe stable cross-function
-  gates. Unsupported x86 functions refuse transactionally and stay in
-  Sarcasm; the forced-tier spec sweep is exact at 58,779/58,779 on both
-  x86_64 and AArch64. The 2026-08-12 x86 run reached 10,606 native entries and
-  1,365 compiled functions; stage/opcode refusal telemetry plus a bounded
-  module-sized code reservation removed all 253 fixed-arena install
-  refusals. The forced sweep is fail-closed on native engagement via
+  for wasm. A qualified SysV x86_64 backend now covers the full f32/f64 scalar
+  ALU and conversion family, the i32/i64 binary/comparison core, scalar globals
+  and memory access, memory size/grow/fill/copy, explicit numeric/memory/stack
+  traps, entry/backedge execution polls, guarded self-links, and W^X-safe stable
+  cross-function gates. Unsupported x86 functions refuse
+  transactionally and stay in Sarcasm; the forced-tier spec sweep is exact at
+  58,779/58,779 on both x86_64 and AArch64. The 2026-09-10 x86 scalar-float
+  checkpoint reached 23,667 native entries and 2,320 compiled functions, up
+  from 10,606/1,365 at the integer/memory checkpoint. The remaining 3,220
+  refusals include zero emission or install failures; SSE2-only hosts use
+  raw-bit rounding helpers instead of assuming SSE4.1. The forced sweep is
+  fail-closed on native engagement via
   `--require-spasm-entry`, and the shared instance/cache, recursive stack,
   cold-gate fallback, and post-entry interrupt tests now execute on both
-  architectures. Remaining x86 float/conversion, bit-count,
+  architectures. Remaining x86 integer bit-count/sign-extension,
   table/reference, passive bulk-memory, SIMD, indirect-call, and memory64
   parity, remaining SIMD lane operations generally, and the
   native-register/imported-call ABI remain next.

--- a/docs/jit.md
+++ b/docs/jit.md
@@ -45,11 +45,12 @@ qualification and module ownership are recorded in
 [ohaimark.md](ohaimark.md) "x86_64 architecture-parity closure."
 Generalized JS-reentrant helpers, native post-call continuations, remaining
 opcode families, and additional codegen targets remain future work. Spasm now
-also has a qualified x86_64 SysV backend for integer scalar/control, i32/i64
-globals, integer memory access, and memory size/grow/fill/copy, alongside
-catchable integer/memory/stack traps, Realm safe points, guarded self-links,
-and stable cross-function gates. Unsupported functions retain transactional
-fallback to Sarcasm. Spasm's delivery state is tracked below. This document
+also has a qualified x86_64 SysV backend for the full f32/f64 scalar ALU and
+conversion family, the i32/i64 binary/comparison core, scalar globals and
+memory access, and memory size/grow/fill/copy, alongside catchable
+numeric/memory/stack traps, Realm safe points, guarded self-links, and stable
+cross-function gates. Unsupported functions retain transactional fallback to
+Sarcasm. Spasm's delivery state is tracked below. This document
 doubles as the design record
 that pinned the architecture before the first emitter was written and as the
 delivery ledger (the "Delivery order" section tracks what each increment
@@ -1303,11 +1304,26 @@ useful:
    --quiet --spasm --require-spasm-entry` (the harness `--spasm` flag forces
    the per-instance gate on for every loaded module, while
    `--require-spasm-entry` fails if fallback alone produced the pass set).
-   On the 2026-08-12 x86_64 qualification this produced 10,606 native entries
-   and 1,365 compiled functions. Refusal telemetry reported 4,158 intentional
-   fallbacks (8 limits, 2,336 signatures, 711 bytecode-shape refusals, and
+   The 2026-08-12 x86_64 integer/memory checkpoint produced 10,606 native
+   entries and 1,365 compiled functions. Refusal telemetry reported 4,158
+   intentional fallbacks (8 limits, 2,336 signatures, 711 bytecode-shape
+   refusals, and
    1,103 unsupported opcodes) with zero code-install exhaustion; the preceding
    fixed 64 KiB arena had lost 253 otherwise-emittable functions at install.
+   The 2026-09-10 scalar-float closure adds f32/f64 signatures, locals, globals,
+   memory operations, arithmetic, comparisons, unary operations, min/max with
+   explicit NaN and signed-zero handling, reinterprets, precision changes, and
+   every trapping, saturating, signed, and unsigned float/int conversion. The
+   x86_64 baseline remains SSE2-safe: ceil/floor/trunc/nearest use small
+   raw-bit helpers instead of assuming SSE4.1, and unsigned i64 conversions use
+   split-at-2^63 lowerings. Float comparisons follow
+   [V8 Liftoff's x64 lowering](https://chromium.googlesource.com/v8/v8.git/+/6a8e79d4df27354a2446b75a7c7916bce1c6844e/src/wasm/baseline/x64/liftoff-assembler-x64-inl.h):
+   UCOMIS plus an explicit parity branch keeps unordered NaN semantics out of
+   ordinary SETcc conditions. The full differential remains 58,779/58,779 and now
+   executes 23,667 native entries across 2,320 compiled functions. The 3,220
+   remaining refusals are 8 limits, 1,401 non-scalar signatures, 745 unsupported
+   bytecode shapes, and 1,066 unsupported opcodes, with zero emission or install
+   failures.
    The **per-function code cache**
    now ships (`spasmEntryFor`): each emittable function compiles once on
    its first Spasm-enabled invoke and the cached `EntryFn` runs every
@@ -1366,13 +1382,16 @@ useful:
    self-call uses local `rel32`, a cross-function caller passes the stable gate
    as a private ninth stack argument to a shared tail-jump stub, and its stack
    guard includes the staging frame, return address, and target prologue.
-   Its low-64-bit Cell lane now carries both i32 and i64 locals, parameters,
-   results, comparisons, arithmetic, div/rem, shifts/rotates, and wrap/extend
-   conversions. The same backend emits i32/i64 globals; every integer load and
-   store width with explicit overflow-safe software bounds checks; and
+   Its low-64-bit Cell lane now carries i32/i64/f32/f64 locals, parameters,
+   results, comparisons, arithmetic, and conversions as raw scalar bits. The
+   f32/f64 surface includes all unary and binary numeric operations, NaN-aware
+   comparisons and min/max, signed-zero handling, reinterprets and precision
+   changes, and every trapping/saturating signed/unsigned float-int conversion.
+   The same backend emits scalar globals; every scalar load and store width with
+   explicit overflow-safe software bounds checks; and
    `memory.size`, helper-backed `memory.grow` with base/length refresh, plus
    overlap-safe inline `memory.fill` / `memory.copy`. Memory64 access/grow,
-   floats and conversions, bit counts, passive bulk-memory operations,
+   integer bit counts and sign-extension ops, passive bulk-memory operations,
    tables/references, SIMD, `call_indirect`, and imported-call native lowering
    remain transactional refusals.
    Non-gated calls retain the checked helper and per-function Sarcasm fallback.

--- a/docs/wasm-engine.md
+++ b/docs/wasm-engine.md
@@ -531,18 +531,21 @@ the measured design space:
   in jit.md §7.1 (still deferred).
 
   The complete opcode surface above is the mature AArch64 backend. The
-  qualified x86_64 SysV backend emits the i32/i64 scalar/control core, integer
-  globals, every integer memory load/store width, memory size/grow/fill/copy,
-  catchable integer/memory/native-stack traps, Realm entry/backedge polls,
-  guarded local self-links, and stable W^X-safe cross-function call gates.
-  Float, table/reference, passive bulk-memory, SIMD, indirect-call, memory64
-  access/grow, and other unsupported x86 bodies refuse before code publication
-  and run in Sarcasm.
+  qualified x86_64 SysV backend emits the full f32/f64 scalar numeric and
+  conversion family, the i32/i64 binary/comparison core, scalar globals, every
+  scalar memory load/store width, memory size/grow/fill/copy, catchable
+  numeric/memory/native-stack traps, Realm entry/backedge polls, guarded local
+  self-links, and stable W^X-safe
+  cross-function call gates. Table/reference, passive bulk-memory, SIMD,
+  indirect-call, memory64 access/grow, and other unsupported x86 bodies refuse
+  before code publication and run in Sarcasm.
   This is a coverage difference, not a semantic one: forced-Spasm sweeps on
-  both architectures pass all 58,779 scored spec commands. The 2026-08-12
-  x86 sweep exercised 10,606 native entries / 1,365 compiled functions and
-  recorded zero code-install exhaustion after introducing the bounded,
-  module-sized executable-code reservation. CI pairs
+  both architectures pass all 58,779 scored spec commands. The 2026-09-10
+  x86 sweep exercised 23,667 native entries / 2,320 compiled functions and
+  recorded zero emission or install failures. Its scalar rounding fallback is
+  deliberately helper-based on SSE2-only targets rather than assuming SSE4.1;
+  the remaining 3,220 refusals are non-scalar signatures, unsupported bytecode
+  shapes/opcodes, and eight size limits. CI pairs
   `--spasm` with `--require-spasm-entry`, and the focused x86 instance/cache,
   trap, safe-point, self-link, and stable-gate tests require actual native
   entry, so the differential gate cannot be satisfied by fallback alone.

--- a/src/runtime/jit/asm_x86_64.zig
+++ b/src/runtime/jit/asm_x86_64.zig
@@ -568,11 +568,42 @@ pub const Masm = struct {
 
     /// `cvtsi2sd destination, source32`.
     pub fn cvtI32ToDouble(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
-        try self.emitByte(0xF2);
-        try self.emitByte(rex(false, isExtendedXmm(destination), false, isExtended(source)));
-        try self.emitByte(0x0F);
-        try self.emitByte(0x2A);
-        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBits(source));
+        try self.emitScalarIntToFloat(0xF2, false, destination, source);
+    }
+
+    /// `cvtsi2ss destination, source32`.
+    pub fn cvtI32ToFloat(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitScalarIntToFloat(0xF3, false, destination, source);
+    }
+
+    /// `cvtsi2ss destination, source64`.
+    pub fn cvtI64ToFloat(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitScalarIntToFloat(0xF3, true, destination, source);
+    }
+
+    /// `cvtsi2sd destination, source64`.
+    pub fn cvtI64ToDouble(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitScalarIntToFloat(0xF2, true, destination, source);
+    }
+
+    /// `cvttss2si destination32, source` (round toward zero).
+    pub fn cvttFloatToI32(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitScalarFloatToInt(0xF3, false, destination, source);
+    }
+
+    /// `cvttss2si destination64, source` (round toward zero).
+    pub fn cvttFloatToI64(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitScalarFloatToInt(0xF3, true, destination, source);
+    }
+
+    /// `cvttsd2si destination32, source` (round toward zero).
+    pub fn cvttDoubleToI32(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitScalarFloatToInt(0xF2, false, destination, source);
+    }
+
+    /// `cvttsd2si destination64, source` (round toward zero).
+    pub fn cvttDoubleToI64(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitScalarFloatToInt(0xF2, true, destination, source);
     }
 
     /// `movq destination, source` where destination is an XMM register and
@@ -595,6 +626,52 @@ pub const Masm = struct {
         try self.emitByte(0xC0 | (lowBitsXmm(source) << 3) | lowBits(destination));
     }
 
+    /// `movd destination, source32` where destination is an XMM register.
+    pub fn movDXmmFromReg(self: *Masm, destination: Xmm, source: Reg) error{OutOfMemory}!void {
+        try self.emitByte(0x66);
+        try self.emitByte(rex(false, isExtendedXmm(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x6E);
+        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBits(source));
+    }
+
+    /// `movd destination32, source` where source is an XMM register.
+    pub fn movDRegFromXmm(self: *Masm, destination: Reg, source: Xmm) error{OutOfMemory}!void {
+        try self.emitByte(0x66);
+        try self.emitByte(rex(false, isExtendedXmm(source), false, isExtended(destination)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x7E);
+        try self.emitByte(0xC0 | (lowBitsXmm(source) << 3) | lowBits(destination));
+    }
+
+    pub fn addFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x58, destination, source);
+    }
+
+    pub fn subFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x5C, destination, source);
+    }
+
+    pub fn mulFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x59, destination, source);
+    }
+
+    pub fn divFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x5E, destination, source);
+    }
+
+    pub fn sqrtFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x51, destination, source);
+    }
+
+    pub fn addDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x58, destination, source);
+    }
+
+    pub fn subDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x5C, destination, source);
+    }
+
     pub fn mulDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
         try self.emitXmmReg(0xF2, 0x59, destination, source);
     }
@@ -603,11 +680,31 @@ pub const Masm = struct {
         try self.emitXmmReg(0xF2, 0x5E, destination, source);
     }
 
-    /// `ucomisd left, right` — its parity flag reports an unordered (NaN)
-    /// comparison, which native lowering routes back to Lantern for canonical
-    /// NaN boxing.
+    pub fn sqrtDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x51, destination, source);
+    }
+
+    /// `cvtss2sd destination, source`.
+    pub fn cvtFloatToDouble(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF3, 0x5A, destination, source);
+    }
+
+    /// `cvtsd2ss destination, source`.
+    pub fn cvtDoubleToFloat(self: *Masm, destination: Xmm, source: Xmm) error{OutOfMemory}!void {
+        try self.emitXmmReg(0xF2, 0x5A, destination, source);
+    }
+
+    /// `ucomisd left, right`; PF reports an unordered (NaN) comparison.
     pub fn ucomisDouble(self: *Masm, left: Xmm, right: Xmm) error{OutOfMemory}!void {
         try self.emitXmmReg(0x66, 0x2E, left, right);
+    }
+
+    /// `ucomiss left, right`; PF reports an unordered (NaN) comparison.
+    pub fn ucomisFloat(self: *Masm, left: Xmm, right: Xmm) error{OutOfMemory}!void {
+        try self.emitByte(rex(false, isExtendedXmm(left), false, isExtendedXmm(right)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x2E);
+        try self.emitByte(0xC0 | (lowBitsXmm(left) << 3) | lowBitsXmm(right));
     }
 
     /// `call target`.
@@ -752,6 +849,34 @@ pub const Masm = struct {
         try self.emitByte(0x0F);
         try self.emitByte(opcode);
         try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBitsXmm(source));
+    }
+
+    fn emitScalarIntToFloat(
+        self: *Masm,
+        prefix: u8,
+        source64: bool,
+        destination: Xmm,
+        source: Reg,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(prefix);
+        try self.emitByte(rex(source64, isExtendedXmm(destination), false, isExtended(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x2A);
+        try self.emitByte(0xC0 | (lowBitsXmm(destination) << 3) | lowBits(source));
+    }
+
+    fn emitScalarFloatToInt(
+        self: *Masm,
+        prefix: u8,
+        destination64: bool,
+        destination: Reg,
+        source: Xmm,
+    ) error{OutOfMemory}!void {
+        try self.emitByte(prefix);
+        try self.emitByte(rex(destination64, isExtended(destination), false, isExtendedXmm(source)));
+        try self.emitByte(0x0F);
+        try self.emitByte(0x2C);
+        try self.emitByte(0xC0 | (lowBits(destination) << 3) | lowBitsXmm(source));
     }
 
     fn emitBranchDisplacement(self: *Masm, label: *Label) !void {
@@ -971,6 +1096,59 @@ test "jit asm_x86_64: encodes i64 division, narrow memory, and CL shifts" {
         0x49, 0xD3,
         0xC2, 0x41,
         0xD3, 0xEA,
+    }, machine.code.items);
+}
+
+test "jit asm_x86_64: encodes scalar float bridges, arithmetic, and compares" {
+    var machine = Masm.init(std.testing.allocator);
+    defer machine.deinit();
+
+    try machine.movDXmmFromReg(.xmm0, .rax);
+    try machine.movDRegFromXmm(.rax, .xmm0);
+    try machine.addFloat(.xmm0, .xmm1);
+    try machine.subFloat(.xmm0, .xmm1);
+    try machine.mulFloat(.xmm0, .xmm1);
+    try machine.divFloat(.xmm0, .xmm1);
+    try machine.addDouble(.xmm0, .xmm1);
+    try machine.subDouble(.xmm0, .xmm1);
+    try machine.sqrtFloat(.xmm0, .xmm1);
+    try machine.sqrtDouble(.xmm0, .xmm1);
+    try machine.cvtI32ToFloat(.xmm0, .rax);
+    try machine.cvtI64ToFloat(.xmm0, .rax);
+    try machine.cvtI32ToDouble(.xmm0, .rax);
+    try machine.cvtI64ToDouble(.xmm0, .rax);
+    try machine.cvttFloatToI32(.rax, .xmm0);
+    try machine.cvttFloatToI64(.rax, .xmm0);
+    try machine.cvttDoubleToI32(.rax, .xmm0);
+    try machine.cvttDoubleToI64(.rax, .xmm0);
+    try machine.cvtFloatToDouble(.xmm0, .xmm1);
+    try machine.cvtDoubleToFloat(.xmm0, .xmm1);
+    try machine.ucomisFloat(.xmm0, .xmm1);
+    try machine.ucomisDouble(.xmm0, .xmm1);
+
+    try std.testing.expectEqualSlices(u8, &.{
+        0x66, 0x40, 0x0F, 0x6E, 0xC0,
+        0x66, 0x40, 0x0F, 0x7E, 0xC0,
+        0xF3, 0x40, 0x0F, 0x58, 0xC1,
+        0xF3, 0x40, 0x0F, 0x5C, 0xC1,
+        0xF3, 0x40, 0x0F, 0x59, 0xC1,
+        0xF3, 0x40, 0x0F, 0x5E, 0xC1,
+        0xF2, 0x40, 0x0F, 0x58, 0xC1,
+        0xF2, 0x40, 0x0F, 0x5C, 0xC1,
+        0xF3, 0x40, 0x0F, 0x51, 0xC1,
+        0xF2, 0x40, 0x0F, 0x51, 0xC1,
+        0xF3, 0x40, 0x0F, 0x2A, 0xC0,
+        0xF3, 0x48, 0x0F, 0x2A, 0xC0,
+        0xF2, 0x40, 0x0F, 0x2A, 0xC0,
+        0xF2, 0x48, 0x0F, 0x2A, 0xC0,
+        0xF3, 0x40, 0x0F, 0x2C, 0xC0,
+        0xF3, 0x48, 0x0F, 0x2C, 0xC0,
+        0xF2, 0x40, 0x0F, 0x2C, 0xC0,
+        0xF2, 0x48, 0x0F, 0x2C, 0xC0,
+        0xF3, 0x40, 0x0F, 0x5A, 0xC1,
+        0xF2, 0x40, 0x0F, 0x5A, 0xC1,
+        0x40, 0x0F, 0x2E, 0xC1, 0x66,
+        0x40, 0x0F, 0x2E, 0xC1,
     }, machine.code.items);
 }
 

--- a/src/runtime/wasm/float_ops.zig
+++ b/src/runtime/wasm/float_ops.zig
@@ -1,0 +1,15 @@
+//! Shared scalar floating-point semantics used by Sarcasm and native tiers.
+
+const std = @import("std");
+
+/// Round to nearest, ties to even (WebAssembly §4.3.3). Zig's `@round`
+/// rounds ties away from zero, so correct the odd tie and preserve zero's sign.
+pub fn roundEven(comptime T: type, x: T) T {
+    const rounded = @round(x);
+    var result = rounded;
+    if (@abs(x - @trunc(x)) == 0.5 and @rem(rounded, 2) != 0) {
+        result = rounded - std.math.sign(rounded);
+    }
+    if (result == 0) return std.math.copysign(@as(T, 0), x);
+    return result;
+}

--- a/src/runtime/wasm/interpreter.zig
+++ b/src/runtime/wasm/interpreter.zig
@@ -22,6 +22,7 @@ const opcodes = @import("opcodes.zig");
 const validator = @import("validator.zig");
 const reader_mod = @import("reader.zig");
 const spasm = @import("spasm.zig");
+const float_ops = @import("float_ops.zig");
 const code_alloc = @import("../jit/code_alloc.zig");
 
 const ValType = types.ValType;
@@ -3871,19 +3872,6 @@ fn readF64(body: []const u8, pc: *usize) f64 {
 
 // ── floating point ──────────────────────────────────────────────────
 
-/// Round to nearest, ties to even (§4.3.3) — distinct from Zig's
-/// `@round`, which rounds ties away from zero.
-fn roundEven(comptime T: type, x: T) T {
-    const r = @round(x);
-    var result = r;
-    if (@abs(x - @trunc(x)) == 0.5 and @rem(r, 2) != 0) {
-        result = r - std.math.sign(r);
-    }
-    // Preserve the sign of a zero result (e.g. nearest(-0.4) = -0.0).
-    if (result == 0) return std.math.copysign(@as(T, 0), x);
-    return result;
-}
-
 /// wasm min: NaN-propagating, with min(-0, +0) = -0 (§4.3.3).
 fn fmin(comptime T: type, a: T, b: T) T {
     if (a != a) return a;
@@ -3907,7 +3895,7 @@ fn floatUnop(comptime T: type, op: Op, x: T) T {
         .f32_ceil, .f64_ceil => @ceil(x),
         .f32_floor, .f64_floor => @floor(x),
         .f32_trunc, .f64_trunc => @trunc(x),
-        .f32_nearest, .f64_nearest => roundEven(T, x),
+        .f32_nearest, .f64_nearest => float_ops.roundEven(T, x),
         .f32_sqrt, .f64_sqrt => @sqrt(x),
         else => unreachable,
     };
@@ -4671,7 +4659,7 @@ fn vround(comptime N: usize, comptime T: type, comptime op: enum { ceil, floor, 
         .trunc => return @bitCast(@trunc(x)),
         .nearest => {
             var r: @Vector(N, T) = x;
-            inline for (0..N) |i| r[i] = roundEven(T, x[i]);
+            inline for (0..N) |i| r[i] = float_ops.roundEven(T, x[i]);
             return @bitCast(r);
         },
     }

--- a/src/runtime/wasm/spasm.zig
+++ b/src/runtime/wasm/spasm.zig
@@ -11,8 +11,8 @@
 //!
 //! Spasm shares the codegen substrate in `src/runtime/jit/` with
 //! Bistromath — the per-ISA encoders and executable-memory allocator (§7).
-//! AArch64 uses the shared masm facade; the qualified x86_64 integer/memory
-//! backend keeps its SysV frame/operand policy in `spasm_x86_64.zig`. What
+//! AArch64 uses the shared masm facade; the qualified x86_64 scalar backend
+//! keeps its SysV frame/operand policy in `spasm_x86_64.zig`. What
 //! Spasm does NOT share is the abstract state above the assembler: Bistromath mirrors the
 //! interpreter's `CallFrame`; Spasm's operand-stack machine is its
 //! whole compiler, and wasm frames live on the native stack with no GC
@@ -898,6 +898,7 @@ pub fn compileWithDiagnostics(
                 .wake_flag_offset = @intCast(@offsetOf(NativeExecutionControl, "wake_flag")),
                 .trap_divide_by_zero = trap_divide_by_zero,
                 .trap_int_overflow = trap_int_overflow,
+                .trap_invalid_conversion = trap_invalid_conversion,
                 .trap_out_of_bounds = trap_out_of_bounds,
                 .trap_call_stack_exhausted = trap_call_stack_exhausted,
                 .mem_view_helper = if (helpers.mem_view) |helper| @intFromPtr(helper) else null,

--- a/src/runtime/wasm/spasm_x86_64.zig
+++ b/src/runtime/wasm/spasm_x86_64.zig
@@ -1,6 +1,6 @@
 //! x86_64 Spasm backend.
 //!
-//! This first backend slice keeps scalar operands in the existing trailing
+//! This backend keeps scalar operands in the existing trailing
 //! `Cell` scratch area rather than trying to project AArch64's seven-register
 //! cache onto the smaller SysV register file. The validated-bytecode compiler
 //! remains one pass, constants still fold, and unsupported instructions refuse
@@ -10,6 +10,7 @@ const std = @import("std");
 
 const x64 = @import("../jit/asm_x86_64.zig");
 const code_alloc = @import("../jit/code_alloc.zig");
+const float_ops = @import("float_ops.zig");
 const CompiledFunc = @import("code.zig").CompiledFunc;
 const Module = @import("module.zig").Module;
 const FuncType = @import("types.zig").FuncType;
@@ -56,6 +57,7 @@ pub const Config = struct {
     wake_flag_offset: i32,
     trap_divide_by_zero: u32,
     trap_int_overflow: u32,
+    trap_invalid_conversion: u32,
     trap_out_of_bounds: u32,
     trap_call_stack_exhausted: u32,
     mem_view_helper: ?usize,
@@ -95,6 +97,8 @@ const op_global_get: u8 = 0x23;
 const op_global_set: u8 = 0x24;
 const op_i32_load: u8 = 0x28;
 const op_i64_load: u8 = 0x29;
+const op_f32_load: u8 = 0x2a;
+const op_f64_load: u8 = 0x2b;
 const op_i32_load8_s: u8 = 0x2c;
 const op_i32_load8_u: u8 = 0x2d;
 const op_i32_load16_s: u8 = 0x2e;
@@ -107,6 +111,8 @@ const op_i64_load32_s: u8 = 0x34;
 const op_i64_load32_u: u8 = 0x35;
 const op_i32_store: u8 = 0x36;
 const op_i64_store: u8 = 0x37;
+const op_f32_store: u8 = 0x38;
+const op_f64_store: u8 = 0x39;
 const op_i32_store8: u8 = 0x3a;
 const op_i32_store16: u8 = 0x3b;
 const op_i64_store8: u8 = 0x3c;
@@ -116,6 +122,8 @@ const op_memory_size: u8 = 0x3f;
 const op_memory_grow: u8 = 0x40;
 const op_i32_const: u8 = 0x41;
 const op_i64_const: u8 = 0x42;
+const op_f32_const: u8 = 0x43;
+const op_f64_const: u8 = 0x44;
 const op_i32_eqz: u8 = 0x45;
 const op_i32_eq: u8 = 0x46;
 const op_i32_ne: u8 = 0x47;
@@ -127,6 +135,18 @@ const op_i32_le_s: u8 = 0x4c;
 const op_i32_le_u: u8 = 0x4d;
 const op_i32_ge_s: u8 = 0x4e;
 const op_i32_ge_u: u8 = 0x4f;
+const op_f32_eq: u8 = 0x5b;
+const op_f32_ne: u8 = 0x5c;
+const op_f32_lt: u8 = 0x5d;
+const op_f32_gt: u8 = 0x5e;
+const op_f32_le: u8 = 0x5f;
+const op_f32_ge: u8 = 0x60;
+const op_f64_eq: u8 = 0x61;
+const op_f64_ne: u8 = 0x62;
+const op_f64_lt: u8 = 0x63;
+const op_f64_gt: u8 = 0x64;
+const op_f64_le: u8 = 0x65;
+const op_f64_ge: u8 = 0x66;
 const op_i32_add: u8 = 0x6a;
 const op_i32_sub: u8 = 0x6b;
 const op_i32_mul: u8 = 0x6c;
@@ -168,9 +188,59 @@ const op_i64_shr_s: u8 = 0x87;
 const op_i64_shr_u: u8 = 0x88;
 const op_i64_rotl: u8 = 0x89;
 const op_i64_rotr: u8 = 0x8a;
+const op_f32_abs: u8 = 0x8b;
+const op_f32_neg: u8 = 0x8c;
+const op_f32_ceil: u8 = 0x8d;
+const op_f32_floor: u8 = 0x8e;
+const op_f32_trunc: u8 = 0x8f;
+const op_f32_nearest: u8 = 0x90;
+const op_f32_sqrt: u8 = 0x91;
+const op_f32_add: u8 = 0x92;
+const op_f32_sub: u8 = 0x93;
+const op_f32_mul: u8 = 0x94;
+const op_f32_div: u8 = 0x95;
+const op_f32_min: u8 = 0x96;
+const op_f32_max: u8 = 0x97;
+const op_f32_copysign: u8 = 0x98;
+const op_f64_abs: u8 = 0x99;
+const op_f64_neg: u8 = 0x9a;
+const op_f64_ceil: u8 = 0x9b;
+const op_f64_floor: u8 = 0x9c;
+const op_f64_trunc: u8 = 0x9d;
+const op_f64_nearest: u8 = 0x9e;
+const op_f64_sqrt: u8 = 0x9f;
+const op_f64_add: u8 = 0xa0;
+const op_f64_sub: u8 = 0xa1;
+const op_f64_mul: u8 = 0xa2;
+const op_f64_div: u8 = 0xa3;
+const op_f64_min: u8 = 0xa4;
+const op_f64_max: u8 = 0xa5;
+const op_f64_copysign: u8 = 0xa6;
 const op_i32_wrap_i64: u8 = 0xa7;
+const op_i32_trunc_f32_s: u8 = 0xa8;
+const op_i32_trunc_f32_u: u8 = 0xa9;
+const op_i32_trunc_f64_s: u8 = 0xaa;
+const op_i32_trunc_f64_u: u8 = 0xab;
 const op_i64_extend_i32_s: u8 = 0xac;
 const op_i64_extend_i32_u: u8 = 0xad;
+const op_i64_trunc_f32_s: u8 = 0xae;
+const op_i64_trunc_f32_u: u8 = 0xaf;
+const op_i64_trunc_f64_s: u8 = 0xb0;
+const op_i64_trunc_f64_u: u8 = 0xb1;
+const op_f32_convert_i32_s: u8 = 0xb2;
+const op_f32_convert_i32_u: u8 = 0xb3;
+const op_f32_convert_i64_s: u8 = 0xb4;
+const op_f32_convert_i64_u: u8 = 0xb5;
+const op_f32_demote_f64: u8 = 0xb6;
+const op_f64_convert_i32_s: u8 = 0xb7;
+const op_f64_convert_i32_u: u8 = 0xb8;
+const op_f64_convert_i64_s: u8 = 0xb9;
+const op_f64_convert_i64_u: u8 = 0xba;
+const op_f64_promote_f32: u8 = 0xbb;
+const op_i32_reinterpret_f32: u8 = 0xbc;
+const op_i64_reinterpret_f64: u8 = 0xbd;
+const op_f32_reinterpret_i32: u8 = 0xbe;
+const op_f64_reinterpret_i64: u8 = 0xbf;
 const op_misc_prefix: u8 = 0xfc;
 
 const Loc = union(enum) {
@@ -241,11 +311,12 @@ pub fn compile(
     const highest_slot = std.math.add(usize, num_locals, operand_stack_capacity) catch return refuse(config, .limits, 0);
     if (highest_slot > @as(usize, std.math.maxInt(i32)) / 16) return refuse(config, .limits, 0);
 
-    // Integer Cells share the same low-64-bit representation at this boundary.
-    // Float, vector, and reference signatures stay transactional refusals.
-    for (func.local_types) |local_type| if (!isIntegerScalar(local_type)) return refuse(config, .signature, 0);
-    for (ftype.params) |param_type| if (!isIntegerScalar(param_type)) return refuse(config, .signature, 0);
-    for (ftype.results) |result_type| if (!isIntegerScalar(result_type)) return refuse(config, .signature, 0);
+    // Scalar Cells share the same low-64-bit representation at this boundary;
+    // floats cross as their raw IEEE-754 bits. Vector and reference signatures
+    // remain transactional refusals.
+    for (func.local_types) |local_type| if (!isScalar(local_type)) return refuse(config, .signature, 0);
+    for (ftype.params) |param_type| if (!isScalar(param_type)) return refuse(config, .signature, 0);
+    for (ftype.results) |result_type| if (!isScalar(result_type)) return refuse(config, .signature, 0);
 
     var m = x64.Masm.init(gpa);
     defer m.deinit();
@@ -254,16 +325,19 @@ pub fn compile(
     var epilogue: x64.Masm.Label = .{};
     var trap_div0: x64.Masm.Label = .{};
     var trap_overflow: x64.Masm.Label = .{};
+    var trap_invalid: x64.Masm.Label = .{};
     var trap_oob: x64.Masm.Label = .{};
     var trap_stack_exhausted: x64.Masm.Label = .{};
     defer entry.deinit(gpa);
     defer epilogue.deinit(gpa);
     defer trap_div0.deinit(gpa);
     defer trap_overflow.deinit(gpa);
+    defer trap_invalid.deinit(gpa);
     defer trap_oob.deinit(gpa);
     defer trap_stack_exhausted.deinit(gpa);
     var trap_div0_used = false;
     var trap_overflow_used = false;
+    var trap_invalid_used = false;
     var trap_oob_used = false;
     var trap_stack_exhausted_used = false;
 
@@ -305,6 +379,18 @@ pub fn compile(
                 stack[sp] = .{ .const_i64 = value };
                 sp += 1;
             },
+            op_f32_const => {
+                const bits = readF32Bits(body, &i) orelse return null;
+                if (sp >= operand_stack_capacity) return null;
+                stack[sp] = .{ .const_i32 = @bitCast(bits) };
+                sp += 1;
+            },
+            op_f64_const => {
+                const bits = readF64Bits(body, &i) orelse return null;
+                if (sp >= operand_stack_capacity) return null;
+                stack[sp] = .{ .const_i64 = @bitCast(bits) };
+                sp += 1;
+            },
             op_drop => {
                 if (sp == 0) return null;
                 sp -= 1;
@@ -312,8 +398,8 @@ pub fn compile(
             op_call => {
                 const callee_index = readUleb32(body, &i) orelse return null;
                 const callee = calleeFuncType(module, callee_index) orelse return null;
-                for (callee.params) |param_type| if (!isIntegerScalar(param_type)) return null;
-                for (callee.results) |result_type| if (!isIntegerScalar(result_type)) return null;
+                for (callee.params) |param_type| if (!isScalar(param_type)) return null;
+                for (callee.results) |result_type| if (!isScalar(result_type)) return null;
 
                 const param_count = callee.params.len;
                 const result_count = callee.results.len;
@@ -425,8 +511,8 @@ pub fn compile(
                 const index = readUleb32(body, &i) orelse return null;
                 if (index >= num_locals or sp >= operand_stack_capacity) return null;
                 switch (func.local_types[index]) {
-                    .i32 => try m.load32Disp32(.rax, .r12, localOffset(index)),
-                    .i64 => try m.load64Disp32(.rax, .r12, localOffset(index)),
+                    .i32, .f32 => try m.load32Disp32(.rax, .r12, localOffset(index)),
+                    .i64, .f64 => try m.load64Disp32(.rax, .r12, localOffset(index)),
                     else => return null,
                 }
                 try m.store64Disp32(.r12, scratchOffset(num_locals, sp), .rax);
@@ -451,11 +537,11 @@ pub fn compile(
                 // the scalar payload starts at offset zero in each Global.
                 const index = readUleb32(body, &i) orelse return null;
                 const global_type = globalValType(module, index) orelse return null;
-                if (!isIntegerScalar(global_type) or sp >= operand_stack_capacity) return null;
+                if (!isScalar(global_type) or sp >= operand_stack_capacity) return null;
                 const pointer_offset = std.math.mul(u32, index, 8) catch return null;
                 if (pointer_offset > std.math.maxInt(i32)) return null;
                 try m.load64Disp32(.r10, .rbp, @intCast(pointer_offset));
-                if (global_type == .i32)
+                if (global_type == .i32 or global_type == .f32)
                     try m.load32Disp32(.rax, .r10, 0)
                 else
                     try m.load64Disp32(.rax, .r10, 0);
@@ -469,7 +555,7 @@ pub fn compile(
                 // registers so a folded constant cannot clobber either.
                 const index = readUleb32(body, &i) orelse return null;
                 const global_type = globalValType(module, index) orelse return null;
-                if (!isIntegerScalar(global_type) or sp == 0) return null;
+                if (!isScalar(global_type) or sp == 0) return null;
                 const pointer_offset = std.math.mul(u32, index, 8) catch return null;
                 if (pointer_offset > std.math.maxInt(i32)) return null;
                 const depth = sp - 1;
@@ -790,6 +876,369 @@ pub fn compile(
                 try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
                 stack[sp - 1] = .runtime;
             },
+            op_f32_add,
+            op_f32_sub,
+            op_f32_mul,
+            op_f32_div,
+            op_f64_add,
+            op_f64_sub,
+            op_f64_mul,
+            op_f64_div,
+            => {
+                // §4.3.3 scalar float arithmetic. Cell slots retain the raw
+                // IEEE-754 bits; xmm0/xmm1 are short-lived SSE temporaries.
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                const is_f32 = op >= op_f32_add and op <= op_f32_div;
+                if (is_f32) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movDXmmFromReg(.xmm0, .rax);
+                    try m.movDXmmFromReg(.xmm1, .rcx);
+                    switch (op) {
+                        op_f32_add => try m.addFloat(.xmm0, .xmm1),
+                        op_f32_sub => try m.subFloat(.xmm0, .xmm1),
+                        op_f32_mul => try m.mulFloat(.xmm0, .xmm1),
+                        else => try m.divFloat(.xmm0, .xmm1),
+                    }
+                    try m.movDRegFromXmm(.rax, .xmm0);
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load64Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movQXmmFromReg(.xmm0, .rax);
+                    try m.movQXmmFromReg(.xmm1, .rcx);
+                    switch (op) {
+                        op_f64_add => try m.addDouble(.xmm0, .xmm1),
+                        op_f64_sub => try m.subDouble(.xmm0, .xmm1),
+                        op_f64_mul => try m.mulDouble(.xmm0, .xmm1),
+                        else => try m.divDouble(.xmm0, .xmm1),
+                    }
+                    try m.movQRegFromXmm(.rax, .xmm0);
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_f32_min, op_f32_max, op_f64_min, op_f64_max => {
+                // SSE MIN/MAX choose the source operand for equal values and
+                // NaNs, which disagrees with Wasm for one signed-zero order and
+                // for a NaN in the destination. Handle unordered/equal cases
+                // explicitly, then select the ordered result by condition.
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                const is_f32 = op == op_f32_min or op == op_f32_max;
+                if (is_f32) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movDXmmFromReg(.xmm0, .rax);
+                    try m.movDXmmFromReg(.xmm1, .rcx);
+                    try m.ucomisFloat(.xmm0, .xmm1);
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load64Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movQXmmFromReg(.xmm0, .rax);
+                    try m.movQXmmFromReg(.xmm1, .rcx);
+                    try m.ucomisDouble(.xmm0, .xmm1);
+                }
+
+                var unordered: x64.Masm.Label = .{};
+                var equal: x64.Masm.Label = .{};
+                var minmax_done: x64.Masm.Label = .{};
+                defer unordered.deinit(gpa);
+                defer equal.deinit(gpa);
+                defer minmax_done.deinit(gpa);
+                try m.jumpCond(.parity, &unordered);
+                try m.jumpCond(.equal, &equal);
+                const keep_left: x64.Cond = if (op == op_f32_min or op == op_f64_min) .below else .above;
+                try m.jumpCond(keep_left, &minmax_done);
+                try m.movReg64(.rax, .rcx);
+                try m.jump(&minmax_done);
+
+                try m.bind(&equal);
+                if (op == op_f32_min)
+                    try m.orReg32(.rax, .rcx)
+                else if (op == op_f32_max)
+                    try m.andReg32(.rax, .rcx)
+                else if (op == op_f64_min)
+                    try m.orReg64(.rax, .rcx)
+                else
+                    try m.andReg64(.rax, .rcx);
+                try m.jump(&minmax_done);
+
+                try m.bind(&unordered);
+                if (is_f32) {
+                    try m.addFloat(.xmm0, .xmm1);
+                    try m.movDRegFromXmm(.rax, .xmm0);
+                } else {
+                    try m.addDouble(.xmm0, .xmm1);
+                    try m.movQRegFromXmm(.rax, .xmm0);
+                }
+                try m.bind(&minmax_done);
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_f32_eq,
+            op_f32_ne,
+            op_f32_lt,
+            op_f32_gt,
+            op_f32_le,
+            op_f32_ge,
+            op_f64_eq,
+            op_f64_ne,
+            op_f64_lt,
+            op_f64_gt,
+            op_f64_le,
+            op_f64_ge,
+            => {
+                // UCOMIS marks NaN with PF=1 and also sets ZF/CF, so no plain
+                // SETcc is sufficient for every Wasm relation. Split the
+                // unordered case explicitly: only `ne` is true for NaN.
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                const is_f32 = op >= op_f32_eq and op <= op_f32_ge;
+                if (is_f32) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movDXmmFromReg(.xmm0, .rax);
+                    try m.movDXmmFromReg(.xmm1, .rcx);
+                    try m.ucomisFloat(.xmm0, .xmm1);
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load64Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movQXmmFromReg(.xmm0, .rax);
+                    try m.movQXmmFromReg(.xmm1, .rcx);
+                    try m.ucomisDouble(.xmm0, .xmm1);
+                }
+
+                var ordered: x64.Masm.Label = .{};
+                var compare_done: x64.Masm.Label = .{};
+                defer ordered.deinit(gpa);
+                defer compare_done.deinit(gpa);
+                try m.jumpCond(.not_parity, &ordered);
+                const is_ne = op == op_f32_ne or op == op_f64_ne;
+                try m.movImm64(.rax, @intFromBool(is_ne));
+                try m.jump(&compare_done);
+                try m.bind(&ordered);
+                const condition: x64.Cond = switch (op) {
+                    op_f32_eq, op_f64_eq => .equal,
+                    op_f32_ne, op_f64_ne => .not_equal,
+                    op_f32_lt, op_f64_lt => .below,
+                    op_f32_gt, op_f64_gt => .above,
+                    op_f32_le, op_f64_le => .below_or_equal,
+                    else => .above_or_equal,
+                };
+                try m.setCond32(.rax, condition);
+                try m.bind(&compare_done);
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_f32_ceil,
+            op_f32_floor,
+            op_f32_trunc,
+            op_f32_nearest,
+            op_f64_ceil,
+            op_f64_floor,
+            op_f64_trunc,
+            op_f64_nearest,
+            => {
+                // SSE4.1 ROUNDSS/ROUNDSD are not part of the x86_64 baseline.
+                // Keep the whole function native on SSE2-only hosts by calling
+                // a small raw-bit helper for the four exact Wasm round modes.
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                const is_f32 = op >= op_f32_ceil and op <= op_f32_nearest;
+                if (is_f32) {
+                    try m.load32Disp32(.rdi, .r12, scratchOffset(num_locals, depth));
+                    try m.movImm64(.rsi, op - op_f32_ceil);
+                    try m.movImm64(.r11, @intFromPtr(&roundF32Bits));
+                } else {
+                    try m.load64Disp32(.rdi, .r12, scratchOffset(num_locals, depth));
+                    try m.movImm64(.rsi, op - op_f64_ceil);
+                    try m.movImm64(.r11, @intFromPtr(&roundF64Bits));
+                }
+                try m.callReg(.r11);
+                try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                stack[depth] = .runtime;
+            },
+            op_f32_abs, op_f32_neg, op_f32_sqrt, op_f64_abs, op_f64_neg, op_f64_sqrt => {
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                const is_f32 = op == op_f32_abs or op == op_f32_neg or op == op_f32_sqrt;
+                if (is_f32) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    switch (op) {
+                        op_f32_abs => {
+                            try m.movImm64(.r10, 0x7fff_ffff);
+                            try m.andReg32(.rax, .r10);
+                        },
+                        op_f32_neg => {
+                            try m.movImm64(.r10, 0x8000_0000);
+                            try m.xorReg32(.rax, .r10);
+                        },
+                        else => {
+                            try m.movDXmmFromReg(.xmm0, .rax);
+                            try m.sqrtFloat(.xmm0, .xmm0);
+                            try m.movDRegFromXmm(.rax, .xmm0);
+                        },
+                    }
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    switch (op) {
+                        op_f64_abs => {
+                            try m.movImm64(.r10, 0x7fff_ffff_ffff_ffff);
+                            try m.andReg64(.rax, .r10);
+                        },
+                        op_f64_neg => {
+                            try m.movImm64(.r10, 0x8000_0000_0000_0000);
+                            try m.xorReg64(.rax, .r10);
+                        },
+                        else => {
+                            try m.movQXmmFromReg(.xmm0, .rax);
+                            try m.sqrtDouble(.xmm0, .xmm0);
+                            try m.movQRegFromXmm(.rax, .xmm0);
+                        },
+                    }
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                stack[depth] = .runtime;
+            },
+            op_f32_copysign, op_f64_copysign => {
+                if (sp < 2) return null;
+                const right = stack[sp - 1];
+                const left = stack[sp - 2];
+                sp -= 1;
+                try materialize(&m, left, num_locals, sp - 1);
+                try materialize(&m, right, num_locals, sp);
+                if (op == op_f32_copysign) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load32Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movImm64(.r10, 0x8000_0000);
+                    try m.andReg32(.rcx, .r10);
+                    try m.movImm64(.r10, 0x7fff_ffff);
+                    try m.andReg32(.rax, .r10);
+                    try m.orReg32(.rax, .rcx);
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, sp - 1));
+                    try m.load64Disp32(.rcx, .r12, scratchOffset(num_locals, sp));
+                    try m.movImm64(.r10, 0x8000_0000_0000_0000);
+                    try m.andReg64(.rcx, .r10);
+                    try m.movImm64(.r10, 0x7fff_ffff_ffff_ffff);
+                    try m.andReg64(.rax, .r10);
+                    try m.orReg64(.rax, .rcx);
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, sp - 1), .rax);
+                stack[sp - 1] = .runtime;
+            },
+            op_i32_reinterpret_f32, op_i64_reinterpret_f64, op_f32_reinterpret_i32, op_f64_reinterpret_i64 => {
+                // Cell lanes already hold the exact scalar bit pattern.
+                if (sp == 0) return null;
+            },
+            op_f32_demote_f64, op_f64_promote_f32 => {
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                if (op == op_f32_demote_f64) {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    try m.movQXmmFromReg(.xmm0, .rax);
+                    try m.cvtDoubleToFloat(.xmm0, .xmm0);
+                    try m.movDRegFromXmm(.rax, .xmm0);
+                } else {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    try m.movDXmmFromReg(.xmm0, .rax);
+                    try m.cvtFloatToDouble(.xmm0, .xmm0);
+                    try m.movQRegFromXmm(.rax, .xmm0);
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                stack[depth] = .runtime;
+            },
+            op_i32_trunc_f32_s,
+            op_i32_trunc_f32_u,
+            op_i32_trunc_f64_s,
+            op_i32_trunc_f64_u,
+            op_i64_trunc_f32_s,
+            op_i64_trunc_f32_u,
+            op_i64_trunc_f64_s,
+            op_i64_trunc_f64_u,
+            => {
+                // §4.3.3 trapping float-to-int truncation. CVTT returns an
+                // ambiguous integer-indefinite value for NaN and overflow, so
+                // distinguish those traps with explicit half-open range tests
+                // before converting an in-range operand.
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                const src_f32 = op == op_i32_trunc_f32_s or op == op_i32_trunc_f32_u or
+                    op == op_i64_trunc_f32_s or op == op_i64_trunc_f32_u;
+                if (src_f32) {
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    try m.movDXmmFromReg(.xmm0, .rax);
+                } else {
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                    try m.movQXmmFromReg(.xmm0, .rax);
+                }
+                trap_invalid_used = true;
+                trap_overflow_used = true;
+                switch (op) {
+                    op_i32_trunc_f32_s => try emitTruncTrap(&m, true, false, true, -2147483648.0, true, 2147483648.0, &trap_invalid, &trap_overflow),
+                    op_i32_trunc_f32_u => try emitTruncTrap(&m, true, false, false, -1.0, false, 4294967296.0, &trap_invalid, &trap_overflow),
+                    op_i32_trunc_f64_s => try emitTruncTrap(&m, false, false, true, -2147483649.0, false, 2147483648.0, &trap_invalid, &trap_overflow),
+                    op_i32_trunc_f64_u => try emitTruncTrap(&m, false, false, false, -1.0, false, 4294967296.0, &trap_invalid, &trap_overflow),
+                    op_i64_trunc_f32_s => try emitTruncTrap(&m, true, true, true, -9223372036854775808.0, true, 9223372036854775808.0, &trap_invalid, &trap_overflow),
+                    op_i64_trunc_f32_u => try emitTruncTrap(&m, true, true, false, -1.0, false, 18446744073709551616.0, &trap_invalid, &trap_overflow),
+                    op_i64_trunc_f64_s => try emitTruncTrap(&m, false, true, true, -9223372036854775808.0, true, 9223372036854775808.0, &trap_invalid, &trap_overflow),
+                    else => try emitTruncTrap(&m, false, true, false, -1.0, false, 18446744073709551616.0, &trap_invalid, &trap_overflow),
+                }
+                try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                stack[depth] = .runtime;
+            },
+            op_f32_convert_i32_s,
+            op_f32_convert_i32_u,
+            op_f32_convert_i64_s,
+            op_f32_convert_i64_u,
+            op_f64_convert_i32_s,
+            op_f64_convert_i32_u,
+            op_f64_convert_i64_s,
+            op_f64_convert_i64_u,
+            => {
+                if (sp == 0) return null;
+                const depth = sp - 1;
+                try materialize(&m, stack[depth], num_locals, depth);
+                const source_i32 = op == op_f32_convert_i32_s or op == op_f32_convert_i32_u or
+                    op == op_f64_convert_i32_s or op == op_f64_convert_i32_u;
+                if (source_i32)
+                    try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth))
+                else
+                    try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+
+                switch (op) {
+                    op_f32_convert_i32_s => try m.cvtI32ToFloat(.xmm0, .rax),
+                    op_f32_convert_i32_u, op_f32_convert_i64_s => try m.cvtI64ToFloat(.xmm0, .rax),
+                    op_f32_convert_i64_u => try emitConvertU64ToFloat(&m, true),
+                    op_f64_convert_i32_s => try m.cvtI32ToDouble(.xmm0, .rax),
+                    op_f64_convert_i32_u, op_f64_convert_i64_s => try m.cvtI64ToDouble(.xmm0, .rax),
+                    else => try emitConvertU64ToFloat(&m, false),
+                }
+                if (op == op_f32_convert_i32_s or op == op_f32_convert_i32_u or
+                    op == op_f32_convert_i64_s or op == op_f32_convert_i64_u)
+                    try m.movDRegFromXmm(.rax, .xmm0)
+                else
+                    try m.movQRegFromXmm(.rax, .xmm0);
+                try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                stack[depth] = .runtime;
+            },
             op_i32_wrap_i64, op_i64_extend_i32_s, op_i64_extend_i32_u => {
                 if (sp == 0) return null;
                 const depth = sp - 1;
@@ -805,6 +1254,8 @@ pub fn compile(
             op_i32_load16_s,
             op_i32_load16_u,
             op_i64_load,
+            op_f32_load,
+            op_f64_load,
             op_i64_load8_s,
             op_i64_load8_u,
             op_i64_load16_s,
@@ -820,18 +1271,18 @@ pub fn compile(
                 const width: u32 = switch (op) {
                     op_i32_load8_s, op_i32_load8_u, op_i64_load8_s, op_i64_load8_u => 1,
                     op_i32_load16_s, op_i32_load16_u, op_i64_load16_s, op_i64_load16_u => 2,
-                    op_i32_load, op_i64_load32_s, op_i64_load32_u => 4,
+                    op_i32_load, op_f32_load, op_i64_load32_s, op_i64_load32_u => 4,
                     else => 8,
                 };
                 try emitMemAddress(&m, offset, width, &trap_oob);
                 trap_oob_used = true;
                 switch (op) {
-                    op_i32_load => try m.load32Disp32(.rax, .r11, 0),
+                    op_i32_load, op_f32_load => try m.load32Disp32(.rax, .r11, 0),
                     op_i32_load8_s => try m.load8Signed32Disp32(.rax, .r11, 0),
                     op_i32_load8_u => try m.load8Disp32(.rax, .r11, 0),
                     op_i32_load16_s => try m.load16Signed32Disp32(.rax, .r11, 0),
                     op_i32_load16_u => try m.load16Disp32(.rax, .r11, 0),
-                    op_i64_load => try m.load64Disp32(.rax, .r11, 0),
+                    op_i64_load, op_f64_load => try m.load64Disp32(.rax, .r11, 0),
                     op_i64_load8_s => try m.load8Signed64Disp32(.rax, .r11, 0),
                     op_i64_load8_u => try m.load8Disp32(.rax, .r11, 0),
                     op_i64_load16_s => try m.load16Signed64Disp32(.rax, .r11, 0),
@@ -846,6 +1297,8 @@ pub fn compile(
             op_i32_store8,
             op_i32_store16,
             op_i64_store,
+            op_f32_store,
+            op_f64_store,
             op_i64_store8,
             op_i64_store16,
             op_i64_store32,
@@ -861,7 +1314,7 @@ pub fn compile(
                 const width: u32 = switch (op) {
                     op_i32_store8, op_i64_store8 => 1,
                     op_i32_store16, op_i64_store16 => 2,
-                    op_i32_store, op_i64_store32 => 4,
+                    op_i32_store, op_f32_store, op_i64_store32 => 4,
                     else => 8,
                 };
                 try emitMemAddress(&m, offset, width, &trap_oob);
@@ -869,7 +1322,7 @@ pub fn compile(
                 switch (op) {
                     op_i32_store8, op_i64_store8 => try m.store8Disp32(.r11, 0, .rax),
                     op_i32_store16, op_i64_store16 => try m.store16Disp32(.r11, 0, .rax),
-                    op_i32_store, op_i64_store32 => try m.store32Disp32(.r11, 0, .rax),
+                    op_i32_store, op_f32_store, op_i64_store32 => try m.store32Disp32(.r11, 0, .rax),
                     else => try m.store64Disp32(.r11, 0, .rax),
                 }
                 sp -= 2;
@@ -907,7 +1360,34 @@ pub fn compile(
             },
             op_misc_prefix => {
                 const sub = readUleb32(body, &i) orelse return null;
-                if (sub == 11) {
+                if (sub <= 7) {
+                    // §4.3.3 saturating float-to-int truncations. Explicit
+                    // branches implement NaN -> 0 and clamp both bounds;
+                    // in-range values share the trapping forms' SSE2 lowering.
+                    if (sp == 0) return null;
+                    const depth = sp - 1;
+                    try materialize(&m, stack[depth], num_locals, depth);
+                    const src_f32 = (sub & 0x2) == 0;
+                    if (src_f32) {
+                        try m.load32Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                        try m.movDXmmFromReg(.xmm0, .rax);
+                    } else {
+                        try m.load64Disp32(.rax, .r12, scratchOffset(num_locals, depth));
+                        try m.movQXmmFromReg(.xmm0, .rax);
+                    }
+                    switch (sub) {
+                        0 => try emitTruncSat(&m, true, false, true),
+                        1 => try emitTruncSat(&m, true, false, false),
+                        2 => try emitTruncSat(&m, false, false, true),
+                        3 => try emitTruncSat(&m, false, false, false),
+                        4 => try emitTruncSat(&m, true, true, true),
+                        5 => try emitTruncSat(&m, true, true, false),
+                        6 => try emitTruncSat(&m, false, true, true),
+                        else => try emitTruncSat(&m, false, true, false),
+                    }
+                    try m.store64Disp32(.r12, scratchOffset(num_locals, depth), .rax);
+                    stack[depth] = .runtime;
+                } else if (sub == 11) {
                     const memory_index = readUleb32(body, &i) orelse return null;
                     if (memory_index != 0 or memoryIs64(module, memory_index) != false or sp < 3) return null;
                     const below = sp - 3;
@@ -1161,6 +1641,11 @@ pub fn compile(
         try m.movImm64(.rax, config.trap_int_overflow);
         try m.jump(&epilogue);
     }
+    if (trap_invalid_used) {
+        try m.bind(&trap_invalid);
+        try m.movImm64(.rax, config.trap_invalid_conversion);
+        try m.jump(&epilogue);
+    }
     if (trap_oob_used) {
         try m.bind(&trap_oob);
         try m.movImm64(.rax, config.trap_out_of_bounds);
@@ -1265,6 +1750,260 @@ fn materializeRange(
     return true;
 }
 
+fn roundF32Bits(bits: u32, mode: u32) callconv(.c) u32 {
+    return @bitCast(roundFloat(f32, @bitCast(bits), mode));
+}
+
+fn roundF64Bits(bits: u64, mode: u32) callconv(.c) u64 {
+    return @bitCast(roundFloat(f64, @bitCast(bits), mode));
+}
+
+fn roundFloat(comptime T: type, value: T, mode: u32) T {
+    return switch (mode) {
+        0 => @ceil(value),
+        1 => @floor(value),
+        2 => @trunc(value),
+        3 => float_ops.roundEven(T, value),
+        else => value,
+    };
+}
+
+/// Emit a §4.3.3 trapping float-to-int truncation. The operand enters in
+/// xmm0. NaN has its own trap; finite values outside the operation's exact
+/// half-open input interval use the integer-overflow trap. Only then is CVTT's
+/// otherwise ambiguous integer-indefinite result safe to consume.
+fn emitTruncTrap(
+    m: *x64.Masm,
+    comptime src_f32: bool,
+    comptime to_i64: bool,
+    comptime signed: bool,
+    comptime lo: f64,
+    comptime lo_inclusive: bool,
+    comptime hi: f64,
+    invalid: *x64.Masm.Label,
+    overflow: *x64.Masm.Label,
+) Error!void {
+    const lo_bits: u64 = if (src_f32)
+        @as(u32, @bitCast(@as(f32, @floatCast(lo))))
+    else
+        @bitCast(lo);
+    const hi_bits: u64 = if (src_f32)
+        @as(u32, @bitCast(@as(f32, @floatCast(hi))))
+    else
+        @bitCast(hi);
+
+    if (src_f32)
+        try m.ucomisFloat(.xmm0, .xmm0)
+    else
+        try m.ucomisDouble(.xmm0, .xmm0);
+    try m.jumpCond(.parity, invalid);
+
+    try m.movImm64(.r10, lo_bits);
+    if (src_f32) {
+        try m.movDXmmFromReg(.xmm1, .r10);
+        try m.ucomisFloat(.xmm0, .xmm1);
+    } else {
+        try m.movQXmmFromReg(.xmm1, .r10);
+        try m.ucomisDouble(.xmm0, .xmm1);
+    }
+    try m.jumpCond(if (lo_inclusive) .below else .below_or_equal, overflow);
+
+    try m.movImm64(.r10, hi_bits);
+    if (src_f32) {
+        try m.movDXmmFromReg(.xmm1, .r10);
+        try m.ucomisFloat(.xmm0, .xmm1);
+    } else {
+        try m.movQXmmFromReg(.xmm1, .r10);
+        try m.ucomisDouble(.xmm0, .xmm1);
+    }
+    try m.jumpCond(.above_or_equal, overflow);
+
+    try emitInRangeFloatToInt(m, src_f32, to_i64, signed);
+}
+
+/// Emit a non-trapping saturating float-to-int conversion. The source enters
+/// in xmm0 and the exact integer bits leave in rax.
+fn emitTruncSat(
+    m: *x64.Masm,
+    comptime src_f32: bool,
+    comptime to_i64: bool,
+    comptime signed: bool,
+) Error!void {
+    const lo: f64 = if (signed)
+        (if (to_i64) -9223372036854775808.0 else -2147483648.0)
+    else
+        0.0;
+    const hi: f64 = if (to_i64)
+        (if (signed) 9223372036854775808.0 else 18446744073709551616.0)
+    else
+        (if (signed) 2147483648.0 else 4294967296.0);
+    const lo_bits: u64 = if (src_f32)
+        @as(u32, @bitCast(@as(f32, @floatCast(lo))))
+    else
+        @bitCast(lo);
+    const hi_bits: u64 = if (src_f32)
+        @as(u32, @bitCast(@as(f32, @floatCast(hi))))
+    else
+        @bitCast(hi);
+    const min_result: u64 = if (!signed) 0 else if (to_i64) 0x8000_0000_0000_0000 else 0x8000_0000;
+    const max_result: u64 = if (to_i64)
+        (if (signed) 0x7fff_ffff_ffff_ffff else 0xffff_ffff_ffff_ffff)
+    else
+        (if (signed) 0x7fff_ffff else 0xffff_ffff);
+
+    var nan: x64.Masm.Label = .{};
+    var clamp_low: x64.Masm.Label = .{};
+    var clamp_high: x64.Masm.Label = .{};
+    var done: x64.Masm.Label = .{};
+    defer nan.deinit(m.gpa);
+    defer clamp_low.deinit(m.gpa);
+    defer clamp_high.deinit(m.gpa);
+    defer done.deinit(m.gpa);
+
+    if (src_f32)
+        try m.ucomisFloat(.xmm0, .xmm0)
+    else
+        try m.ucomisDouble(.xmm0, .xmm0);
+    try m.jumpCond(.parity, &nan);
+
+    try m.movImm64(.r10, lo_bits);
+    if (src_f32) {
+        try m.movDXmmFromReg(.xmm1, .r10);
+        try m.ucomisFloat(.xmm0, .xmm1);
+    } else {
+        try m.movQXmmFromReg(.xmm1, .r10);
+        try m.ucomisDouble(.xmm0, .xmm1);
+    }
+    try m.jumpCond(.below_or_equal, &clamp_low);
+
+    try m.movImm64(.r10, hi_bits);
+    if (src_f32) {
+        try m.movDXmmFromReg(.xmm1, .r10);
+        try m.ucomisFloat(.xmm0, .xmm1);
+    } else {
+        try m.movQXmmFromReg(.xmm1, .r10);
+        try m.ucomisDouble(.xmm0, .xmm1);
+    }
+    try m.jumpCond(.above_or_equal, &clamp_high);
+
+    try emitInRangeFloatToInt(m, src_f32, to_i64, signed);
+    try m.jump(&done);
+
+    try m.bind(&nan);
+    try m.movImm64(.rax, 0);
+    try m.jump(&done);
+    try m.bind(&clamp_low);
+    try m.movImm64(.rax, min_result);
+    try m.jump(&done);
+    try m.bind(&clamp_high);
+    try m.movImm64(.rax, max_result);
+    try m.bind(&done);
+}
+
+fn emitInRangeFloatToInt(
+    m: *x64.Masm,
+    comptime src_f32: bool,
+    comptime to_i64: bool,
+    comptime signed: bool,
+) Error!void {
+    if (signed) {
+        if (src_f32) {
+            if (to_i64)
+                try m.cvttFloatToI64(.rax, .xmm0)
+            else
+                try m.cvttFloatToI32(.rax, .xmm0);
+        } else {
+            if (to_i64)
+                try m.cvttDoubleToI64(.rax, .xmm0)
+            else
+                try m.cvttDoubleToI32(.rax, .xmm0);
+        }
+    } else if (to_i64) {
+        try emitTruncFloatToU64(m, src_f32);
+    } else if (src_f32) {
+        // Every valid u32 result fits a signed i64 conversion.
+        try m.cvttFloatToI64(.rax, .xmm0);
+    } else {
+        try m.cvttDoubleToI64(.rax, .xmm0);
+    }
+}
+
+/// x86_64 has no baseline scalar float-to-u64 conversion. Values below 2^63
+/// use CVTT directly; the high half converts `value - 2^63` and restores the
+/// top bit. `emitTruncTrap` has already excluded NaN and values outside u64.
+fn emitTruncFloatToU64(m: *x64.Masm, comptime src_f32: bool) Error!void {
+    const two63_bits: u64 = if (src_f32)
+        @as(u32, @bitCast(@as(f32, 9223372036854775808.0)))
+    else
+        @bitCast(@as(f64, 9223372036854775808.0));
+    var low_half: x64.Masm.Label = .{};
+    var done: x64.Masm.Label = .{};
+    defer low_half.deinit(m.gpa);
+    defer done.deinit(m.gpa);
+
+    try m.movImm64(.r10, two63_bits);
+    if (src_f32) {
+        try m.movDXmmFromReg(.xmm1, .r10);
+        try m.ucomisFloat(.xmm0, .xmm1);
+    } else {
+        try m.movQXmmFromReg(.xmm1, .r10);
+        try m.ucomisDouble(.xmm0, .xmm1);
+    }
+    try m.jumpCond(.below, &low_half);
+
+    if (src_f32) {
+        try m.subFloat(.xmm0, .xmm1);
+        try m.cvttFloatToI64(.rax, .xmm0);
+    } else {
+        try m.subDouble(.xmm0, .xmm1);
+        try m.cvttDoubleToI64(.rax, .xmm0);
+    }
+    try m.movImm64(.r10, 0x8000_0000_0000_0000);
+    try m.orReg64(.rax, .r10);
+    try m.jump(&done);
+
+    try m.bind(&low_half);
+    if (src_f32)
+        try m.cvttFloatToI64(.rax, .xmm0)
+    else
+        try m.cvttDoubleToI64(.rax, .xmm0);
+    try m.bind(&done);
+}
+
+/// SSE2 has signed i64-to-float conversion only. For values in the unsigned
+/// high half, convert `(value >> 1) | (value & 1)` and double the result; this
+/// is the standard correctly-rounded lowering used by baseline wasm engines.
+/// Enters with the u64 in rax and leaves the result in xmm0.
+fn emitConvertU64ToFloat(m: *x64.Masm, output_f32: bool) Error!void {
+    var low_half: x64.Masm.Label = .{};
+    var done: x64.Masm.Label = .{};
+    defer low_half.deinit(m.gpa);
+    defer done.deinit(m.gpa);
+
+    try m.testReg64(.rax, .rax);
+    try m.jumpCond(.not_sign, &low_half);
+    try m.movReg64(.rcx, .rax);
+    try m.shrImm8(.rax, 1);
+    try m.movImm64(.r10, 1);
+    try m.andReg64(.rcx, .r10);
+    try m.orReg64(.rax, .rcx);
+    if (output_f32) {
+        try m.cvtI64ToFloat(.xmm0, .rax);
+        try m.addFloat(.xmm0, .xmm0);
+    } else {
+        try m.cvtI64ToDouble(.xmm0, .rax);
+        try m.addDouble(.xmm0, .xmm0);
+    }
+    try m.jump(&done);
+
+    try m.bind(&low_half);
+    if (output_f32)
+        try m.cvtI64ToFloat(.xmm0, .rax)
+    else
+        try m.cvtI64ToDouble(.xmm0, .rax);
+    try m.bind(&done);
+}
+
 fn compareCondition(op: u8) x64.Cond {
     return switch (op) {
         op_i32_eq => .equal,
@@ -1304,8 +2043,8 @@ fn refuse(config: Config, stage: RefusalStage, opcode: u8) ?[]const u8 {
     return null;
 }
 
-fn isIntegerScalar(value_type: ValType) bool {
-    return value_type == .i32 or value_type == .i64;
+fn isScalar(value_type: ValType) bool {
+    return value_type == .i32 or value_type == .i64 or value_type == .f32 or value_type == .f64;
 }
 
 /// Resolve the global index space (imports first, then definitions) without
@@ -1469,7 +2208,7 @@ fn callGateAddress(config: Config, callee: DefinedCallee) ?usize {
     _ = stub;
     const base = config.call_gates_base orelse return null;
     if (callee.local_index >= config.call_gates_len) return null;
-    for (callee.func.local_types) |local_type| if (!isIntegerScalar(local_type)) return null;
+    for (callee.func.local_types) |local_type| if (!isScalar(local_type)) return null;
     const offset = std.math.mul(usize, callee.local_index, config.call_gate_stride) catch return null;
     return std.math.add(usize, base, offset) catch null;
 }
@@ -1481,7 +2220,7 @@ fn readBlockArity(body: []const u8, index: *usize) ?u32 {
             index.* += 1;
             break :blk 0;
         },
-        0x7f, 0x7e => blk: {
+        0x7f, 0x7e, 0x7d, 0x7c => blk: {
             index.* += 1;
             break :blk 1;
         },
@@ -1540,6 +2279,20 @@ fn readSleb64(body: []const u8, index: *usize) ?i64 {
         if (shift >= 70) return null;
     }
     return null;
+}
+
+fn readF32Bits(body: []const u8, index: *usize) ?u32 {
+    if (index.* > body.len or body.len - index.* < @sizeOf(u32)) return null;
+    const bits = std.mem.readInt(u32, body[index.*..][0..@sizeOf(u32)], .little);
+    index.* += @sizeOf(u32);
+    return bits;
+}
+
+fn readF64Bits(body: []const u8, index: *usize) ?u64 {
+    if (index.* > body.len or body.len - index.* < @sizeOf(u64)) return null;
+    const bits = std.mem.readInt(u64, body[index.*..][0..@sizeOf(u64)], .little);
+    index.* += @sizeOf(u64);
+    return bits;
 }
 
 fn readMemArg(body: []const u8, index: *usize) ?u32 {

--- a/src/runtime/wasm/tests.zig
+++ b/src/runtime/wasm/tests.zig
@@ -2928,7 +2928,7 @@ const f64_min_body = [_]u8{
 };
 
 test "wasm spasm: f64.min compiles and runs in the FP unit" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f64_min_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_min_body);
 
@@ -2955,6 +2955,18 @@ test "wasm spasm: f64.min compiles and runs in the FP unit" {
     // min(3.0, 5.0) == 3.0, via FMIN.
     try testing.expectEqual(@as(f64, 3.0), @as(f64, @bitCast(@as(u64, @truncate(res[0])))));
     try testing.expect(instance.spasm_runs >= 1);
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, -0.0))));
+    cells[1] = @as(u128, @as(u64, @bitCast(@as(f64, 0.0))));
+    const zero_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(zero_res);
+    try testing.expect(std.math.signbit(@as(f64, @bitCast(@as(u64, @truncate(zero_res[0]))))));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(std.math.nan(f64))));
+    cells[1] = @as(u128, @as(u64, @bitCast(@as(f64, 1.0))));
+    const nan_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(nan_res);
+    try testing.expect(std.math.isNan(@as(f64, @bitCast(@as(u64, @truncate(nan_res[0]))))));
 }
 
 // An `(f64,f64)->f64` copysign exported as "cs" (0xa6 = f64.copysign).
@@ -2966,7 +2978,7 @@ const f64_copysign_body = [_]u8{
 };
 
 test "wasm spasm: f64.copysign combines magnitude and sign by bit ops" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f64_copysign_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_copysign_body);
 
@@ -3005,7 +3017,7 @@ const reinterpret_body = [_]u8{
 };
 
 test "wasm spasm: i32.reinterpret_f32 passes the bits through" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + reinterpret_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &reinterpret_body);
 
@@ -3042,7 +3054,7 @@ const promote_body = [_]u8{
 };
 
 test "wasm spasm: f64.promote_f32 widens via FCVT" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + promote_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &promote_body);
 
@@ -3079,7 +3091,7 @@ const demote_body = [_]u8{
 };
 
 test "wasm spasm: f32.demote_f64 narrows via FCVT" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + demote_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &demote_body);
 
@@ -3116,7 +3128,7 @@ const convert_i32_s_body = [_]u8{
 };
 
 test "wasm spasm: f64.convert_i32_s widens a signed i32 via SCVTF" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + convert_i32_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i32_s_body);
 
@@ -3154,7 +3166,7 @@ const convert_i32_u_body = [_]u8{
 };
 
 test "wasm spasm: f32.convert_i32_u widens an unsigned i32 via UCVTF" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + convert_i32_u_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i32_u_body);
 
@@ -3191,7 +3203,7 @@ const convert_i64_s_body = [_]u8{
 };
 
 test "wasm spasm: f64.convert_i64_s widens a signed i64 via SCVTF (X-form)" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + convert_i64_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &convert_i64_s_body);
 
@@ -3219,6 +3231,43 @@ test "wasm spasm: f64.convert_i64_s widens a signed i64 via SCVTF (X-form)" {
     try testing.expect(instance.spasm_runs >= 1);
 }
 
+// An `(i64)->f64` unsigned convert exported as "u64" (0xba =
+// f64.convert_i64_u). maxInt(u64) rounds to 2^64 in binary64.
+const convert_i64_u_body = [_]u8{
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7e, 0x01, 0x7c, // type (i64)->f64
+    0x03, 0x02, 0x01, 0x00, // func 0 : type 0
+    0x07, 0x07, 0x01, 0x03, 0x75, 0x36, 0x34, 0x00, 0x00, // export "u64" -> 0
+    0x0a, 0x07, 0x01, 0x05, 0x00, 0x20, 0x00, 0xba, 0x0b, // local.get 0; f64.convert_i64_u; end
+};
+
+test "wasm spasm: f64.convert_i64_u handles the unsigned high half" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    var buf: [8 + convert_i64_u_body.len]u8 = undefined;
+    const bytes = withPreamble(&buf, &convert_i64_u_body);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const m = try wasm.decode(a, bytes);
+    const mp = try a.create(wasm.Module);
+    mp.* = m;
+
+    var instance: interp.Instance = undefined;
+    try interp.instantiate(&instance, a, testing.allocator, mp, .{});
+    defer instance.deinit();
+    instance.spasm_enabled = true;
+
+    const fidx = funcExport(mp, "u64") orelse return error.NoSuchExport;
+    const cells = try a.alloc(u128, 1);
+    cells[0] = std.math.maxInt(u64);
+
+    const res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(res);
+
+    try testing.expectEqual(@as(f64, 18446744073709551616.0), @as(f64, @bitCast(@as(u64, @truncate(res[0])))));
+    try testing.expect(instance.spasm_runs >= 1);
+}
+
 // An `(f32)->i32` saturating truncation exported as "ts": local.get 0;
 // i32.trunc_sat_f32_s; end. The op is the 0xFC prefix + sub-opcode 0.
 const trunc_sat_s_body = [_]u8{
@@ -3228,8 +3277,8 @@ const trunc_sat_s_body = [_]u8{
     0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0xfc, 0x00, 0x0b, // local.get 0; i32.trunc_sat_f32_s; end
 };
 
-test "wasm spasm: i32.trunc_sat_f32_s saturates out-of-range via FCVTZS" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+test "wasm spasm: i32.trunc_sat_f32_s clamps both bounds" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + trunc_sat_s_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &trunc_sat_s_body);
 
@@ -3254,6 +3303,11 @@ test "wasm spasm: i32.trunc_sat_f32_s saturates out-of-range via FCVTZS" {
 
     // 1e30 is far past INT32_MAX, so the saturating truncation clamps to it.
     try testing.expectEqual(@as(u32, 0x7fffffff), @as(u32, @truncate(res[0])));
+
+    cells[0] = @as(u128, @as(u32, @bitCast(@as(f32, -1e30))));
+    const negative_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(negative_res);
+    try testing.expectEqual(@as(u32, 0x80000000), @as(u32, @truncate(negative_res[0])));
     try testing.expect(instance.spasm_runs >= 1);
 }
 
@@ -3266,8 +3320,8 @@ const trunc_sat_u_body = [_]u8{
     0x0a, 0x08, 0x01, 0x06, 0x00, 0x20, 0x00, 0xfc, 0x07, 0x0b, // local.get 0; i64.trunc_sat_f64_u; end
 };
 
-test "wasm spasm: i64.trunc_sat_f64_u maps NaN to zero via FCVTZU" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+test "wasm spasm: i64.trunc_sat_f64_u handles NaN, bounds, and the high half" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + trunc_sat_u_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &trunc_sat_u_body);
 
@@ -3290,8 +3344,23 @@ test "wasm spasm: i64.trunc_sat_f64_u maps NaN to zero via FCVTZU" {
     const res = try interp.invoke(&instance, testing.allocator, fidx, cells);
     defer testing.allocator.free(res);
 
-    // The saturating truncation maps NaN to 0 (FCVTZU's NaN behavior).
+    // Saturating truncation maps NaN to 0 on every backend.
     try testing.expectEqual(@as(u64, 0), @as(u64, @truncate(res[0])));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, 9223372036854779904.0))));
+    const high_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(high_res);
+    try testing.expectEqual(@as(u64, 0x8000_0000_0000_1000), @as(u64, @truncate(high_res[0])));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, -1.5))));
+    const negative_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(negative_res);
+    try testing.expectEqual(@as(u64, 0), @as(u64, @truncate(negative_res[0])));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, 18446744073709551616.0))));
+    const overflow_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(overflow_res);
+    try testing.expectEqual(std.math.maxInt(u64), @as(u64, @truncate(overflow_res[0])));
     try testing.expect(instance.spasm_runs >= 1);
 }
 
@@ -3321,8 +3390,8 @@ fn truncTrapInstance(a: std.mem.Allocator, mp: **wasm.Module) !interp.Instance {
     return instance;
 }
 
-test "wasm spasm: i32.trunc_f32_s converts an in-range value via FCVTZS" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+test "wasm spasm: i32.trunc_f32_s converts an in-range value natively" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3343,7 +3412,7 @@ test "wasm spasm: i32.trunc_f32_s converts an in-range value via FCVTZS" {
 }
 
 test "wasm spasm: i32.trunc_f32_s traps on NaN (invalid conversion)" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3361,7 +3430,7 @@ test "wasm spasm: i32.trunc_f32_s traps on NaN (invalid conversion)" {
 }
 
 test "wasm spasm: i32.trunc_f32_s traps on overflow (out of range)" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var arena = std.heap.ArenaAllocator.init(testing.allocator);
     defer arena.deinit();
     const a = arena.allocator();
@@ -3373,6 +3442,52 @@ test "wasm spasm: i32.trunc_f32_s traps on overflow (out of range)" {
     const cells = try a.alloc(u128, 1);
     cells[0] = @as(u128, @as(u32, @bitCast(@as(f32, 1e30)))); // far past INT32_MAX
 
+    try testing.expectError(error.IntegerOverflow, interp.invoke(&instance, testing.allocator, fidx, cells));
+    try testing.expect(instance.spasm_runs >= 1);
+}
+
+// An `(f64)->i64` unsigned trapping truncation exported as "tu64"
+// (0xb1 = i64.trunc_f64_u). This exercises the range above INT64_MAX,
+// which x86_64's signed CVTTSD2SI instruction cannot convert directly.
+const trunc_u64_body = [_]u8{
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7c, 0x01, 0x7e, // type (f64)->i64
+    0x03, 0x02, 0x01, 0x00, // func 0 : type 0
+    0x07, 0x08, 0x01, 0x04, 0x74, 0x75, 0x36, 0x34, 0x00, 0x00, // export "tu64" -> 0
+    0x0a, 0x07, 0x01, 0x05, 0x00, 0x20, 0x00, 0xb1, 0x0b, // local.get 0; i64.trunc_f64_u; end
+};
+
+test "wasm spasm: i64.trunc_f64_u handles the unsigned high half and bounds" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    var buf: [8 + trunc_u64_body.len]u8 = undefined;
+    const bytes = withPreamble(&buf, &trunc_u64_body);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const m = try wasm.decode(a, bytes);
+    const mp = try a.create(wasm.Module);
+    mp.* = m;
+
+    var instance: interp.Instance = undefined;
+    try interp.instantiate(&instance, a, testing.allocator, mp, .{});
+    defer instance.deinit();
+    instance.spasm_enabled = true;
+
+    const fidx = funcExport(mp, "tu64") orelse return error.NoSuchExport;
+    const cells = try a.alloc(u128, 1);
+    const high_value: f64 = 9223372036854779904.0; // 2^63 + 4096
+    cells[0] = @as(u128, @as(u64, @bitCast(high_value)));
+
+    const high_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(high_res);
+    try testing.expectEqual(@as(u64, 0x8000_0000_0000_1000), @as(u64, @truncate(high_res[0])));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, -0.5))));
+    const negative_fraction_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(negative_fraction_res);
+    try testing.expectEqual(@as(u64, 0), @as(u64, @truncate(negative_fraction_res[0])));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, 18446744073709551616.0))));
     try testing.expectError(error.IntegerOverflow, interp.invoke(&instance, testing.allocator, fidx, cells));
     try testing.expect(instance.spasm_runs >= 1);
 }
@@ -3723,7 +3838,7 @@ const f64_lt_body = [_]u8{
 };
 
 test "wasm spasm: f64.lt compiles and compares in the FP unit" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f64_lt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_lt_body);
 
@@ -3749,6 +3864,11 @@ test "wasm spasm: f64.lt compiles and compares in the FP unit" {
 
     try testing.expectEqual(@as(u32, 1), @as(u32, @truncate(res[0]))); // 1.5 < 2.5
     try testing.expect(instance.spasm_runs >= 1);
+
+    cells[0] = @as(u128, @as(u64, @bitCast(std.math.nan(f64))));
+    const nan_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(nan_res);
+    try testing.expectEqual(@as(u32, 0), @as(u32, @truncate(nan_res[0])));
 }
 
 // A one-page-memory module: `(i32)->f64` exported as "ld" — local.get 0;
@@ -3762,7 +3882,7 @@ const f64_load_body = [_]u8{
 };
 
 test "wasm spasm: f64.load reads an eight-byte double" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f64_load_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f64_load_body);
 
@@ -3799,7 +3919,7 @@ const f32_add_body = [_]u8{
 };
 
 test "wasm spasm: f32.add compiles and runs Spasm-compiled" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f32_add_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f32_add_body);
 
@@ -3838,7 +3958,7 @@ const f32_sqrt_body = [_]u8{
 };
 
 test "wasm spasm: f32.sqrt compiles and runs in the FP unit" {
-    if (comptime !@import("spasm.zig").full_coverage_supported) return error.SkipZigTest;
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
     var buf: [8 + f32_sqrt_body.len]u8 = undefined;
     const bytes = withPreamble(&buf, &f32_sqrt_body);
 
@@ -3863,6 +3983,84 @@ test "wasm spasm: f32.sqrt compiles and runs in the FP unit" {
 
     // sqrt(16.0) == 4.0 in single precision, via FSQRT through the W↔S bridge.
     try testing.expectEqual(@as(f32, 4.0), @as(f32, @bitCast(@as(u32, @truncate(res[0])))));
+    try testing.expect(instance.spasm_runs >= 1);
+}
+
+// An `(f32)->f32` ceil exported as "ceil" (0x8d = f32.ceil).
+const f32_ceil_body = [_]u8{
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7d, 0x01, 0x7d, // type (f32)->f32
+    0x03, 0x02, 0x01, 0x00, // func 0 : type 0
+    0x07, 0x08, 0x01, 0x04, 0x63, 0x65, 0x69, 0x6c, 0x00, 0x00, // export "ceil" -> 0
+    0x0a, 0x07, 0x01, 0x05, 0x00, 0x20, 0x00, 0x8d, 0x0b, // local.get 0; f32.ceil; end
+};
+
+test "wasm spasm: f32.ceil preserves directed rounding and negative zero" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    var buf: [8 + f32_ceil_body.len]u8 = undefined;
+    const bytes = withPreamble(&buf, &f32_ceil_body);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const m = try wasm.decode(a, bytes);
+    const mp = try a.create(wasm.Module);
+    mp.* = m;
+
+    var instance: interp.Instance = undefined;
+    try interp.instantiate(&instance, a, testing.allocator, mp, .{});
+    defer instance.deinit();
+    instance.spasm_enabled = true;
+
+    const fidx = funcExport(mp, "ceil") orelse return error.NoSuchExport;
+    const cells = try a.alloc(u128, 1);
+    cells[0] = @as(u128, @as(u32, @bitCast(@as(f32, 1.25))));
+    const positive_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(positive_res);
+    try testing.expectEqual(@as(f32, 2.0), @as(f32, @bitCast(@as(u32, @truncate(positive_res[0])))));
+
+    cells[0] = @as(u128, @as(u32, @bitCast(@as(f32, -0.25))));
+    const zero_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(zero_res);
+    try testing.expect(std.math.signbit(@as(f32, @bitCast(@as(u32, @truncate(zero_res[0]))))));
+    try testing.expect(instance.spasm_runs >= 1);
+}
+
+// An `(f64)->f64` nearest exported as "near" (0x9e = f64.nearest).
+const f64_nearest_body = [_]u8{
+    0x01, 0x06, 0x01, 0x60, 0x01, 0x7c, 0x01, 0x7c, // type (f64)->f64
+    0x03, 0x02, 0x01, 0x00, // func 0 : type 0
+    0x07, 0x08, 0x01, 0x04, 0x6e, 0x65, 0x61, 0x72, 0x00, 0x00, // export "near" -> 0
+    0x0a, 0x07, 0x01, 0x05, 0x00, 0x20, 0x00, 0x9e, 0x0b, // local.get 0; f64.nearest; end
+};
+
+test "wasm spasm: f64.nearest rounds ties to even" {
+    if (comptime !@import("spasm.zig").supported) return error.SkipZigTest;
+    var buf: [8 + f64_nearest_body.len]u8 = undefined;
+    const bytes = withPreamble(&buf, &f64_nearest_body);
+
+    var arena = std.heap.ArenaAllocator.init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+    const m = try wasm.decode(a, bytes);
+    const mp = try a.create(wasm.Module);
+    mp.* = m;
+
+    var instance: interp.Instance = undefined;
+    try interp.instantiate(&instance, a, testing.allocator, mp, .{});
+    defer instance.deinit();
+    instance.spasm_enabled = true;
+
+    const fidx = funcExport(mp, "near") orelse return error.NoSuchExport;
+    const cells = try a.alloc(u128, 1);
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, 2.5))));
+    const even_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(even_res);
+    try testing.expectEqual(@as(f64, 2.0), @as(f64, @bitCast(@as(u64, @truncate(even_res[0])))));
+
+    cells[0] = @as(u128, @as(u64, @bitCast(@as(f64, -3.5))));
+    const negative_res = try interp.invoke(&instance, testing.allocator, fidx, cells);
+    defer testing.allocator.free(negative_res);
+    try testing.expectEqual(@as(f64, -4.0), @as(f64, @bitCast(@as(u64, @truncate(negative_res[0])))));
     try testing.expect(instance.spasm_runs >= 1);
 }
 

--- a/wasm-bench-results.md
+++ b/wasm-bench-results.md
@@ -16,6 +16,26 @@ run against the previous section with the *same host*.
 
 ## History
 
+### 2026-09-10, x86_64 scalar-float expansion, target `x86_64-macos` under Rosetta on `Darwin 25.6.0 arm64`
+
+Three ReleaseFast ABBA samples after adding the complete f32/f64 scalar ALU and
+conversion family to the SysV backend. The fixed benchmark workloads are still
+integer-only, so this is a regression sentinel for the shared entry, frame, and
+call paths rather than a float-throughput claim. The full forced-Spasm corpus
+stayed `58,779/58,779`, while x86 native engagement rose from 10,606 to 23,667
+entries and from 1,365 to 2,320 compiled functions.
+
+Every checksum matched, every timed row stayed native, and diagnostics reported
+`helper 0/0`; all three workloads remained above the 5x Spasm target. The new
+SSE2-portable rounding helpers are covered by focused and spec-corpus tests but
+are not exercised by these workloads.
+
+| bench | interpreter ms/rep | Spasm bare ms/rep | Spasm wake ms/rep | paired speedup | wake / bare |
+|---|---:|---:|---:|---:|---:|
+| loop `sum(i*i)`, n=2,000,000 | 59.325-70.117 | 8.082-8.110 | 7.972-8.150 | 7.32-8.68x | 0.984-1.005x |
+| `fib(32)` self-recursive | 248.464-318.792 | 34.937-37.996 | 35.088-36.217 | 7.11-8.39x | 0.953-1.004x |
+| `fib(32)` cross-recursive | 231.803-254.294 | 37.016-38.513 | 36.773-37.056 | 6.02-6.87x | 0.958-1.000x |
+
 ### 2026-08-12, x86_64 integer/memory expansion, target `x86_64-macos` under Rosetta on `Darwin 25.6.0 arm64`
 
 Three ReleaseFast ABBA samples after extending the SysV backend through i64,

--- a/wasm-results.md
+++ b/wasm-results.md
@@ -31,9 +31,11 @@ proposal's `(ref exn)` text syntax, so its `.wast` files don't lower
 
 The forced-Spasm differential posture (`--spasm`) produces this exact score on
 both qualified code-generation targets: native AArch64 and x86_64-macos under
-Rosetta (2026-08-10). Gating runs add `--require-spasm-entry`; focused target
+Rosetta (2026-09-10). Gating runs add `--require-spasm-entry`; focused target
 tests additionally require generated x86 instance/cache, trap, safe-point,
 self-link, and stable-gate execution. Unsupported x86 opcode families fall
 back per function and therefore remain covered by the same semantic sweep.
-The fail-closed witness observed 880 native entries / 559 compiled functions
-on x86_64 and 53,718 / 3,648 on AArch64 in the qualification rerun.
+The fail-closed witness observed 23,667 native entries / 2,320 compiled
+functions on x86_64 and 53,707 / 3,637 on AArch64. The x86 sweep recorded
+3,220 transactional refusals (8 limits, 1,401 signatures, 745 bytecode shapes,
+1,066 opcodes) and zero emission or install failures.


### PR DESCRIPTION
## Summary
- add f32/f64 signatures, locals, globals, memory access, arithmetic, comparisons, and unary operations to the x86_64 Spasm backend
- implement Wasm-correct NaN and signed-zero min/max behavior plus every trapping, saturating, signed, and unsigned float/int conversion
- keep the backend SSE2-safe with raw-bit helpers for directed rounding and split-at-2^63 unsigned i64 lowerings
- share ties-to-even semantics with Sarcasm and update architecture, conformance, and benchmark records

## Verification
- `zig build test-fast`
- `zig build test-fast -Dtarget=x86_64-macos`
- focused scalar-float and encoder tests on native AArch64 and Rosetta x86_64
- forced Spasm spec corpus on both architectures: 58,779/58,779, with 23,667 x86 native entries and zero emission/install failures
- `zig build -Dtarget=x86_64-linux-musl`
- `zig build -Dtarget=aarch64-linux-gnu`
- three `zig build wasm-bench -Dtarget=x86_64-macos` ABBA samples; all rows native, helper-free, and above the 5x target